### PR TITLE
fix: node engine setting outdated in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 10.13.0",
+    "node": ">= 10.19.0",
     "npm": ">= 6.11.0"
   },
   "bin": {


### PR DESCRIPTION
Expected version is 10.19.0

------

Current behavior

```json
package.json

"engines": {
  "node": ">= 10.13.0",
  "npm": ">= 6.11.0"
},
```

```sh
nest-cli   master  yarn                                                          
yarn install v1.22.0
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
error jest@26.1.0: The engine "node" is incompatible with this module. Expected version ">= 10.14.2". Got "10.13.0"
error Found incompatible module.
```

---

```bash
/nest-cli   hotfix/7.4.2 ●  nvm use 10.14
Now using node v10.14.2 (npm v6.4.1)
```

```json
package.json

"engines": {
  "node": ">= 10.14.2",
  "npm": ">= 6.11.0"
},
```

```bash
nest-cli   hotfix/7.4.2 ●  yarn         
yarn install v1.22.0
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
error got@11.3.0: The engine "node" is incompatible with this module. Expected version ">=10.19.0". Got "10.14.2"
error Found incompatible module.
```

---


```bash
/nest-cli   hotfix/7.4.2 ●  nvm install 10.19
Downloading and installing node v10.19.0...
Downloading https://nodejs.org/dist/v10.19.0/node-v10.19.0-darwin-x64.tar.xz...
############################################################################################################################################################################################################### 100,0%
Computing checksum with shasum -a 256
Checksums matched!
Now using node v10.19.0 (npm v6.13.4)
```

```json
package.json

"engines": {
  "node": ">= 10.19.0",
  "npm": ">= 6.11.0"
},
```

*LGTM now*
# 🤘
