### PR TITLE
fix(new): --skip-install never working (sprint-1)

### DIFF
--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -1,5 +1,4 @@
 import { Command, CommanderStatic } from 'commander';
-import { parse } from '../lib/inputs/parse';
 import { AbstractCommand } from './abstract.command';
 import { Input } from './command.input';
 
@@ -12,11 +11,11 @@ export class GenerateCommand extends AbstractCommand {
       .option('--dry-run', 'Allow to test changes before execute command')
       .action(async (schematic: string, name: string, path: string, command: Command) => {
         const options: Input[] = [];
-        options.push(parse('dry-run')(command.dryRun !== undefined ? command.dryRun : false));
+        options.push({ name: 'dry-run', value: !!command.dryRun });
         const inputs: Input[] = [];
-        inputs.push(parse('schematic')(schematic));
-        inputs.push(parse('name')(name));
-        inputs.push(parse('path')(path));
+        inputs.push({ name: 'schematic', value: schematic });
+        inputs.push({ name: 'name', value: name });
+        inputs.push({ name: 'path', value: path });
         await this.action.handle(inputs, options);
       });
   }

--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -1,5 +1,4 @@
 import { Command, CommanderStatic } from 'commander';
-import { parse } from '../lib/inputs/parse';
 import { AbstractCommand } from './abstract.command';
 import { Input } from './command.input';
 
@@ -11,17 +10,19 @@ export class NewCommand extends AbstractCommand {
       .description('Generate a new Nest application.')
       .option('-d, --dry-run', 'Allow to test changes before execute command.')
       .option('-s, --skip-install', 'Allow to skip package installation.')
-      .option('-p, --package-manager [package-manager]', 'Allow to specify package manager to skip package-manager selection.')
+      .option(
+        '-p, --package-manager [package-manager]',
+        'Allow to specify package manager to skip package-manager selection.',
+      )
       .action(async (name: string, description: string, version: string, author: string, command: Command) => {
         const options: Input[] = [];
-        options.push(parse('dry-run')(command.dryRun !== undefined ? command.dryRun : false));
-        options.push(parse('skip-install')(command.skipInstall !== undefined ? command.skipInstall : false));
-        options.push(parse('package-manager')(command.packageManager));
+        options.push({ name: 'dry-run', value: !!command.dryRun });
+        options.push({ name: 'skip-install', value: !!command.skipInstall });
         const inputs: Input[] = [];
-        inputs.push(parse('name')(name));
-        inputs.push(parse('description')(description));
-        inputs.push(parse('version')(version));
-        inputs.push(parse('author')(author));
+        inputs.push({ name: 'name', value: name });
+        inputs.push({ name: 'description', value: description });
+        inputs.push({ name: 'version', value: version });
+        inputs.push({ name: 'author', value: author });
         await this.action.handle(inputs, options);
       });
   }

--- a/commands/update.command.ts
+++ b/commands/update.command.ts
@@ -1,5 +1,4 @@
 import { Command, CommanderStatic } from 'commander';
-import { parse } from '../lib/inputs/parse';
 import { AbstractCommand } from './abstract.command';
 import { Input } from './command.input';
 
@@ -13,8 +12,8 @@ export class UpdateCommand extends AbstractCommand {
       .option('-t, --tag <tag>', 'Call for upgrading to latest | beta | rc | next tag.')
       .action(async (command: Command) => {
         const options: Input[] = [];
-        options.push(parse('force')(command.force !== undefined ? command.force : false));
-        options.push(parse('tag')(command.tag));
+        options.push({ name: 'force', value: !!command.force });
+        options.push({ name: 'tag', value: command.tag });
         await this.action.handle([], options);
       });
   }

--- a/lib/inputs/parse.ts
+++ b/lib/inputs/parse.ts
@@ -1,5 +1,0 @@
-import { Input } from '../../commands';
-
-export const parse = (name: string): (value: boolean | string) => Input => {
-  return (value: boolean | string): Input => ({ name, value });
-};

--- a/test/lib/inputs/parse.spec.ts
+++ b/test/lib/inputs/parse.spec.ts
@@ -1,9 +1,0 @@
-import { parse } from '../../../lib/inputs/parse';
-
-describe('Input Parse', () => {
-  it('should return a Input with name and value', () => {
-    const name = 'name';
-    const value = 'value';
-    const input = parse(name)(value);
-  });
-});


### PR DESCRIPTION
Hi there.

I noticed that `--skip-install` did not seem to work in the `sprint-1` branch. I fixed this in `new.action.ts`. Another part of the fix is in `new.command.ts` where the property `skip-install` was read in `command`, instead of `skipInstall`. 

_NB: At the same time I took the liberty to remove the `parse` utility method which was adding more complexity than required for the creation of a simple literal object (`Input`). Let me know if I shouldn't have_ 

Starting from this point, I'd like to define a factory (or any other soft abstraction) for `*.command.ts`s and remove the sort-of duplications (filling `inputs` and `options`). If you think this is appropriate/relevant.