### PR TITLE
Exit process after successfully creating project

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -206,6 +206,9 @@ const printCollective = () => {
     )}`,
   );
   emptyLine();
+  
+// Exits the process after the project has been successfully created
+ process.exit(0)
 };
 
 const print = (color: string | null = null) => (str = '') => {


### PR DESCRIPTION
Currently, after a project has been successfully created by the `nest-cli` the process keeps running and is not terminated

![Screenshot 2019-10-03 at 12 34 07 PM](https://user-images.githubusercontent.com/28215750/66127495-bc3d9480-e5e3-11e9-9ecf-ec4a6ae176a4.png)

## What Does This PR Do?

This PR helps terminate the process by running `process.exit`