### PR TITLE
feat(cli) Add generateOptions to configuration

### DIFF
--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -13,6 +13,7 @@ import {
   askForProjectName,
   moveDefaultProjectToStart,
   shouldAskForProject,
+  shouldGenerateSpec,
 } from '../lib/utils/project-utils';
 import { AbstractAction } from './abstract.action';
 
@@ -30,6 +31,7 @@ const generateFiles = async (inputs: Input[]) => {
     .value as string;
   const appName = inputs.find(option => option.name === 'project')!
     .value as string;
+  const spec = inputs.find(option => option.name === 'spec');
 
   const collection: AbstractCollection = CollectionFactory.create(
     collectionOption || configuration.collection,
@@ -43,6 +45,16 @@ const generateFiles = async (inputs: Input[]) => {
   let sourceRoot = appName
     ? getValueOrDefault(configuration, 'sourceRoot', appName)
     : configuration.sourceRoot;
+
+  const specValue = spec!.value as boolean;
+  const specOptions = spec!.options as any;
+  let generateSpec = shouldGenerateSpec(
+    configuration,
+    schematic,
+    appName,
+    specValue,
+    specOptions.passedAsInput,
+  );
 
   // If you only add a `lib` we actually don't have monorepo: true BUT we do have "projects"
   // Ensure we don't run for new app/libs schematics
@@ -74,9 +86,21 @@ const generateFiles = async (inputs: Input[]) => {
     if (project !== configuration.sourceRoot) {
       sourceRoot = configurationProjects[project].sourceRoot;
     }
+
+    if (answers.appName !== defaultProjectName) {
+      // Only overwrite if the appName is not the default- as it has already been loaded above
+      generateSpec = shouldGenerateSpec(
+        configuration,
+        schematic,
+        answers.appName,
+        specValue,
+        specOptions.passedAsInput,
+      );
+    }
   }
 
   schematicOptions.push(new SchematicOption('sourceRoot', sourceRoot));
+  schematicOptions.push(new SchematicOption('spec', generateSpec));
   try {
     const schematicInput = inputs.find(input => input.name === 'schematic');
     if (!schematicInput) {
@@ -91,9 +115,10 @@ const generateFiles = async (inputs: Input[]) => {
 };
 
 const mapSchematicOptions = (inputs: Input[]): SchematicOption[] => {
+  const excludedInputNames = ['schematic', 'spec'];
   const options: SchematicOption[] = [];
   inputs.forEach(input => {
-    if (input.name !== 'schematic' && input.value !== undefined) {
+    if (!excludedInputNames.includes(input.name) && input.value !== undefined) {
       options.push(new SchematicOption(input.name, input.value));
     }
   });

--- a/commands/command.input.ts
+++ b/commands/command.input.ts
@@ -1,4 +1,5 @@
 export interface Input {
   name: string;
   value: boolean | string;
+  options?: any;
 }

--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -17,7 +17,17 @@ export class GenerateCommand extends AbstractCommand {
       )
       .option('-p, --project [project]', 'Project in which to generate files.')
       .option('--flat', 'Enforce flat structure of generated element.')
-      .option('--no-spec', 'Disable spec files generation.')
+      .option(
+        '--spec',
+        'Enforce spec files generation.',
+        () => {
+          return { value: true, passedAsInput: true };
+        },
+        true,
+      )
+      .option('--no-spec', 'Disable spec files generation.', () => {
+        return { value: false, passedAsInput: true };
+      })
       .option(
         '-c, --collection [collectionName]',
         'Schematics collection to use.',
@@ -34,7 +44,16 @@ export class GenerateCommand extends AbstractCommand {
           options.push({ name: 'flat', value: command.flat });
           options.push({
             name: 'spec',
-            value: command.spec,
+            value:
+              typeof command.spec === 'boolean'
+                ? command.spec
+                : command.spec.value,
+            options: {
+              passedAsInput:
+                typeof command.spec === 'boolean'
+                  ? false
+                  : command.spec.passedAsInput,
+            },
           });
           options.push({
             name: 'collection',

--- a/lib/compiler/helpers/get-value-or-default.ts
+++ b/lib/compiler/helpers/get-value-or-default.ts
@@ -19,12 +19,15 @@ export function getValueOrDefault<T = any>(
       configuration,
       `projects.${appName}.`.concat(propertyPath),
     );
-    if (perAppValue) {
+    if (perAppValue !== undefined) {
       return perAppValue as T;
     }
   }
-  const value = getValueOfPath(configuration, propertyPath);
-  return value || defaultValue;
+  let value = getValueOfPath(configuration, propertyPath);
+  if (value === undefined) {
+    value = defaultValue;
+  }
+  return value;
 }
 
 function getValueOfPath<T = any>(

--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -15,6 +15,10 @@ interface CompilerOptions {
   deleteOutDir?: boolean;
 }
 
+interface GenerateOptions {
+  spec?: boolean | Record<string, boolean>;
+}
+
 export interface ProjectConfiguration {
   type?: string;
   root?: string;
@@ -31,6 +35,7 @@ export interface Configuration {
   entryFile?: string;
   monorepo?: boolean;
   compilerOptions?: CompilerOptions;
+  generateOptions?: GenerateOptions;
   projects?: {
     [key: string]: ProjectConfiguration;
   };

--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -14,6 +14,7 @@ export const defaultConfiguration: Required<Configuration> = {
     plugins: [],
     assets: [],
   },
+  generateOptions: {},
 };
 
 export const defaultOutDir = 'dist';

--- a/lib/utils/project-utils.ts
+++ b/lib/utils/project-utils.ts
@@ -1,5 +1,6 @@
 import * as inquirer from 'inquirer';
 import { Answers, Question } from 'inquirer';
+import { getValueOrDefault } from '../compiler/helpers/get-value-or-default';
 import { Configuration, ProjectConfiguration } from '../configuration';
 import { generateSelect } from '../questions/questions';
 
@@ -14,6 +15,56 @@ export function shouldAskForProject(
     Object.entries(configurationProjects).length !== 0 &&
     !appName
   );
+}
+
+export function shouldGenerateSpec(
+  configuration: Required<Configuration>,
+  schematic: string,
+  appName: string,
+  specValue: boolean,
+  specPassedAsInput?: boolean,
+) {
+  if (specPassedAsInput === true || specPassedAsInput === undefined) {
+    // CLI parameters has the highest priority
+    return specValue;
+  }
+
+  let specConfiguration = getValueOrDefault(
+    configuration,
+    'generateOptions.spec',
+    appName || '',
+  );
+  if (typeof specConfiguration === 'boolean') {
+    return specConfiguration;
+  }
+
+  if (
+    typeof specConfiguration === 'object' &&
+    specConfiguration[schematic] !== undefined
+  ) {
+    return specConfiguration[schematic];
+  }
+
+  if (typeof specConfiguration === 'object' && appName) {
+    // The appName has a generateOption spec, but not for the schematic trying to generate
+    // Check if the global generateOptions has a spec to use instead
+    specConfiguration = getValueOrDefault(
+      configuration,
+      'generateOptions.spec',
+      '',
+    );
+    if (typeof specConfiguration === 'boolean') {
+      return specConfiguration;
+    }
+
+    if (
+      typeof specConfiguration === 'object' &&
+      specConfiguration[schematic] !== undefined
+    ) {
+      return specConfiguration[schematic];
+    }
+  }
+  return specValue;
 }
 
 export async function askForProjectName(

--- a/test/lib/compiler/helpers/get-value-or-default.spec.ts
+++ b/test/lib/compiler/helpers/get-value-or-default.spec.ts
@@ -1,0 +1,165 @@
+import { getValueOrDefault } from '../../../../lib/compiler/helpers/get-value-or-default';
+import { Configuration } from '../../../../lib/configuration';
+
+describe('Get Value or Default', () => {
+  it('should return assigned configuration value', async () => {
+    let configuration: Required<Configuration> = {
+      monorepo: true,
+      sourceRoot: '',
+      entryFile: '',
+      projects: {},
+      language: '',
+      collection: '',
+      compilerOptions: {},
+    };
+    let value = getValueOrDefault(configuration, 'monorepo', '');
+    expect(value).toEqual(true);
+
+    configuration = {
+      monorepo: false,
+      sourceRoot: '',
+      entryFile: '',
+      projects: {},
+      language: '',
+      collection: '',
+      compilerOptions: {},
+    };
+    value = getValueOrDefault(configuration, 'monorepo', '');
+    expect(value).toEqual(false);
+
+    value = getValueOrDefault(configuration, 'notfound', '');
+    expect(value).toBeUndefined();
+  });
+
+  it('should return assigned project configuration value', async () => {
+    let configuration: Required<Configuration> = {
+      monorepo: true,
+      sourceRoot: '',
+      entryFile: '',
+      projects: {
+        'test-project': {
+          compilerOptions: {
+            webpack: true,
+          },
+        },
+      },
+      language: '',
+      collection: '',
+      compilerOptions: {},
+    };
+    let value = getValueOrDefault(
+      configuration,
+      'compilerOptions.webpack',
+      'test-project',
+    );
+    expect(value).toEqual(true);
+
+    configuration = {
+      monorepo: true,
+      sourceRoot: '',
+      entryFile: '',
+      projects: {
+        'test-project': {
+          compilerOptions: {
+            webpack: false,
+          },
+        },
+      },
+      language: '',
+      collection: '',
+      compilerOptions: {},
+    };
+    value = getValueOrDefault(
+      configuration,
+      'compilerOptions.webpack',
+      'test-project',
+    );
+    expect(value).toEqual(false);
+
+    configuration = {
+      monorepo: true,
+      sourceRoot: '',
+      entryFile: '',
+      projects: {
+        'test-project': {
+          compilerOptions: {},
+        },
+      },
+      language: '',
+      collection: '',
+      compilerOptions: {},
+    };
+    value = getValueOrDefault(
+      configuration,
+      'compilerOptions.webpack',
+      'test-project',
+    );
+    expect(value).toBeUndefined();
+  });
+
+  it('should return default configuration value when project value not found', async () => {
+    let configuration: Required<Configuration> = {
+      monorepo: true,
+      sourceRoot: '',
+      entryFile: '',
+      projects: {
+        'test-project': {
+          compilerOptions: {},
+        },
+      },
+      language: '',
+      collection: '',
+      compilerOptions: {
+        webpack: true,
+      },
+    };
+    let value = getValueOrDefault(
+      configuration,
+      'compilerOptions.webpack',
+      'test-project',
+    );
+    expect(value).toEqual(true);
+
+    configuration = {
+      monorepo: true,
+      sourceRoot: '',
+      entryFile: '',
+      projects: {
+        'test-project': {
+          compilerOptions: {},
+        },
+      },
+      language: '',
+      collection: '',
+      compilerOptions: {
+        webpack: false,
+      },
+    };
+    value = getValueOrDefault(
+      configuration,
+      'compilerOptions.webpack',
+      'test-project',
+    );
+    expect(value).toEqual(false);
+
+    configuration = {
+      monorepo: true,
+      sourceRoot: '',
+      entryFile: '',
+      projects: {
+        'test-project': {
+          compilerOptions: {},
+        },
+      },
+      language: '',
+      collection: '',
+      compilerOptions: {},
+    };
+    value = getValueOrDefault(
+      configuration,
+      'compilerOptions.webpack',
+      'test-project',
+    );
+    expect(value).toBeUndefined();
+  });
+});

--- a/test/lib/compiler/helpers/get-value-or-default.spec.ts
+++ b/test/lib/compiler/helpers/get-value-or-default.spec.ts
@@ -11,6 +11,7 @@ describe('Get Value or Default', () => {
       language: '',
       collection: '',
       compilerOptions: {},
+      generateOptions: {},
     };
     let value = getValueOrDefault(configuration, 'monorepo', '');
     expect(value).toEqual(true);
@@ -23,6 +24,7 @@ describe('Get Value or Default', () => {
       language: '',
       collection: '',
       compilerOptions: {},
+      generateOptions: {},
     };
     value = getValueOrDefault(configuration, 'monorepo', '');
     expect(value).toEqual(false);
@@ -46,6 +48,7 @@ describe('Get Value or Default', () => {
       language: '',
       collection: '',
       compilerOptions: {},
+      generateOptions: {},
     };
     let value = getValueOrDefault(
       configuration,
@@ -68,6 +71,7 @@ describe('Get Value or Default', () => {
       language: '',
       collection: '',
       compilerOptions: {},
+      generateOptions: {},
     };
     value = getValueOrDefault(
       configuration,
@@ -88,6 +92,7 @@ describe('Get Value or Default', () => {
       language: '',
       collection: '',
       compilerOptions: {},
+      generateOptions: {},
     };
     value = getValueOrDefault(
       configuration,
@@ -112,6 +117,7 @@ describe('Get Value or Default', () => {
       compilerOptions: {
         webpack: true,
       },
+      generateOptions: {},
     };
     let value = getValueOrDefault(
       configuration,
@@ -134,6 +140,7 @@ describe('Get Value or Default', () => {
       compilerOptions: {
         webpack: false,
       },
+      generateOptions: {},
     };
     value = getValueOrDefault(
       configuration,
@@ -154,6 +161,7 @@ describe('Get Value or Default', () => {
       language: '',
       collection: '',
       compilerOptions: {},
+      generateOptions: {},
     };
     value = getValueOrDefault(
       configuration,

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -52,6 +52,7 @@ describe('Nest Configuration Loader', () => {
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
       },
+      generateOptions: {},
     });
   });
   it('should call reader.read when load with filename', async () => {
@@ -74,6 +75,7 @@ describe('Nest Configuration Loader', () => {
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
       },
+      generateOptions: {},
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently you must specify `--no-spec` on *ALL* generate commands, to not pass the `--spec` flag onwards to the collection, that generates the files. No configuration is available to allow for the `--no-spec` command to be default behavior, unless otherwise specified.

This PR fixes/closes:
- #314 

## What is the new behavior?
With this feature, you are able to specify a `generateOptions` in the configuration file, which currently only have the ability to change the generation options for `spec`, however you can then specify `spec` to be either a boolean (true/false) or an object, which the different generate names as key, with booleans as value, like so:
```
"generateOptions": {
  "spec": true
}
```
or
```
"generateOptions": {
  "spec": {
    "service": true
    ...
  }
}
```

The arguments for generate has been slightly altered, to allow for this change. There has been added a new `--spec <true/false>` option, such that the `spec` parameter is not default to true when the command is passed to the action, but undefined.

This feature follows a hierarchy, such that the CLI arguments have highest priority, then comes the projects individual options (options specified within the `"projects": {}...` option), and lastly the overall `generateOptions` for the project.

Highest:
```
nest g service Cats --spec true
```

Lower:
```
{
  "sourceRoot": "src",
  "projects": {
    "cat-project": {
      "generateOptions": {
        "spec": true
      }
    }
  }
  ...
}
```

Lowest:
```
{
  "sourceRoot": "src",
  "generateOptions: {
   "spec": true
  }
  ...
}
```

Such that if `--spec true` is set on the CLI and the `spec` in the `nest-cli.json` options is set to false, it would overwrite and pass true to the action, and so forward.

One thing I’m unable to currently figure out, is that you can only use the generateOptions with the spec as an object if you use the full name of the schematic you want to run. Ex `service` and not `s` - if anyone has a good suggestion on how to be able to handle aliases, please let me know! :) 

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[x] Maybe?
```
The generate command, has been changed such that the `spec` argument is no longer default to true, but undefined, unless otherwise specified in the CLI arguments. However for the `nestjs/schematics`, it looks like the spec default is always true? Please inform me if otherwise / if needs to be changed

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Make sure that if your custom collection needs `--spec` to be passed as default to the action, that you in the future write `--spec true` or add it to your `nest-cli.json` configuration file

Looking forward to comments and feedback :)
- Emil G

PS. I'm not sure where to add docs to this feature? If you tell me, I will try and write some :)
