### PR TITLE
fix(cli): support multiple webpack confgis

### DIFF
--- a/lib/compiler/webpack-compiler.ts
+++ b/lib/compiler/webpack-compiler.ts
@@ -16,7 +16,7 @@ export class WebpackCompiler {
     configuration: Required<Configuration>,
     webpackConfigFactoryOrConfig: (
       config: webpack.Configuration,
-    ) => webpack.Configuration,
+    ) => webpack.Configuration | webpack.Configuration[],
     tsConfigPath: string,
     appName: string,
     isDebugEnabled = false,
@@ -68,10 +68,21 @@ export class WebpackCompiler {
       typeof webpackConfigFactoryOrConfig !== 'function'
         ? webpackConfigFactoryOrConfig
         : webpackConfigFactoryOrConfig(defaultOptions);
-    const webpackConfiguration = {
-      ...defaultOptions,
-      ...projectWebpackOptions,
-    };
+
+    let webpackConfiguration: webpack.Configuration | webpack.Configuration[];
+
+    if (Array.isArray(projectWebpackOptions)) {
+      webpackConfiguration = projectWebpackOptions.map((projectWebpackOptionsItem) => ({
+        ...defaultOptions,
+        ...projectWebpackOptionsItem,
+      }));
+    } else {
+      webpackConfiguration = {
+        ...defaultOptions,
+        ...projectWebpackOptions,
+      };
+    }
+
     const compiler = webpack(webpackConfiguration);
 
     const afterCallback = (err: Error, stats: any) => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[?] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, [the `webpackConfigFactoryOrConfig` doesn’t support multiple _webpack_ configs](https://github.com/nestjs/nest-cli/blob/master/lib/compiler/webpack-compiler.ts#L67-L74), which was [introduced in `webpack@3.1.0`](https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations).

## What is the new behavior?
This change allows consumer to use a factory the runs either a _webpack_ config or an array of _webpack_ configs. In my case, I’m working on an isomorphic application where I want to use different _webpack_ configs for the client and server bundles. Unfortunately, this change seems rather difficult to write tests for.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information