### PR TITLE
Fix webpack config - NODE_ENV had a string 'none'

### DIFF
--- a/lib/compiler/defaults/webpack-defaults.ts
+++ b/lib/compiler/defaults/webpack-defaults.ts
@@ -51,6 +51,9 @@ export const webpackDefaultsFactory = (
     ],
   },
   mode: 'none',
+  optimization: {
+    nodeEnv: false,
+  },
   plugins: [
     new webpack.IgnorePlugin({
       checkResource(resource: any) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Other... Please describe: It is a configuration detail
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I guess more than one user will have got stuck with this detail, and I think the NODE_ENV should be a pure variable. The value 'undefined' must be per base, I think it has the same effect replacing the default setting but I feel it must be so.

Issue Number: #420 


## What is the new behavior?
NODE_ENV === undefined
Now NODE_ENV will be undefined by nature and can be replaced.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
