### PR TITLE
fix: run npm build before run npm link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY --from=builder /nestjs/cli/actions actions
 COPY --from=builder /nestjs/cli/bin bin
 COPY --from=builder /nestjs/cli/commands commands
 COPY --from=builder /nestjs/cli/lib lib
+RUN npm run build
 RUN npm link
 WORKDIR /workspace
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ cd <project>
 With your Node runtime:
 ```
 $ npm install
+$ npm run build
 $ npm link
 ```
 


### PR DESCRIPTION
Run `npm run build` before execute npm link also updated docker and readme file.