### PR TITLE
Adds --config option to build and start commands

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -59,7 +59,8 @@ export class BuildAction extends AbstractAction {
     isDebugEnabled = false,
     onSuccess?: () => void,
   ) {
-    const configuration = await this.loader.load();
+    const configFileName = options.find( option => option.name === 'config')!.value as string;
+    const configuration = await this.loader.load(configFileName);
     const appName = inputs.find(input => input.name === 'app')!.value as string;
 
     const pathToTsconfig = getValueOrDefault<string>(

--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -13,7 +13,8 @@ import { BuildAction } from './build.action';
 export class StartAction extends BuildAction {
   public async handle(inputs: Input[], options: Input[]) {
     try {
-      const configuration = await this.loader.load();
+      const configFileName = options.find( option => option.name === 'config')!.value as string;
+      const configuration = await this.loader.load(configFileName);
       const appName = inputs.find(input => input.name === 'app')!
         .value as string;
 

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -6,6 +6,7 @@ export class BuildCommand extends AbstractCommand {
   public load(program: CommanderStatic): void {
     program
       .command('build [app]')
+      .option('-c, --config [path]', 'Path to nest-cli config file')
       .option('-p, --path [path]', 'Path to tsconfig file')
       .option('-w, --watch', 'Run in watch mode (live-reload)')
       .option('--webpack', 'Use webpack for compilation')
@@ -14,6 +15,11 @@ export class BuildCommand extends AbstractCommand {
       .description('Build Nest application')
       .action(async (app: string, command: Command) => {
         const options: Input[] = [];
+
+        options.push({
+          name: 'config',
+          value: command.config,
+        });
 
         const isWebpackEnabled = command.tsc ? false : command.webpack;
         options.push({ name: 'webpack', value: isWebpackEnabled });

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -6,6 +6,7 @@ export class StartCommand extends AbstractCommand {
   public load(program: CommanderStatic): void {
     program
       .command('start [app]')
+      .option('-c, --config [path]', 'Path to nest-cli config file')
       .option('-p, --path [path]', 'Path to tsconfig file')
       .option('-w, --watch', 'Run in watch mode (live-reload)')
       .option(
@@ -18,6 +19,11 @@ export class StartCommand extends AbstractCommand {
       .description('Start Nest application')
       .action(async (app: string, command: Command) => {
         const options: Input[] = [];
+
+        options.push({
+          name: 'config',
+          value: command.config,
+        });
 
         const isWebpackEnabled = command.tsc ? false : command.webpack;
         options.push({ name: 'webpack', value: isWebpackEnabled });

--- a/lib/configuration/configuration.loader.ts
+++ b/lib/configuration/configuration.loader.ts
@@ -1,5 +1,5 @@
 import { Configuration } from './configuration';
 
 export interface ConfigurationLoader {
-  load(): Required<Configuration> | Promise<Required<Configuration>>;
+  load(name?: string): Required<Configuration> | Promise<Required<Configuration>>;
 }

--- a/lib/configuration/nest-configuration.loader.ts
+++ b/lib/configuration/nest-configuration.loader.ts
@@ -6,13 +6,14 @@ import { defaultConfiguration } from './defaults';
 export class NestConfigurationLoader implements ConfigurationLoader {
   constructor(private readonly reader: Reader) {}
 
-  public async load(): Promise<Required<Configuration>> {
-    const content: string | undefined = await this.reader.readAnyOf([
+  public async load(name?: string): Promise<Required<Configuration>> {
+    const content: string | undefined = name ? await this.reader.read(name) : await this.reader.readAnyOf([
       '.nestcli.json',
       '.nest-cli.json',
       'nest-cli.json',
       'nest.json',
     ]);
+
     if (!content) {
       return defaultConfiguration;
     }

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -16,6 +16,15 @@ describe('Nest Configuration Loader', () => {
             }),
           ),
         ),
+        read: jest.fn(() =>
+          Promise.resolve(
+            JSON.stringify({
+              language: 'ts',
+              collection: '@nestjs/schematics',
+              entryFile: 'secondary',
+            }),
+          ),
+        ),
       };
     });
     reader = mock();
@@ -34,6 +43,26 @@ describe('Nest Configuration Loader', () => {
       collection: '@nestjs/schematics',
       sourceRoot: 'src',
       entryFile: 'main',
+      monorepo: false,
+      projects: {},
+      compilerOptions: {
+        assets: [],
+        plugins: [],
+        tsConfigPath: 'tsconfig.build.json',
+        webpack: false,
+        webpackConfigPath: 'webpack.config.js',
+      },
+    });
+  });
+  it('should call reader.read when load with filename', async () => {
+    const loader: ConfigurationLoader = new NestConfigurationLoader(reader);
+    const configuration: Configuration = await loader.load('nest-cli.secondary.config.json');
+    expect(reader.read).toHaveBeenCalledWith('nest-cli.secondary.config.json');
+    expect(configuration).toEqual({
+      language: 'ts',
+      collection: '@nestjs/schematics',
+      sourceRoot: 'src',
+      entryFile: 'secondary',
       monorepo: false,
       projects: {},
       compilerOptions: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ X ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Implements #452 

## What is the new behavior?

Both *build* and *start* commands now accept a --config option to switch between different nest-cli.config.json files.

Eg: `nest-cli build --config brand-new-config-file.nest-cli.json`

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Enjoy!