### PR TITLE
update success message to show selected package manager after install…

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -153,7 +153,7 @@ const installPackages = async (inputs: Input[], options: Input[]) => {
   if (inputPackageManager !== undefined) {
     try {
       packageManager = PackageManagerFactory.create(inputPackageManager);
-      await packageManager.install(installDirectory);
+      await packageManager.install(installDirectory, inputPackageManager);
     } catch (error) {
       if (error && error.message) {
         console.error(chalk.red(error.message));
@@ -161,7 +161,7 @@ const installPackages = async (inputs: Input[], options: Input[]) => {
     }
   } else {
     packageManager = await selectPackageManager();
-    await packageManager.install(installDirectory);
+    await packageManager.install(installDirectory, packageManager.name.toLowerCase());
   }
 };
 

--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -11,7 +11,7 @@ import { ProjectDependency } from './project.dependency';
 export abstract class AbstractPackageManager {
   constructor(protected runner: AbstractRunner) {}
 
-  public async install(directory: string) {
+  public async install(directory: string, packageManager: string) {
     const spinner = ora({
       spinner: {
         interval: 120,
@@ -38,7 +38,7 @@ export abstract class AbstractPackageManager {
       console.info(messages.GET_STARTED_INFORMATION);
       console.info();
       console.info(chalk.gray(messages.CHANGE_DIR_COMMAND(directory)));
-      console.info(chalk.gray(messages.START_COMMAND));
+      console.info(chalk.gray(messages.START_COMMAND(packageManager)));
       console.info();
     } catch {
       spinner.fail();

--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -28,7 +28,7 @@ export const messages = {
     emojis.POINT_RIGHT
   }  Get started with the following commands:`,
   CHANGE_DIR_COMMAND: (name: string) => `$ cd ${name}`,
-  START_COMMAND: '$ npm run start',
+  START_COMMAND: (name: string) => `$ ${name} run start`,
   PACKAGE_MANAGER_INSTALLATION_FAILED: `${
     emojis.SCREAM
   }  Packages installation failed, see above`,


### PR DESCRIPTION
After a successful installation, the `START_COMMAND` is hardcoded to `npm run start`. 
This pull request makes it dynamic based on the user input