### PR TITLE
bugfix(cli) use outDir from asset item instead of the default one

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -41,7 +41,7 @@ export class AssetsManager {
       const copyFiles = (item: AssetEntry) =>
         new Promise((resolve, reject) =>
           copyfiles(
-            [(item as any).glob!, outDir],
+            [(item as any).glob!, (item as any).outDir!],
             {
               exclude: item.exclude,
               flat: item.flat,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

assets will be copied to the default outDir of the app.

## What is the new behavior?

will be copied to the outDir of each item

```
        "org-api": {
            "type": "application",
            "root": "apps/org-api",
            "entryFile": "main",
            "sourceRoot": "apps/org-api/src",
            "compilerOptions": {
                "tsConfigPath": "apps/org-api/tsconfig.app.json",
                "assets": [{
                    "include": "../client/**/*",
                    "outDir": "dist/apps/org-api/apps/org-api/client/"
                }]
            }
        }
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
