### PR TITLE
Add list of available schematics for nest generate command help

### DIFF
--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -1,13 +1,15 @@
 import { Command, CommanderStatic } from 'commander';
 import { AbstractCommand } from './abstract.command';
 import { Input } from './command.input';
+import { NestCollection } from '../lib/schematics/nest.collection';
+const Table = require('cli-table2');
 
 export class GenerateCommand extends AbstractCommand {
   public load(program: CommanderStatic) {
     program
       .command('generate <schematic> <name> [path]')
       .alias('g')
-      .description('Generate a Nest element.')
+      .description(this.buildDescription())
       .option('--dry-run', 'Allow to test changes before command execution')
       .option('--flat', 'Enforce flat structure of generated element')
       .option('--no-spec', 'Disable spec files generation')
@@ -34,5 +36,40 @@ export class GenerateCommand extends AbstractCommand {
           await this.action.handle(inputs, options);
         },
       );
+  }
+
+  private buildDescription(): string {
+    let description = ''
+      .concat('Generate a Nest element.\n\n')
+      .concat('  Available schematics:\n')
+      .concat(
+        this.buildSchematicsListAsTable()
+      );
+
+    return description;
+  }
+
+  private buildSchematicsListAsTable(): string {
+    // See https://github.com/jamestalmage/cli-table2 for documentation
+    const leftMargin = ' '.repeat(4);
+    const tableConfig = {
+      head: ['name', 'alias'],
+      chars: {
+        'left': leftMargin.concat('│'),
+        'top-left': leftMargin.concat('┌'),
+        'bottom-left': leftMargin.concat('└'),
+        'mid': '',
+        'left-mid': '',
+        'mid-mid': '',
+        'right-mid': ''
+      }
+    };
+    let table = new Table(tableConfig);
+
+    for (let schematic of NestCollection.getSchematics()) {
+      table.push([schematic.name, schematic.alias]);
+    }
+
+    return table.toString();
   }
 }

--- a/lib/schematics/nest.collection.ts
+++ b/lib/schematics/nest.collection.ts
@@ -2,13 +2,13 @@ import { AbstractRunner } from '../runners';
 import { AbstractCollection } from './abstract.collection';
 import { SchematicOption } from './schematic.option';
 
-interface Schematic {
+export interface Schematic {
   name: string;
   alias: string;
 }
 
 export class NestCollection extends AbstractCollection {
-  private schematics: Schematic[] = [
+  private static schematics: Schematic[] = [
     { name: 'application', alias: 'app' },
     { name: 'class', alias: 'cl' },
     { name: 'configuration', alias: 'config' },
@@ -35,8 +35,12 @@ export class NestCollection extends AbstractCollection {
     await super.execute(schematic, options);
   }
 
+  public static getSchematics(): Array<Schematic> {
+    return NestCollection.schematics;
+  }
+
   private validate(name: string) {
-    const schematic = this.schematics.find(
+    const schematic = NestCollection.schematics.find(
       (s) => s.name === name || s.alias === name,
     );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs/cli",
-  "version": "5.6.2",
+  "version": "5.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -448,6 +448,12 @@
         "@angular-devkit/schematics": "7.0.5"
       }
     },
+    "@types/cli-table2": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@types/cli-table2/-/cli-table2-0.2.2.tgz",
+      "integrity": "sha512-jxhhsTp23whYfYjEBUVICs3tAm9CoZrqLzVC/X81nU2G/6H/47NreEirvP5UAjTkuJYWY8/nh2eZNBLXsViWsg==",
+      "dev": true
+    },
     "@types/inquirer": {
       "version": "0.0.41",
       "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.41.tgz",
@@ -687,8 +693,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -1373,6 +1378,41 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
       "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
     },
+    "cli-table2": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
+      "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
+      "requires": {
+        "colors": "^1.1.2",
+        "lodash": "^3.10.1",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -1413,8 +1453,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1437,6 +1476,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "colors": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==",
+      "optional": true
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -2098,12 +2143,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2118,17 +2165,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2245,7 +2295,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2257,6 +2308,7 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2271,6 +2323,7 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2278,12 +2331,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2302,6 +2357,7 @@
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2382,7 +2438,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2394,6 +2451,7 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2515,6 +2573,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4263,8 +4322,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.0.1",
@@ -6297,7 +6355,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nuxtjs/opencollective": "^0.1.0",
     "@types/jest": "^22.2.3",
     "chalk": "^2.4.1",
+    "cli-table2": "^0.2.0",
     "commander": "^2.15.1",
     "inquirer": "^5.2.0",
     "node-emoji": "^1.8.1",
@@ -44,6 +45,7 @@
     "ts-node": "^6.0.5"
   },
   "devDependencies": {
+    "@types/cli-table2": "^0.2.2",
     "@types/inquirer": "0.0.41",
     "@types/node": "^9.6.19",
     "@types/node-emoji": "^1.8.0",


### PR DESCRIPTION
In order to facilitate developers to remember the list of available schematic that can be generated with this CLI, this PR adds that list as a table on the help page.

`nest generate --help` will show this page :

![20181116-130224](https://user-images.githubusercontent.com/5792207/48620312-f12b0380-e99f-11e8-89c8-317189e1c745.png)
