### PR TITLE
fix() : wrap runner binary with quotes to manage spaces in binary path

### DIFF
--- a/lib/runners/abstract.runner.ts
+++ b/lib/runners/abstract.runner.ts
@@ -13,7 +13,7 @@ export class AbstractRunner {
       cwd: cwd
     };
     return new Promise<null | string>((resolve, reject) => {
-      const child: ChildProcess = spawn(this.binary, args, options);
+      const child: ChildProcess = spawn(`"${ this.binary }"`, args, options);
       if (collect) {
         child.stdout.on('data', (data) => resolve(data.toString().replace(/\r\n|\n/, '')));
       }


### PR DESCRIPTION
fix #123 