### PR TITLE
Add Info Command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,19 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.33.tgz",
-      "integrity": "sha512-8fVvl6Yyk3jZvSYxRMS9/AmZJ5RXCOP9N4xSlykyBViVESu751pxHYTN14Embn1Fem78YwEHdC7p7KGQQpwunw==",
+      "version": "7.0.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.48.tgz",
+      "integrity": "sha512-LLlXafM3BD52MH056tHxTXO8JFCnpJJQkdzIU3+m8ew+CXJY/5zIXgDNb4TK/QFvlI8QexLS5tL+sE0Qhegr1w==",
       "dev": true
+    },
+    "@types/os-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/os-name/-/os-name-2.0.0.tgz",
+      "integrity": "sha512-YJHW0NjAhnSWeF34rk70IXgyg2Q8qDgT8QLKByHPQ1BgNBVoU9HQsCmkI650NTW0MTMsgKQyZLQJ91M3YlQhzw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.48"
+      }
     },
     "@types/sinon": {
       "version": "2.3.2",
@@ -84,11 +93,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
       "version": "1.3.2",
@@ -339,6 +343,30 @@
         "prettyjson": "1.2.1",
         "tabtab": "2.2.2",
         "winston": "2.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "capture-stack-trace": {
@@ -364,18 +392,6 @@
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
         "type-detect": "4.0.3"
-      }
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
       }
     },
     "check-error": {
@@ -1738,6 +1754,33 @@
         "commander": "2.9.0",
         "is-my-json-valid": "2.16.0",
         "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "has-ansi": {
@@ -1844,10 +1887,32 @@
         "through": "2.3.8"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -2258,6 +2323,11 @@
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
+    },
+    "macos-release": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
     },
     "make-dir": {
       "version": "1.1.0",
@@ -3910,6 +3980,15 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
+    "os-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+      "requires": {
+        "macos-release": "1.1.0",
+        "win-release": "1.1.1"
+      }
+    },
     "os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -4418,11 +4497,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-    },
     "tabtab": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tabtab/-/tabtab-2.2.2.tgz",
@@ -4706,6 +4780,14 @@
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "requires": {
         "string-width": "1.0.2"
+      }
+    },
+    "win-release": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+      "requires": {
+        "semver": "5.4.1"
       }
     },
     "winston": {

--- a/package.json
+++ b/package.json
@@ -30,12 +30,14 @@
   },
   "dependencies": {
     "caporal": "^0.6.0",
-    "nodemon": "^1.12.1"
+    "nodemon": "^1.12.1",
+    "os-name": "^2.0.1"
   },
   "devDependencies": {
     "@types/chai": "^3.5.2",
     "@types/mocha": "^2.2.41",
-    "@types/node": "^7.0.33",
+    "@types/node": "^7.0.48",
+    "@types/os-name": "^2.0.0",
     "@types/sinon": "^2.3.2",
     "chai": "^4.0.0",
     "coveralls": "^2.13.1",

--- a/src/common/program/interfaces/command.handler.interface.ts
+++ b/src/common/program/interfaces/command.handler.interface.ts
@@ -1,6 +1,7 @@
-import {Logger} from '../../logger/interfaces/logger.interface';
-import {CommandArguments} from './command.aguments.interface';
-import {CommandOptions} from './command.options.interface';
+import { Logger } from '../../logger/interfaces/logger.interface';
+import { CommandArguments } from './command.aguments.interface';
+import { CommandOptions } from './command.options.interface';
+
 
 export interface CommandHandler {
   execute(args: CommandArguments, options: CommandOptions, logger: Logger): Promise<void>;

--- a/src/core/utils/nest-ascii.ts
+++ b/src/core/utils/nest-ascii.ts
@@ -1,0 +1,11 @@
+export const nestWords = `
+ _   _           _      ____ _     ___
+| \\ | | ___  ___| |_   / ___| |   |_ _|
+|  \\| |/ _ \\/ __| __| | |   | |    | |
+| |\\  |  __/\\__ \\ |_  | |___| |___ | |
+|_| \\_|\\___||___/\\__|  \\____|_____|___|
+
+`
+// Please don't fiddle with this unless you know what you're doing.
+// Though it may look weird in the text editor, all the characters are carefully escaped
+// and look normal when echoed out to the command line.

--- a/src/lib/command-descriptors/info.command-descriptor.ts
+++ b/src/lib/command-descriptors/info.command-descriptor.ts
@@ -1,0 +1,16 @@
+import { CommandDescriptor } from '../../common/program/interfaces/command.descriptor.interface';
+import { Command } from '../../common/program/interfaces/command.interface';
+import { InfoCommandHandler } from '../handlers/info-command.handler';
+
+
+export class InfoCommandDescriptor implements CommandDescriptor {
+    constructor(
+        private _handler = new InfoCommandHandler()
+    ) { }
+
+    public describe(command: Command): void {
+        command
+            .alias('i')
+            .handler(this._handler);
+    }
+}

--- a/src/lib/command-descriptors/tests/info.command-descriptor.spec.ts
+++ b/src/lib/command-descriptors/tests/info.command-descriptor.spec.ts
@@ -1,0 +1,45 @@
+import * as sinon from 'sinon';
+import { CommandDescriptor } from '../../../common/program/interfaces/command.descriptor.interface';
+import { CommandHandler } from '../../../common/program/interfaces/command.handler.interface';
+import { Command } from '../../../common/program/interfaces/command.interface';
+import { Program } from '../../../common/program/interfaces/program.interface';
+import { CaporalProgram } from '../../../core/program/caporal/caporal.program';
+import { InfoCommandHandler } from '../../handlers/info-command.handler';
+import { InfoCommandDescriptor } from '../info.command-descriptor';
+
+
+describe('InfoCommandDescriptor', () => {
+    let sandbox: sinon.SinonSandbox;
+    beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    let command: Command;
+    beforeEach(() => {
+        const program: Program = new CaporalProgram();
+        command = program.command('name', 'description');
+    });
+
+    describe('#declare()', () => {
+
+        let handlerStub: sinon.SinonStub;
+        beforeEach(() => {
+            handlerStub = sandbox.stub(command, 'handler').callsFake(() => command);
+        });
+
+        let handler: InfoCommandHandler;
+        beforeEach(() => {
+            handler = new InfoCommandHandler();
+            const descriptor: CommandDescriptor = new InfoCommandDescriptor(handler);
+            descriptor.describe(command);
+        });
+
+        it('should call handler() with the ServeCommandHandler', () => {
+            sinon.assert.calledWith(handlerStub, handler);
+        });
+    });
+});

--- a/src/lib/handlers/info-command.handler.ts
+++ b/src/lib/handlers/info-command.handler.ts
@@ -1,0 +1,88 @@
+import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as nodemon from 'nodemon';
+import * as path from 'path';
+import { Logger } from '../../common/logger/interfaces/logger.interface';
+import { GenerateCommandArguments } from '../../common/program/interfaces/command.aguments.interface';
+import { CommandHandler } from '../../common/program/interfaces/command.handler.interface';
+import { GenerateCommandOptions } from '../../common/program/interfaces/command.options.interface';
+import { ConfigurationService } from '../../core/configuration/configuration.service';
+import { ColorService } from '../../core/logger/color.service';
+import { LoggerService } from '../../core/logger/logger.service';
+import { nestWords } from '../../core/utils/nest-ascii';
+import osName = require('os-name');
+
+
+export class InfoCommandHandler implements CommandHandler {
+
+    private logger: Logger;
+
+    public execute(
+        args: GenerateCommandArguments,
+        options: GenerateCommandOptions,
+        logger: Logger
+    ): Promise<void> {
+        LoggerService.setLogger(logger);
+        this.logger = logger;
+        logger.debug(ColorService.blue('[DEBUG]'), 'execute serve command');
+        return ConfigurationService.load()
+            .then(async () => {
+                const nodeVersion = process.version + ' ' + ((<any>process).release.lts || '');
+                const nestVersion = await this.getNestVersion();
+                const cliVersion = await this.getCliVersion();
+                const npmVersion = await this.getNpmVersion();
+                logger.info(ColorService.yellow(nestWords));
+                logger.info(ColorService.green('[System Information]'))
+                logger.info(this.concatenate('OS Version', osName()));
+                logger.info(this.concatenate('NodeJS Version', nodeVersion));
+                logger.info(this.concatenate('NPM Version', npmVersion));
+                logger.info(ColorService.green('[Nest Information]'))
+                logger.info(this.concatenate('NestJS Version', nestVersion));
+                logger.info(this.concatenate('Nest CLI Version', cliVersion));
+                logger.info('');
+            })
+    }
+
+    private concatenate(property: string, value: string): string {
+        return property + ' ' + ColorService.blue(`${value}`);
+    }
+
+    private async getNestVersion(): Promise<string> {
+        return await this._getVersionOf(path.join(process.cwd(), 'node_modules/@nestjs/core/package.json'));
+    }
+
+    private async getCliVersion(): Promise<string> {
+        return await this._getVersionOf(path.resolve('./package.json'));
+    }
+
+    private getNpmVersion(): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const child = exec('npm -v')
+            child.stdout.on('data', (data) => {
+                resolve(data.toString());
+            });
+            child.stderr.on('data', (err) => {
+                return this.logger.error(ColorService.red('[ERROR]'), 'There was an error reading the current NPM version.')
+            });
+        })
+    }
+
+    private _getVersionOf(file: string): Promise<string> {
+        return new Promise((resolve, reject) => {
+            fs.readFile(file, 'utf-8', (err, data) => {
+                if (err) {
+                    this.logger.error(ColorService.red('[ERROR]'), 'There was an error reading package.json.');
+                    return reject();
+                }
+
+                const p = JSON.parse(data);
+                if (p && p.version) {
+                    return resolve(p.version);
+                } else {
+                    this.logger.error(ColorService.red('[ERROR]'), 'This project does not depend on @nestjs/core. That is an error.');
+                    return reject();
+                }
+            })
+        });
+    }
+}

--- a/src/lib/handlers/tests/info-command.handler.spec.ts
+++ b/src/lib/handlers/tests/info-command.handler.spec.ts
@@ -1,0 +1,33 @@
+import * as sinon from 'sinon';
+import { CommandHandler } from '../../../common/program/interfaces/command.handler.interface';
+import { ConfigurationService } from '../../../core/configuration/configuration.service';
+import { InfoCommandHandler } from '../info-command.handler';
+
+
+describe('InfoCommandHandler', () => {
+    let sandbox: sinon.SinonSandbox;
+    beforeEach(() => sandbox = sinon.sandbox.create());
+    afterEach(() => sandbox.restore());
+
+    let handler: CommandHandler;
+    beforeEach(() => {
+        handler = new InfoCommandHandler();
+    });
+
+    let loadStub: sinon.SinonStub;
+    let getPropertyStub: sinon.SinonStub;
+    beforeEach(() => {
+        loadStub = sandbox.stub(ConfigurationService, 'load').callsFake(() => Promise.resolve());
+        getPropertyStub = sandbox.stub(ConfigurationService, 'getProperty').callsFake(() => 'ts')
+    });
+
+    describe('#execute()', () => {
+        it('should run the command handler', () => {
+            return handler.execute({}, {}, console)
+                .then(() => {
+                    sinon.assert.calledOnce(loadStub);
+                });
+        });
+
+    });
+});

--- a/src/nest-cli.application.ts
+++ b/src/nest-cli.application.ts
@@ -1,6 +1,7 @@
 import { CaporalProgram } from './core/program/caporal/caporal.program';
 import { CreateCommandDescriptor } from './lib/command-descriptors/create.command-descriptor';
 import { GenerateCommandDescriptor } from './lib/command-descriptors/generate.command-descriptor';
+import { InfoCommandDescriptor } from './lib/command-descriptors/info.command-descriptor';
 import { ServeCommandDescriptor } from './lib/command-descriptors/serve.command-descriptor';
 import { UpdateCommandDescriptor } from './lib/command-descriptors/update.command-descriptor';
 
@@ -15,6 +16,7 @@ export class NestCliApplication {
         new GenerateCommandDescriptor().describe(program.command('generate', 'Generate a new Nest asset'));
         new UpdateCommandDescriptor().describe(program.command('update', 'Update the Nest project'));
         new ServeCommandDescriptor().describe(program.command('serve', 'Run a live-reloading development server.'));
+        new InfoCommandDescriptor().describe(program.command('info', 'Get system and environment information.'));
       })
       .listen();
   }


### PR DESCRIPTION
This command will help Nest consumers get their environment info out faster to paste into new issues to help contributors diagnose faster.

Usage: `nest info`
Alias: `nest i`

Sample logs: 
<img width="426" alt="screen shot 2017-11-15 at 11 26 03 pm" src="https://user-images.githubusercontent.com/4442130/32873854-678c966a-ca5c-11e7-899b-84475abcb5f9.png">

This issue closes #27 