### PR TITLE
build: speed up the TypeScript transpilation when using webpack

### DIFF
--- a/lib/compiler/defaults/webpack-defaults.ts
+++ b/lib/compiler/defaults/webpack-defaults.ts
@@ -30,6 +30,7 @@ export const webpackDefaultsFactory = (
           {
             loader: 'ts-loader',
             options: {
+              transpileOnly: true,
               configFile: tsConfigFile,
               getCustomTransformers: (program: any) => ({
                 before: plugins.beforeHooks.map(hook => hook(program)),


### PR DESCRIPTION
Disable the type-checking while transpiling the TS files, as the ForkTsCheckerWebpackPlugin
is already handling this within another process

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Run `nest build` for a webpack based Nest.js-CLI project (it should be considerably big). 

Issue Number: N/A


## What is the new behavior?
With ts-loaders `transpileOnly`-flag set to `true`, the transpilation process gets a serious speed up, as it disables the type-checking while transpiling the sources.
It is still safe to do this, as the type checking takes place in another process using the `ForkTsCheckerWebpackPlugin`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
