### PR TITLE
feat() support project selection in add action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .envrc
 node_modules/
 .DS_Store
+*.map
 
 # output
 lib/**/*.js

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 ## Description
 
-In order to help people manage their projects, the CLI tool has been created. It helps on many grounds at once, from scaffolding the project to build well-structured applications. The Nest CLI is based on the [@angular-devkit](https://github.com/angular/devkit) package. Also, there're special schematics that are dedicated to the Nest development [@nestjs/schematics](https://github.com/nestjs/schematics).
+The Nest CLI is a command-line interface tool that helps you to initialize, develop, and maintain your Nest applications. It assists in multiple ways, including scaffolding the project, serving it in development mode, and building and bundling the application for production distribution. It embodies best-practice architectural patterns to encourage well-structured apps.
+
+The CLI works with [schematics](https://github.com/angular/angular-cli/tree/master/packages/angular_devkit/schematics), and provides built in support from the schematics collection at [@nestjs/schematics](https://github.com/nestjs/schematics).
 
 
 ## Installation

--- a/actions/add.action.ts
+++ b/actions/add.action.ts
@@ -1,3 +1,8 @@
+import chalk from 'chalk';
+
+import { MESSAGES } from '../lib/ui';
+
+import { Answers } from 'inquirer';
 import { Input } from '../commands';
 import {
   AbstractPackageManager,
@@ -10,49 +15,170 @@ import {
 } from '../lib/schematics';
 import { AbstractAction } from './abstract.action';
 
+import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
+
+import {
+  askForProjectName,
+  moveDefaultProjectToStart,
+  shouldAskForProject,
+} from '../lib/utils/project-utils';
+
+import { loadConfiguration } from '../lib/utils/load-configuration';
+
+const schematicName = 'nest-add';
+
 export class AddAction extends AbstractAction {
-  public async handle(inputs: Input[], outputs: any[], extraFlags: string[]) {
-    const manager: AbstractPackageManager = await PackageManagerFactory.find();
-    const libraryInput: Input = inputs.find(
-      input => input.name === 'library',
-    ) as Input;
+  public async handle(inputs: Input[], options: Input[], extraFlags: string[]) {
+    const libraryName = this.getLibraryName(inputs);
+    const packageName = this.getPackageName(libraryName);
+    const collectionName = this.getCollectionName(libraryName, packageName);
+    const tagName = this.getTagName(packageName);
+    const packageInstallSuccess = await this.installPackage(
+      collectionName,
+      tagName,
+    );
+    if (packageInstallSuccess) {
+      const sourceRootOption: Input = await this.getSourceRoot(
+        inputs.concat(options),
+      );
+      options.push(sourceRootOption);
 
-    if (!libraryInput) {
-      return;
+      await this.addLibrary(collectionName, options, extraFlags);
+    } else {
+      console.error(
+        chalk.red(
+          MESSAGES.LIBRARY_INSTALLATION_FAILED_BAD_PACKAGE(libraryName),
+        ),
+      );
     }
-    const library: string = libraryInput.value as string;
-    const packageName = library.startsWith('@')
-      ? library.split('/', 2).join('/')
-      : library.split('/', 1)[0];
+    process.exit(0);
+  }
 
-    // Remove the tag/version from the package name.
-    const collectionName =
-      (packageName.startsWith('@')
-        ? packageName.split('@', 2).join('@')
-        : packageName.split('@', 1).join('@')) +
-      library.slice(packageName.length);
+  private async getSourceRoot(inputs: Input[]): Promise<Input> {
+    const configuration = await loadConfiguration();
+    const configurationProjects = configuration.projects;
 
-    let tagName = packageName.startsWith('@')
-      ? packageName.split('@', 3)[2]
-      : packageName.split('@', 2)[1];
+    const appName = inputs.find(option => option.name === 'project')!
+      .value as string;
 
+    let sourceRoot = appName
+      ? getValueOrDefault(configuration, 'sourceRoot', appName)
+      : configuration.sourceRoot;
+
+    const shouldAsk = await shouldAskForProject(
+      schematicName,
+      configurationProjects,
+      appName,
+    );
+    if (shouldAsk) {
+      const defaultLabel: string = ' [ Default ]';
+      let defaultProjectName: string = configuration.sourceRoot + defaultLabel;
+
+      for (const property in configurationProjects) {
+        if (
+          configurationProjects[property].sourceRoot ===
+          configuration.sourceRoot
+        ) {
+          defaultProjectName = property + defaultLabel;
+          break;
+        }
+      }
+
+      const projects = moveDefaultProjectToStart(
+        configuration,
+        defaultProjectName,
+        defaultLabel,
+      );
+
+      const answers: Answers = await askForProjectName(
+        MESSAGES.LIBRARY_PROJECT_SELECTION_QUESTION,
+        projects,
+      );
+      const project: string = answers.appName.replace(defaultLabel, '');
+      if (project !== configuration.sourceRoot) {
+        sourceRoot = configurationProjects[project].sourceRoot;
+      }
+    }
+    return { name: 'sourceRoot', value: sourceRoot };
+  }
+
+  private async installPackage(
+    collectionName: string,
+    tagName: string,
+  ): Promise<boolean> {
+    const manager: AbstractPackageManager = await PackageManagerFactory.find();
     tagName = tagName || 'latest';
-    await manager.addProduction([collectionName], tagName);
+    let installResult = false;
+    try {
+      installResult = await manager.addProduction([collectionName], tagName);
+    } catch (error) {
+      if (error && error.message) {
+        console.error(chalk.red(error.message));
+      }
+    }
+    return installResult;
+  }
 
-    const schematicName = 'nest-add';
+  private async addLibrary(
+    collectionName: string,
+    options: Input[],
+    extraFlags: string[],
+  ) {
+    console.info(MESSAGES.LIBRARY_INSTALLATION_STARTS);
+    const schematicOptions: SchematicOption[] = [];
+    schematicOptions.push(
+      new SchematicOption('sourceRoot', options.find(
+        option => option.name === 'sourceRoot',
+      )!.value as string),
+    );
+    const extraFlagsString = extraFlags ? extraFlags.join(' ') : undefined;
+
     try {
       const collection: AbstractCollection = CollectionFactory.create(
         collectionName,
       );
-      const schematicOptions: SchematicOption[] = [];
-      const extraFlagsString = extraFlags ? extraFlags.join(' ') : undefined;
       await collection.execute(
         schematicName,
         schematicOptions,
         extraFlagsString,
       );
-    } catch (e) {
-      return;
+    } catch (error) {
+      if (error && error.message) {
+        console.error(chalk.red(error.message));
+        return Promise.reject();
+      }
     }
+  }
+
+  private getLibraryName(inputs: Input[]): string {
+    const libraryInput: Input = inputs.find(
+      input => input.name === 'library',
+    ) as Input;
+
+    if (!libraryInput) {
+      throw new Error('No library found in command input');
+    }
+    return libraryInput.value as string;
+  }
+
+  private getPackageName(library: string): string {
+    return library.startsWith('@')
+      ? library.split('/', 2).join('/')
+      : library.split('/', 1)[0];
+  }
+
+  private getCollectionName(library: string, packageName: string): string {
+    return (
+      (packageName.startsWith('@')
+        ? packageName.split('@', 2).join('@')
+        : packageName.split('@', 1).join('@')) +
+      library.slice(packageName.length)
+    );
+  }
+
+  private getTagName(packageName: string): string {
+    return packageName.startsWith('@')
+      ? packageName.split('@', 3)[2]
+      : packageName.split('@', 2)[1];
   }
 }

--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -1,16 +1,8 @@
 import chalk from 'chalk';
-import * as inquirer from 'inquirer';
-import { Answers, Question } from 'inquirer';
+import { Answers } from 'inquirer';
 import { Input } from '../commands';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
-import {
-  Configuration,
-  ConfigurationLoader,
-  ProjectConfiguration,
-} from '../lib/configuration';
-import { NestConfigurationLoader } from '../lib/configuration/nest-configuration.loader';
-import { generateSelect } from '../lib/questions/questions';
-import { FileSystemReader } from '../lib/readers';
+
 import {
   AbstractCollection,
   CollectionFactory,
@@ -18,6 +10,14 @@ import {
 } from '../lib/schematics';
 import { MESSAGES } from '../lib/ui';
 import { AbstractAction } from './abstract.action';
+
+import {
+  askForProjectName,
+  moveDefaultProjectToStart,
+  shouldAskForProject,
+} from '../lib/utils/project-utils';
+
+import { loadConfiguration } from '../lib/utils/load-configuration';
 
 export class GenerateAction extends AbstractAction {
   public async handle(inputs: Input[], options: Input[]) {
@@ -49,7 +49,7 @@ const generateFiles = async (inputs: Input[]) => {
 
   // If you only add a `lib` we actually don't have monorepo: true BUT we do have "projects"
   // Ensure we don't run for new app/libs schematics
-  if (shouldAskForProject(schematic, configurationProjects, appName)) {
+  if (await shouldAskForProject(schematic, configurationProjects, appName)) {
     const defaultLabel: string = ' [ Default ]';
     let defaultProjectName: string = configuration.sourceRoot + defaultLabel;
 
@@ -68,7 +68,11 @@ const generateFiles = async (inputs: Input[]) => {
       defaultLabel,
     );
 
-    const answers: Answers = await askForProjectName(projects);
+    const answers: Answers = await askForProjectName(
+      MESSAGES.PROJECT_SELECTION_QUESTION,
+      projects,
+    );
+
     const project: string = answers.appName.replace(defaultLabel, '');
     if (project !== configuration.sourceRoot) {
       sourceRoot = configurationProjects[project].sourceRoot;
@@ -89,36 +93,6 @@ const generateFiles = async (inputs: Input[]) => {
   }
 };
 
-const moveDefaultProjectToStart = (
-  configuration: Configuration,
-  defaultProjectName: string,
-  defaultLabel: string,
-) => {
-  let projects: string[] = Object.keys(configuration.projects as {});
-  if (configuration.sourceRoot !== 'src') {
-    projects = projects.filter(
-      p => p !== defaultProjectName.replace(defaultLabel, ''),
-    );
-  }
-  projects.unshift(defaultProjectName);
-  return projects;
-};
-
-const askForProjectName = async (projects: string[]): Promise<Answers> => {
-  const questions: Question[] = [
-    generateSelect('appName')(MESSAGES.PROJECT_SELECTION_QUESTION)(projects),
-  ];
-  const prompt = inquirer.createPromptModule();
-  return await prompt(questions);
-};
-
-const loadConfiguration = async (): Promise<Required<Configuration>> => {
-  const loader: ConfigurationLoader = new NestConfigurationLoader(
-    new FileSystemReader(process.cwd()),
-  );
-  return loader.load();
-};
-
 const mapSchematicOptions = (inputs: Input[]): SchematicOption[] => {
   const options: SchematicOption[] = [];
   inputs.forEach(input => {
@@ -127,17 +101,4 @@ const mapSchematicOptions = (inputs: Input[]): SchematicOption[] => {
     }
   });
   return options;
-};
-
-const shouldAskForProject = (
-  schematic: string,
-  configurationProjects: { [key: string]: ProjectConfiguration },
-  appName: string,
-) => {
-  return (
-    ['app', 'sub-app', 'library', 'lib'].includes(schematic) === false &&
-    configurationProjects &&
-    Object.entries(configurationProjects).length !== 0 &&
-    !appName
-  );
 };

--- a/actions/info.action.ts
+++ b/actions/info.action.ts
@@ -42,20 +42,30 @@ const displayPackageManagerVersion = async () => {
   const manager: AbstractPackageManager = await PackageManagerFactory.find();
   try {
     const version: string = await manager.version();
-    console.info(`${manager.name} Version    :`, chalk.blue(version));
+    console.info(`${manager.name} Version    :`, chalk.blue(version), '\n');
   } catch {
-    console.error(`${manager.name} Version    :`, chalk.red('Unknown'));
+    console.error(`${manager.name} Version    :`, chalk.red('Unknown'), '\n');
   }
 };
 
 const displayNestInformation = async () => {
-  console.info(chalk.green('[Nest Information]'));
+  displayCliVersion();
+  console.info(chalk.green('[Nest Platform Information]'));
   try {
     const dependencies: PackageJsonDependencies = await readProjectPackageJsonDependencies();
     displayNestVersions(dependencies);
   } catch {
     console.error(chalk.red(MESSAGES.NEST_INFORMATION_PACKAGE_MANAGER_FAILED));
   }
+};
+
+const displayCliVersion = () => {
+  console.info(chalk.green('[Nest CLI]'));
+  console.info(
+    'Nest CLI Version :',
+    chalk.blue(require('../package.json').version),
+    '\n',
+  );
 };
 
 const readProjectPackageJsonDependencies = async (): Promise<

--- a/bin/nest.ts
+++ b/bin/nest.ts
@@ -6,8 +6,16 @@ import { CommandLoader } from '../commands';
 const bootstrap = () => {
   const program: CommanderStatic = commander;
   program
-    .version(require('../package.json').version)
-    .usage('<command> [options]');
+    .version(
+      require('../package.json').version,
+      '-v, --version',
+      'Output the current version.',
+    )
+    .usage('<command> [options]')
+    .helpOption('-h, --help', 'Output usage information.')
+    .on('--help', () => {
+      return 'HelpMe!';
+    });
   CommandLoader.load(program);
   commander.parse(process.argv);
 

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -6,11 +6,11 @@ export class BuildCommand extends AbstractCommand {
   public load(program: CommanderStatic): void {
     program
       .command('build [app]')
-      .option('-p, --path [path]', 'Path to tsconfig file')
-      .option('-w, --watch', 'Run in watch mode (live-reload)')
-      .option('--webpack', 'Use webpack for compilation')
-      .option('--webpackPath [path]', 'Path to webpack configuration')
-      .description('Build Nest application')
+      .option('-p, --path [path]', 'Path to tsconfig file.')
+      .option('-w, --watch', 'Run in watch mode (live-reload).')
+      .option('--webpack', 'Use webpack for compilation.')
+      .option('--webpackPath [path]', 'Path to webpack configuration.')
+      .description('Build Nest application.')
       .action(async (app: string, command: Command) => {
         const options: Input[] = [];
 

--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -11,13 +11,16 @@ export class GenerateCommand extends AbstractCommand {
       .command('generate <schematic> [name] [path]')
       .alias('g')
       .description(this.buildDescription())
-      .option('--dry-run', 'Allow to test changes before command execution')
-      .option('-p, --project [project]', 'Project in which to generate files')
-      .option('--flat', 'Enforce flat structure of generated element')
-      .option('--no-spec', 'Disable spec files generation')
+      .option(
+        '--dry-run',
+        'Report actions that would be taken without writing out results.',
+      )
+      .option('-p, --project [project]', 'Project in which to generate files.')
+      .option('--flat', 'Enforce flat structure of generated element.')
+      .option('--no-spec', 'Disable spec files generation.')
       .option(
         '-c, --collection [collectionName]',
-        'Collection that shall be used',
+        'Schematics collection to use.',
       )
       .action(
         async (
@@ -54,7 +57,7 @@ export class GenerateCommand extends AbstractCommand {
 
   private buildDescription(): string {
     return (
-      'Generate a Nest element\n' +
+      'Generate a Nest element.\n' +
       '  Available schematics:\n' +
       this.buildSchematicsListAsTable()
     );

--- a/commands/info.command.ts
+++ b/commands/info.command.ts
@@ -6,7 +6,7 @@ export class InfoCommand extends AbstractCommand {
     program
       .command('info')
       .alias('i')
-      .description('Display Nest CLI details')
+      .description('Display Nest project details.')
       .action(async () => {
         await this.action.handle();
       });

--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -8,24 +8,24 @@ export class NewCommand extends AbstractCommand {
     program
       .command('new [name]')
       .alias('n')
-      .description('Generate Nest application')
+      .description('Generate Nest application.')
       .option(
         '-d, --dry-run',
-        'Allow to test changes before executing the command',
+        'Report actions that would be performed without writing out results.',
       )
-      .option('-g, --skip-git', 'Allow to skip git repository initialization')
-      .option('-s, --skip-install', 'Allow to skip packages installation')
+      .option('-g, --skip-git', 'Skip git repository initialization.')
+      .option('-s, --skip-install', 'Skip package installation.')
       .option(
         '-p, --package-manager [package-manager]',
-        'Allow to specify package manager to skip package-manager selection',
+        'Specify package manager.',
       )
       .option(
         '-l, --language [language]',
-        'Language that shall be used (TS or JS)',
+        'Programming language to be used (TypeScript or JavaScript).',
       )
       .option(
         '-c, --collection [collectionName]',
-        'Collection that shall be used',
+        'Schematics collection to use.',
       )
       .action(async (name: string, command: Command) => {
         const options: Input[] = [];

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -6,15 +6,15 @@ export class StartCommand extends AbstractCommand {
   public load(program: CommanderStatic): void {
     program
       .command('start [app]')
-      .option('-p, --path [path]', 'Path to tsconfig file')
-      .option('-w, --watch', 'Run in watch mode (live-reload)')
+      .option('-p, --path [path]', 'Path to tsconfig file.')
+      .option('-w, --watch', 'Run in watch mode (live-reload).')
       .option(
         '-d, --debug [hostport] ',
-        'Run in debug mode (with --inspect flag)',
+        'Run in debug mode (with --inspect flag).',
       )
-      .option('--webpack', 'Use webpack for compilation')
-      .option('--webpackPath [path]', 'Path to webpack configuration')
-      .description('Build Nest application')
+      .option('--webpack', 'Use webpack for compilation.')
+      .option('--webpackPath [path]', 'Path to webpack configuration.')
+      .description('Run Nest application.')
       .action(async (app: string, command: Command) => {
         const options: Input[] = [];
 

--- a/commands/update.command.ts
+++ b/commands/update.command.ts
@@ -7,11 +7,14 @@ export class UpdateCommand extends AbstractCommand {
     program
       .command('update')
       .alias('u')
-      .description('Update Nest dependencies')
-      .option('-f, --force', 'Call for upgrading instead of updating.')
+      .description('Update Nest dependencies.')
+      .option(
+        '-f, --force',
+        'Remove and re-install dependencies (instead of update).',
+      )
       .option(
         '-t, --tag <tag>',
-        'Call for upgrading to latest | beta | rc | next tag.',
+        'Upgrade to tagged packages (latest | beta | rc | next tag).',
       )
       .action(async (command: Command) => {
         const options: Input[] = [];

--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -49,7 +49,10 @@ export abstract class AbstractPackageManager {
     return this.runner.run(commandArguments, collect) as Promise<string>;
   }
 
-  public async addProduction(dependencies: string[], tag: string) {
+  public async addProduction(
+    dependencies: string[],
+    tag: string,
+  ): Promise<boolean> {
     const command: string = [this.cli.add, this.cli.saveFlag]
       .filter(i => i)
       .join(' ');
@@ -61,14 +64,16 @@ export abstract class AbstractPackageManager {
         interval: 120,
         frames: ['▹▹▹▹▹', '▸▹▹▹▹', '▹▸▹▹▹', '▹▹▸▹▹', '▹▹▹▸▹', '▹▹▹▹▸'],
       },
-      text: MESSAGES.PACKAGE_MANAGER_INSTALLATION_IN_PROGRESS,
+      text: MESSAGES.PACKAGE_MANAGER_PRODUCTION_INSTALLATION_IN_PROGRESS,
     });
     spinner.start();
     try {
       await this.add(`${command} ${args}`);
       spinner.succeed();
+      return true;
     } catch {
       spinner.fail();
+      return false;
     }
   }
 

--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -3,7 +3,9 @@ import { EMOJIS } from './emojis';
 
 export const MESSAGES = {
   PROJECT_SELECTION_QUESTION: 'Which project would you like to generate to?',
-  DRY_RUN_MODE: 'Command has been executed in the dry mode, nothing changed!',
+  LIBRARY_PROJECT_SELECTION_QUESTION:
+    'Which project would you like to add the library to?',
+  DRY_RUN_MODE: 'Command has been executed in dry run mode, nothing changed!',
   PROJECT_INFORMATION_START: `${EMOJIS.ZAP}  We will scaffold your app in a few seconds..`,
   RUNNER_EXECUTION_ERROR: (command: string) =>
     `\nFailed to execute command: ${command}`,
@@ -11,6 +13,7 @@ export const MESSAGES = {
   PACKAGE_MANAGER_INSTALLATION_IN_PROGRESS: `Installation in progress... ${EMOJIS.COFFEE}`,
   PACKAGE_MANAGER_UPDATE_IN_PROGRESS: `Installation in progress... ${EMOJIS.COFFEE}`,
   PACKAGE_MANAGER_UPGRADE_IN_PROGRESS: `Installation in progress... ${EMOJIS.COFFEE}`,
+  PACKAGE_MANAGER_PRODUCTION_INSTALLATION_IN_PROGRESS: `Package installation in progress... ${EMOJIS.COFFEE}`,
   GIT_INITIALIZATION_ERROR: 'Git repository has not been initialized',
   PACKAGE_MANAGER_INSTALLATION_SUCCEED: (name: string) =>
     `${EMOJIS.ROCKET}  Successfully created project ${chalk.green(name)}`,
@@ -20,4 +23,8 @@ export const MESSAGES = {
   PACKAGE_MANAGER_INSTALLATION_FAILED: `${EMOJIS.SCREAM}  Packages installation failed, see above`,
   // tslint:disable-next-line:max-line-length
   NEST_INFORMATION_PACKAGE_MANAGER_FAILED: `${EMOJIS.SMIRK}  cannot read your project package.json file, are you inside your project directory?`,
+  LIBRARY_INSTALLATION_FAILED_BAD_PACKAGE: (name: string) =>
+    `Unable to install library ${name} because package did not install. Please check package name.`,
+  LIBRARY_INSTALLATION_FAILED_NO_LIBRARY: 'No library found.',
+  LIBRARY_INSTALLATION_STARTS: 'Starting library setup...',
 };

--- a/lib/utils/load-configuration.ts
+++ b/lib/utils/load-configuration.ts
@@ -1,0 +1,10 @@
+import { Configuration, ConfigurationLoader } from '../configuration';
+import { NestConfigurationLoader } from '../configuration/nest-configuration.loader';
+import { FileSystemReader } from '../readers';
+
+export async function loadConfiguration(): Promise<Required<Configuration>> {
+  const loader: ConfigurationLoader = new NestConfigurationLoader(
+    new FileSystemReader(process.cwd()),
+  );
+  return loader.load();
+}

--- a/lib/utils/project-utils.ts
+++ b/lib/utils/project-utils.ts
@@ -1,0 +1,46 @@
+import * as inquirer from 'inquirer';
+
+import { Configuration, ProjectConfiguration } from '../configuration';
+
+import { Answers, Question } from 'inquirer';
+
+import { generateSelect } from '../questions/questions';
+
+export async function shouldAskForProject(
+  schematic: string,
+  configurationProjects: { [key: string]: ProjectConfiguration },
+  appName: string,
+) {
+  return (
+    ['app', 'sub-app', 'library', 'lib'].includes(schematic) === false &&
+    configurationProjects &&
+    Object.entries(configurationProjects).length !== 0 &&
+    !appName
+  );
+}
+
+export async function askForProjectName(
+  promptQuestion: string,
+  projects: string[],
+): Promise<Answers> {
+  const questions: Question[] = [
+    generateSelect('appName')(promptQuestion)(projects),
+  ];
+  const prompt = inquirer.createPromptModule();
+  return await prompt(questions);
+}
+
+export function moveDefaultProjectToStart(
+  configuration: Configuration,
+  defaultProjectName: string,
+  defaultLabel: string,
+) {
+  let projects: string[] = Object.keys(configuration.projects as {});
+  if (configuration.sourceRoot !== 'src') {
+    projects = projects.filter(
+      p => p !== defaultProjectName.replace(defaultLabel, ''),
+    );
+  }
+  projects.unshift(defaultProjectName);
+  return projects;
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format": "prettier --write \"**/*.ts\"",
     "lint": "tslint -p .",
     "start": "node bin/nest.js",
-    "test": "jest --config test/jest-config.json",
+    "test": "npm run clean && jest --config test/jest-config.json",
     "test:dev": "jest --config test/jest-config.json --watchAll"
   },
   "repository": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
See below

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No

But, see below
```

## Other information
### Main feature
This PR introduces a new feature for the `nest add` command.  The command now:
- Allows passing in a project name with `-p` option
- Automatically handles multi-project selection if a project is not supplied
  - checks for whether the project structure is *standard* or *monorepo*
  - if monorepo, prompts for the project name
- Invokes the `nest-add` schematic on the target library and passes in the source root via `--sourceRoot`

### Minor changes
- improve help messages (slight wording/grammar improvements; consistent title casing and periods, as guided by the Angular CLI conventions)
- improve test script: run npm clean before running tests
- refactor utils for monorepo/project selection into library functions
- refactor `generate` action/command to use above utils
- add display of CLI version to info command
- update readme to be consistent with docs

### Compatibility
- Monorepos introduced an incompatibility with any libraries that implemented a `nest-add` schematic because the schematic would be unaware of a monorepo structure.
- It's anticipated that there are very few, if any, such 3rd party libraries in the wild.  Certainly, I'm not aware of any bug reports from such authors after having introduced monorepos, though it may be early.
- There *is* at least one `@nestjs` library that implements the `nest-add` schematic: `https://github.com/nestjs/azure-func-http`.  @kamilmysliwiec  may know of more.
- In order to function properly in a monorepo, with this supporting change in place, library authors implementing a `nest-add` schematic should accept a `--sourceRoot` flag and install code relative to the supplied path.