### PR TITLE
feat(cli) Add preserveWatchOutput option on start command

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -1,3 +1,4 @@
+import * as ts from 'typescript';
 import chalk from 'chalk';
 import { join } from 'path';
 import webpack = require('webpack');
@@ -118,7 +119,11 @@ export class BuildAction extends AbstractAction {
     }
 
     if (watchMode) {
-      this.watchCompiler.run(configuration, pathToTsconfig, appName, onSuccess);
+      const tsCompilerOptions: ts.CompilerOptions = {};
+      if(options.find(option => option.name === 'preserveWatchOutput' && option.value === true)) {
+        tsCompilerOptions.preserveWatchOutput = true
+      }
+      this.watchCompiler.run(configuration, pathToTsconfig, appName, tsCompilerOptions, onSuccess);
     } else {
       this.compiler.run(configuration, pathToTsconfig, appName, onSuccess);
     }

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -17,6 +17,7 @@ export class StartCommand extends AbstractCommand {
       .option('--webpackPath [path]', 'Path to webpack configuration.')
       .option('--tsc', 'Use tsc for compilation.')
       .option('-e, --exec [binary]', 'Binary to run (default: "node").')
+      .option('--preserveWatchOutput', 'Use preserveWatchOutput option when tsc watch mode.')
       .description('Run Nest application.')
       .action(async (app: string, command: Command) => {
         const options: Input[] = [];
@@ -42,6 +43,10 @@ export class StartCommand extends AbstractCommand {
           name: 'exec',
           value: command.exec,
         });
+        options.push({
+          name: 'preserveWatchOutput',
+          value: !!command.preserveWatchOutput && !!command.watch && !isWebpackEnabled
+        })
 
         const inputs: Input[] = [];
         inputs.push({ name: 'app', value: app });

--- a/lib/compiler/watch-compiler.ts
+++ b/lib/compiler/watch-compiler.ts
@@ -18,6 +18,7 @@ export class WatchCompiler {
     configuration: Required<Configuration>,
     configFilename: string,
     appName: string,
+    tsCompilerOptions: ts.CompilerOptions,
     onSuccess?: () => void,
   ) {
     const tsBin = this.typescriptLoader.load();
@@ -43,7 +44,7 @@ export class WatchCompiler {
     );
     const host = tsBin.createWatchCompilerHost(
       configPath,
-      {},
+      tsCompilerOptions,
       tsBin.sys,
       createProgram,
       this.createDiagnosticReporter(origDiagnosticReporter),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #587 

There's no option for disable the console "clear" on `nest start` command.


## What is the new behavior?

Add option name `preserveWatchOutput` like `nest start --watch --preserveWatchOutput`.
It only works when watchmode is enabled and compiler is tsc.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
