### PR TITLE
Rename server.ts to main.ts to fix "nest new" issue

### DIFF
--- a/src/commands/create/configuration.emitter.ts
+++ b/src/commands/create/configuration.emitter.ts
@@ -39,7 +39,7 @@ export class ConfigurationEmitter {
     return new Promise((resolve, reject) => {
       fs.writeFile(
         filename,
-        JSON.stringify({ language: 'ts', entryFile: 'src/server.ts' }, null, 2),
+        JSON.stringify({ language: 'ts', entryFile: 'src/main.ts' }, null, 2),
         (error: NodeJS.ErrnoException) => {
           if (error !== undefined && error !== null) {
             return reject(error);

--- a/src/commands/create/tests/configuration.emitter.spec.ts
+++ b/src/commands/create/tests/configuration.emitter.spec.ts
@@ -38,7 +38,7 @@ describe('ConfigurationEmitter', () => {
       statStub.callsFake((filename, callback) => callback(new Error('error message')));
       const name = 'name';
       await emitter.emit(name);
-      sandbox.assert.calledWith(writeFileStub, path.join(process.cwd(), name, 'nestconfig.json'), JSON.stringify({ language: 'ts', entryFile: 'src/server.ts' }, null, 2));
+      sandbox.assert.calledWith(writeFileStub, path.join(process.cwd(), name, 'nestconfig.json'), JSON.stringify({ language: 'ts', entryFile: 'src/main.ts' }, null, 2));
     });
   });
 });

--- a/src/commands/serve/tests/handler.spec.ts
+++ b/src/commands/serve/tests/handler.spec.ts
@@ -21,7 +21,7 @@ describe('ServeHandler', () => {
         if (propertyName === 'language') {
           return 'ts';
         } else if (propertyName === 'entryFile') {
-          return 'src/server.ts'
+          return 'src/main.ts'
         }
       });
     startStub = sandbox.stub(NodemonAdapter, 'start');
@@ -48,14 +48,14 @@ describe('ServeHandler', () => {
         if (propertyName === 'language') {
           return 'js';
         } else if (propertyName === 'entryFile') {
-          return 'src/server.js'
+          return 'src/main.js'
         }
       });
       handler.handle();
       sandbox.assert.calledWith(startStub, {
         'watch': [ 'src/**/*.js' ],
         'ignore': [ 'src/**/*.spec.js' ],
-        'exec': `node ${ path.resolve(process.cwd(), 'src/server.js') }`
+        'exec': `node ${ path.resolve(process.cwd(), 'src/main.js') }`
       });
     });
     it('should call nodemon with the right parameters for ts language', () => {
@@ -63,7 +63,7 @@ describe('ServeHandler', () => {
       sandbox.assert.calledWith(startStub, {
         'watch': [ 'src/**/*.ts' ],
         'ignore': [ 'src/**/*.spec.ts' ],
-        'exec': `./node_modules/.bin/ts-node ${ path.resolve(process.cwd(), 'src/server.ts') }`
+        'exec': `./node_modules/.bin/ts-node ${ path.resolve(process.cwd(), 'src/main.ts') }`
       });
     });
   });


### PR DESCRIPTION
It was not possible to run (nest serve) freshly created project (after nest new). Basically server.ts was renamed to main.ts in nestjs/typescript-starter repository.