### PR TITLE
refactor: use nest-cli.json (backward compatible + defaults)

### DIFF
--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -1,0 +1,4 @@
+export const defaultConfiguration = {
+  language: 'ts',
+  collection: '@nestjs/schematics',
+};

--- a/lib/configuration/nest-configuration.loader.ts
+++ b/lib/configuration/nest-configuration.loader.ts
@@ -1,11 +1,15 @@
 import { Reader } from '../readers';
 import { Configuration } from './configuration';
 import { ConfigurationLoader } from './configuration.loader';
+import { defaultConfiguration } from './defaults';
 
 export class NestConfigurationLoader implements ConfigurationLoader {
   constructor(private readonly reader: Reader) {}
   public async load(): Promise<Configuration> {
-    const content: string = await this.reader.read('.nestcli.json');
-    return JSON.parse(content);
+    const content: string | undefined = await this.reader.readAnyOf([
+      '.nestcli.json',
+      '.nest-cli.json',
+    ]);
+    return content ? JSON.parse(content) : defaultConfiguration;
   }
 }

--- a/lib/readers/file-system.reader.ts
+++ b/lib/readers/file-system.reader.ts
@@ -3,26 +3,46 @@ import { Reader } from './reader';
 
 export class FileSystemReader implements Reader {
   constructor(private readonly directory: string) {}
+
   public async list(): Promise<string[]> {
     return new Promise<string[]>((resolve, reject) => {
-      fs.readdir(this.directory, (error: NodeJS.ErrnoException, filenames: string[]) => {
-        if (!!error) {
-          reject(error);
-        } else {
-          resolve(filenames);
-        }
-      });
+      fs.readdir(
+        this.directory,
+        (error: NodeJS.ErrnoException, filenames: string[]) => {
+          if (!!error) {
+            reject(error);
+          } else {
+            resolve(filenames);
+          }
+        },
+      );
     });
   }
+
   public async read(name: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-      fs.readFile(`${ this.directory }/${ name }`, (error: NodeJS.ErrnoException, data: Buffer) => {
-        if (!!error) {
-          reject(error);
-        } else {
-          resolve(data.toString());
-        }
-      });
+      fs.readFile(
+        `${this.directory}/${name}`,
+        (error: NodeJS.ErrnoException, data: Buffer) => {
+          if (!!error) {
+            reject(error);
+          } else {
+            resolve(data.toString());
+          }
+        },
+      );
     });
+  }
+
+  public async readAnyOf(filenames: string[]): Promise<string | undefined> {
+    try {
+      for (const file of filenames) {
+        return await this.read(file);
+      }
+    } catch (err) {
+      return filenames.length > 0
+        ? await this.readAnyOf(filenames.slice(1, filenames.length))
+        : undefined;
+    }
   }
 }

--- a/lib/readers/reader.ts
+++ b/lib/readers/reader.ts
@@ -1,4 +1,5 @@
 export interface Reader {
   list(): string[] | Promise<string[]>;
   read(name: string): string | Promise<string>;
+  readAnyOf(filenames: string[]): string | Promise<string | undefined>;
 }

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -8,18 +8,25 @@ describe('Nest Configuration Loader', () => {
     const mock = jest.fn();
     mock.mockImplementation(() => {
       return {
-        read: jest.fn(() => Promise.resolve(JSON.stringify({
-          language: 'ts',
-          collection: '@nestjs/schematics',
-        }))),
+        readAnyOf: jest.fn(() =>
+          Promise.resolve(
+            JSON.stringify({
+              language: 'ts',
+              collection: '@nestjs/schematics',
+            }),
+          ),
+        ),
       };
     });
     reader = mock();
   });
-  it('should call reader.read when load', async () => {
+  it('should call reader.readAnyOf when load', async () => {
     const loader: ConfigurationLoader = new NestConfigurationLoader(reader);
     const configuration: Configuration = await loader.load();
-    expect(reader.read).toHaveBeenCalledWith('.nestcli.json');
+    expect(reader.readAnyOf).toHaveBeenCalledWith([
+      '.nestcli.json',
+      '.nest-cli.json',
+    ]);
     expect(configuration).toEqual({
       language: 'ts',
       collection: '@nestjs/schematics',


### PR DESCRIPTION
Supports:
1. nest-cli.json
2. nestcli.json
otherwise, loads default options.

resolves: #174 