### PR TITLE
fix(cli): webpack in docker can't watch

### DIFF
--- a/lib/compiler/webpack-compiler.ts
+++ b/lib/compiler/webpack-compiler.ts
@@ -8,7 +8,7 @@ import { getValueOrDefault } from './helpers/get-value-or-default';
 import { PluginsLoader } from './plugins-loader';
 
 export class WebpackCompiler {
-  constructor(private readonly pluginsLoader: PluginsLoader) {}
+  constructor(private readonly pluginsLoader: PluginsLoader) { }
 
   public run(
     configuration: Required<Configuration>,
@@ -65,11 +65,12 @@ export class WebpackCompiler {
       typeof webpackConfigFactoryOrConfig !== 'function'
         ? webpackConfigFactoryOrConfig
         : webpackConfigFactoryOrConfig(defaultOptions);
-
-    const compiler = webpack({
+    //to get watch/watchOptions
+    const webpackConfiguration = {
       ...defaultOptions,
       ...projectWebpackOptions,
-    });
+    }
+    const compiler = webpack(webpackConfiguration);
 
     const afterCallback = (err: Error, stats: any) => {
       const statsOutput = stats.toString({
@@ -85,12 +86,12 @@ export class WebpackCompiler {
       console.log(statsOutput);
     };
 
-    if (watchMode) {
+    if (watchMode || webpackConfiguration.watch) {
       compiler.hooks.watchRun.tapAsync('Rebuild info', (params, callback) => {
         console.log(`\n${INFO_PREFIX} Webpack is building your sources...\n`);
         callback();
       });
-      compiler.watch({}, afterCallback);
+      compiler.watch(webpackConfiguration.watchOptions!, afterCallback);
     } else {
       compiler.run(afterCallback);
     }

--- a/lib/compiler/webpack-compiler.ts
+++ b/lib/compiler/webpack-compiler.ts
@@ -91,7 +91,7 @@ export class WebpackCompiler {
         console.log(`\n${INFO_PREFIX} Webpack is building your sources...\n`);
         callback();
       });
-      compiler.watch(webpackConfiguration.watchOptions!, afterCallback);
+      compiler.watch(webpackConfiguration.watchOptions! || {}, afterCallback);
     } else {
       compiler.run(afterCallback);
     }

--- a/lib/compiler/webpack-compiler.ts
+++ b/lib/compiler/webpack-compiler.ts
@@ -65,7 +65,6 @@ export class WebpackCompiler {
       typeof webpackConfigFactoryOrConfig !== 'function'
         ? webpackConfigFactoryOrConfig
         : webpackConfigFactoryOrConfig(defaultOptions);
-    //to get watch/watchOptions
     const webpackConfiguration = {
       ...defaultOptions,
       ...projectWebpackOptions,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [y] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [y] Tests for the changes have been added (for bug fixes / features)
- [y] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[y] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When nest debug in docker with 
nest-cli.json
```json
{
  "collection": "@nestjs/schematics",
  "sourceRoot": "src",
  "compilerOptions": {
    "webpack": true
  }
}
```
webpack.config.js
```js
const config = (option) => {
    option.watch = true
    option.watchOptions = {
        aggregateTimeout: 300,
        poll: 1000
    }
    return option
}
module.exports = config
```
I find the webpack can't watch changes when I save,
So I debugger and search ,find`webpack-compiler.ts` line 94 `watchOptions` is `{}`,when the code change in docker it can't watched and compile
Issue Number: N/A


## What is the new behavior?
it's worked on docker

## Does this PR introduce a breaking change?
```
[x] Yes
[y] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
