### PR TITLE
chore(github): add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+PLEASE HELP US PROCESS GITHUB ISSUES FASTER BY PROVIDING THE FOLLOWING INFORMATION.
+
+ISSUES MISSING IMPORTANT INFORMATION MAY BE CLOSED WITHOUT INVESTIGATION.
+-->
+
+## I'm submitting a...
+<!-- 
+Please search GitHub for a similar issue or PR before submitting.
+Check one of the following options with "x" -->
+<pre><code>
+[ ] Regression <!--(a behavior that used to work and stopped working in a new release)-->
+[ ] Bug report
+[ ] Feature request
+[ ] Documentation issue or request
+[ ] Support request => Please do not submit support request here, instead post your question on Stack Overflow.
+</code></pre>
+
+## Current behavior
+<!-- Describe how the issue manifests. -->
+
+
+## Expected behavior
+<!-- Describe what the desired behavior would be. -->
+
+
+## Minimal reproduction of the problem with instructions
+<!-- Please share a repo, a gist, or step-by-step instructions. -->
+
+## What is the motivation / use case for changing the behavior?
+<!-- Describe the motivation or the concrete use case. -->
+
+
+## Environment
+<!--- Run `nest info` and paste it below -->
+```
+
+```


### PR DESCRIPTION
While adding new issue I noticed there's no issue template set up, so I copied it from https://github.com/nestjs/nest/blob/master/.github/ISSUE_TEMPLATE.md and changed the last bit to match contribution guidelines.