### PR TITLE
feat(cli): add directory option to the application schematic

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -26,6 +26,7 @@ import { AbstractAction } from './abstract.action';
 
 export class NewAction extends AbstractAction {
   public async handle(inputs: Input[], options: Input[]) {
+    const directoryOption = options.find(option => option.name === 'directory');
     const dryRunOption = options.find(option => option.name === 'dry-run');
     const isDryRunEnabled = dryRunOption && dryRunOption.value;
 
@@ -38,8 +39,9 @@ export class NewAction extends AbstractAction {
     const shouldSkipGit = options.some(
       option => option.name === 'skip-git' && option.value === true,
     );
-    const projectDirectory = dasherize(
-      getApplicationNameInput(inputs)!.value as string,
+    const projectDirectory = getProjectDirectory(
+      getApplicationNameInput(inputs)!,
+      directoryOption,
     );
 
     if (!shouldSkipInstall) {
@@ -63,6 +65,16 @@ export class NewAction extends AbstractAction {
 
 const getApplicationNameInput = (inputs: Input[]) =>
   inputs.find(input => input.name === 'name');
+
+const getProjectDirectory = (
+  applicationName: Input,
+  directoryOption?: Input,
+): string => {
+  return (
+    (directoryOption && (directoryOption.value as string)) ||
+    dasherize(applicationName.value as string)
+  );
+};
 
 const askForMissingInformation = async (inputs: Input[]) => {
   console.info(MESSAGES.PROJECT_INFORMATION_START);

--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -9,6 +9,7 @@ export class NewCommand extends AbstractCommand {
       .command('new [name]')
       .alias('n')
       .description('Generate Nest application.')
+      .option('--directory [directory]', 'Specify the destination directory')
       .option(
         '-d, --dry-run',
         'Report actions that would be performed without writing out results.',
@@ -29,6 +30,7 @@ export class NewCommand extends AbstractCommand {
       )
       .action(async (name: string, command: Command) => {
         const options: Input[] = [];
+        options.push({ name: 'directory', value: command.directory });
         options.push({ name: 'dry-run', value: !!command.dryRun });
         options.push({ name: 'skip-git', value: !!command.skipGit });
         options.push({ name: 'skip-install', value: !!command.skipInstall });


### PR DESCRIPTION
nestjs/nest-cli#283

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: nestjs/nest-cli#283
```
> nest new @scope/package
```
This command will generate application files inside the 'package' folder and additionally, it will put everything inside a wrapping folder '@scope'. Furthermore currently there is no option to generate the application to another directory than the same as the application name says.
## What is the new behavior?
```
> nest new @scope/package --directory=scope-package
```
This command will produce new application inside scope-package/

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
It will not work without the new feature ( nestjs/schematics#283 ) on the schematics side. Versions of the nest-cli and schematics must much.

## Other information
Needs nestjs/schematics#283 to be merged first.