### PR TITLE
remove double-space in package manager question

### DIFF
--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -10,7 +10,7 @@ export const messages = {
     `Failed to execute command: ${command}`,
   PACKAGE_MANAGER_QUESTION: `Which package manager would you ${
     emojis.HEART
-  }  to use?`,
+  } to use?`,
   PACKAGE_MANAGER_INSTALLATION_IN_PROGRESS: `Installation in progress... ${
     emojis.COFFEE
   }`,


### PR DESCRIPTION
I removed a double space in the 
> Which package manager would you :heart: to use?

message that is shown upon initialization of a new project.

Other strings in the file also contained double spaces after emojies, but the emoji was at the beginning of the string, so it might have been an intentional styling. I left them as they were before.