### PR TITLE
Fixed: Create project crash

### DIFF
--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -30,8 +30,7 @@ export abstract class AbstractPackageManager {
     try {
       const commandArguments = `${this.cli.install} --silent`;
       const collect = true;
-      const dasherizedDirectory: string = dasherize(directory);
-      await this.runner.run(commandArguments, collect, join(process.cwd(), dasherizedDirectory));
+      await this.runner.run(commandArguments, collect, join(process.cwd(), dasherize(directory)));
       spinner.succeed();
       console.info();
       console.info(messages.PACKAGE_MANAGER_INSTALLATION_SUCCEED(directory));

--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -30,8 +30,8 @@ export abstract class AbstractPackageManager {
     try {
       const commandArguments = `${this.cli.install} --silent`;
       const collect = true;
-      const dasherizedDir: string = dasherize(directory);
-      await this.runner.run(commandArguments, collect, join(process.cwd(), dasherizedDir));
+      const dasherizedDirectory: string = dasherize(directory);
+      await this.runner.run(commandArguments, collect, join(process.cwd(), dasherizedDirectory));
       spinner.succeed();
       console.info();
       console.info(messages.PACKAGE_MANAGER_INSTALLATION_SUCCEED(directory));

--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -1,3 +1,4 @@
+import { dasherize } from '@angular-devkit/core/src/utils/strings';
 import chalk from 'chalk';
 import { readFile } from 'fs';
 import * as ora from 'ora';
@@ -6,7 +7,6 @@ import { AbstractRunner } from '../runners/abstract.runner';
 import { messages } from '../ui';
 import { PackageManagerCommands } from './package-manager-commands';
 import { ProjectDependency } from './project.dependency';
-import { strings } from '@angular-devkit/core';
 
 export abstract class AbstractPackageManager {
   constructor(protected runner: AbstractRunner) {}
@@ -30,7 +30,7 @@ export abstract class AbstractPackageManager {
     try {
       const commandArguments = `${this.cli.install} --silent`;
       const collect = true;
-      const dasherizedDirectory: string = strings.dasherize(directory);
+      const dasherizedDirectory: string = dasherize(directory);
       await this.runner.run(commandArguments, collect, join(process.cwd(), dasherizedDirectory));
       spinner.succeed();
       console.info();

--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -6,6 +6,7 @@ import { AbstractRunner } from '../runners/abstract.runner';
 import { messages } from '../ui';
 import { PackageManagerCommands } from './package-manager-commands';
 import { ProjectDependency } from './project.dependency';
+import { strings } from '@angular-devkit/core';
 
 export abstract class AbstractPackageManager {
   constructor(protected runner: AbstractRunner) {}
@@ -29,7 +30,8 @@ export abstract class AbstractPackageManager {
     try {
       const commandArguments = `${this.cli.install} --silent`;
       const collect = true;
-      await this.runner.run(commandArguments, collect, join(process.cwd(), directory));
+      const dasherizedDirectory: string = strings.dasherize(directory);
+      await this.runner.run(commandArguments, collect, join(process.cwd(), dasherizedDirectory));
       spinner.succeed();
       console.info();
       console.info(messages.PACKAGE_MANAGER_INSTALLATION_SUCCEED(directory));

--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -30,7 +30,8 @@ export abstract class AbstractPackageManager {
     try {
       const commandArguments = `${this.cli.install} --silent`;
       const collect = true;
-      await this.runner.run(commandArguments, collect, join(process.cwd(), dasherize(directory)));
+      const dasherizedDir: string = dasherize(directory);
+      await this.runner.run(commandArguments, collect, join(process.cwd(), dasherizedDir));
       spinner.succeed();
       console.info();
       console.info(messages.PACKAGE_MANAGER_INSTALLATION_SUCCEED(directory));


### PR DESCRIPTION
## Fixed crash bug when create project
* Using **test_p** as the project name and then I got below error:

```shell
➜  Projects nest new test_p

⚡️  Creating your Nest project...
🙌  We have to collect additional information:

? description : a test project
? version : 0.0.0
? author : sanhan.sj

💥  Thank you for your time!

CREATE /test-p/.prettierrc (51 bytes)
....
CREATE /test-p/webpack.config.js (695 bytes)

? Which package manager would you ❤️  to use? npm
▹▹▹▹▹ Take ☕️  or 🍺  during the packages installation process and enjoy your timeevents.js:183
      throw er; // Unhandled 'error' event
      ^

Error: spawn /bin/sh ENOENT
    at _errnoException (util.js:1022:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
    at onErrorNT (internal/child_process.js:372:16)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
➜  Projects
```

* Reason: The `test_p` has processed as `test-p` by strings.dasherize
```js
await this.runner.run(commandArguments, collect, join(process.cwd(), directory));
```
* Resolve method:
join(process.cwd(), strings.dasherize(directory))

* test result:
```shell
➜  nest-cli git:(fixed/npm_install_crash_bug_1) ✗ node bin/nest.js new test_p

⚡️  Creating your Nest project...
🙌  We have to collect additional information:

? description : description
? version : 0.0.0
? author :

💥  Thank you for your time!

CREATE /test-p/.prettierrc (51 bytes)
...
CREATE /test-p/.nestcli.json (60 bytes)

? Which package manager would you ❤️  to use? npm
✔ Take ☕️  or 🍺  during the packages installation process and enjoy your time

🚀  Successfully created project test-p
👉  Get started with the following commands:

$ cd test-p
$ npm run start
```