### PR TITLE
Prettier and linter would differ in configuration

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "quoteProps": "preserve",
 }

--- a/bin/nest.ts
+++ b/bin/nest.ts
@@ -6,8 +6,8 @@ import { CommandLoader } from '../commands';
 const bootstrap = () => {
   const program: CommanderStatic = commander;
   program
-  .version(require('../package.json').version)
-  .usage('<command> [options]');
+    .version(require('../package.json').version)
+    .usage('<command> [options]');
   CommandLoader.load(program);
   commander.parse(process.argv);
 

--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -65,12 +65,10 @@ export class GenerateCommand extends AbstractCommand {
     const tableConfig = {
       head: ['name', 'alias'],
       chars: {
-        // tslint:disable-next-line:quotemark
-        "left": leftMargin.concat('│'),
+        'left': leftMargin.concat('│'),
         'top-left': leftMargin.concat('┌'),
         'bottom-left': leftMargin.concat('└'),
-        // tslint:disable-next-line:quotemark
-        "mid": '',
+        'mid': '',
         'left-mid': '',
         'mid-mid': '',
         'right-mid': '',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "clean": "gulp clean:bundle",
     "format": "prettier --write \"**/*.ts\"",
-    "lint": "./node_modules/tslint/bin/tslint -p .",
+    "lint": "tslint -p .",
     "start": "node bin/nest.js",
     "test": "jest --config test/jest-config.json",
     "test:dev": "jest --config test/jest-config.json --watchAll"

--- a/tools/gulp/gulpfile.ts
+++ b/tools/gulp/gulpfile.ts
@@ -1,2 +1,1 @@
 import './tasks/clean';
-


### PR DESCRIPTION
- Prettier: Preserve quotes
- package.json: Make tslint load the npm way
- nest.ts, generate.command.ts, gulpfile.ts: Prettier changes