### PR TITLE
Replacing `[PACKAGE_MANAGER] run start`

### DIFF
--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -16,7 +16,7 @@ export const MESSAGES = {
     `${EMOJIS.ROCKET}  Successfully created project ${chalk.green(name)}`,
   GET_STARTED_INFORMATION: `${EMOJIS.POINT_RIGHT}  Get started with the following commands:`,
   CHANGE_DIR_COMMAND: (name: string) => `$ cd ${name}`,
-  START_COMMAND: (name: string) => `$ ${name} run start`,
+  START_COMMAND: (name: string) => `$ ${name} start`,
   PACKAGE_MANAGER_INSTALLATION_FAILED: `${EMOJIS.SCREAM}  Packages installation failed, see above`,
   // tslint:disable-next-line:max-line-length
   NEST_INFORMATION_PACKAGE_MANAGER_FAILED: `${EMOJIS.SMIRK}  cannot read your project package.json file, are you inside your project directory?`,


### PR DESCRIPTION
## What Does This PR Do?

> This PR basically replaces the start command message from `[PACKAGE_MANAGER] run start` to `[PACKAGE_MANAGER] start` since it is faster to type and both supported package managers `i.e yarn and npm` both support this command 😁