### PR TITLE
feat(cli): add pnpm package manager support

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -174,6 +174,7 @@ const askForPackageManager = async (): Promise<Answers> => {
     generateSelect('package-manager')(MESSAGES.PACKAGE_MANAGER_QUESTION)([
       PackageManager.NPM,
       PackageManager.YARN,
+      PackageManager.PNPM
     ]),
   ];
   const prompt = inquirer.createPromptModule();

--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -26,6 +26,7 @@ export const defaultGitIgnore = `# compiled output
 logs
 *.log
 npm-debug.log*
+pnpm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*

--- a/lib/package-managers/index.ts
+++ b/lib/package-managers/index.ts
@@ -3,5 +3,6 @@ export * from './package-manager.factory';
 export * from './abstract.package-manager';
 export * from './npm.package-manager';
 export * from './yarn.package-manager';
+export * from './pnpm.package-manager';
 export * from './project.dependency';
 export * from './package-manager-commands';

--- a/lib/package-managers/package-manager.factory.ts
+++ b/lib/package-managers/package-manager.factory.ts
@@ -3,6 +3,7 @@ import { AbstractPackageManager } from './abstract.package-manager';
 import { NpmPackageManager } from './npm.package-manager';
 import { PackageManager } from './package-manager';
 import { YarnPackageManager } from './yarn.package-manager';
+import { PnpmPackageManager } from './pnpm.package-manager';
 
 export class PackageManagerFactory {
   public static create(name: PackageManager | string): AbstractPackageManager {
@@ -11,6 +12,8 @@ export class PackageManagerFactory {
         return new NpmPackageManager();
       case PackageManager.YARN:
         return new YarnPackageManager();
+      case PackageManager.PNPM:
+        return new PnpmPackageManager();
       default:
         throw new Error(`Package manager ${name} is not managed.`);
     }
@@ -22,8 +25,12 @@ export class PackageManagerFactory {
         if (error) {
           resolve(this.create(PackageManager.NPM));
         } else {
-          if (files.findIndex(filename => filename === 'yarn.lock') > -1) {
+          if (files.findIndex((filename) => filename === 'yarn.lock') > -1) {
             resolve(this.create(PackageManager.YARN));
+          } else if (
+              files.findIndex((filename) => filename === 'pnpm-lock.yaml') > -1
+          ) {
+            resolve(this.create(PackageManager.PNPM));
           } else {
             resolve(this.create(PackageManager.NPM));
           }

--- a/lib/package-managers/package-manager.ts
+++ b/lib/package-managers/package-manager.ts
@@ -1,4 +1,5 @@
 export enum PackageManager {
   NPM = 'npm',
   YARN = 'yarn',
+  PNPM = 'pnpm'
 }

--- a/lib/package-managers/pnpm.package-manager.ts
+++ b/lib/package-managers/pnpm.package-manager.ts
@@ -1,0 +1,27 @@
+import { Runner, RunnerFactory } from '../runners';
+import { PnpmRunner } from '../runners/pnpm.runner';
+import { AbstractPackageManager } from './abstract.package-manager';
+import { PackageManager } from './package-manager';
+import { PackageManagerCommands } from './package-manager-commands';
+
+export class PnpmPackageManager extends AbstractPackageManager {
+  constructor() {
+    super(RunnerFactory.create(Runner.PNPM) as PnpmRunner);
+  }
+
+  public get name() {
+    return PackageManager.PNPM.toUpperCase();
+  }
+
+  // As of PNPM v5.3, all commands are shared with NPM v6.14.5. See: https://pnpm.js.org/en/pnpm-vs-npm
+  get cli(): PackageManagerCommands {
+    return {
+      install: 'install',
+      add: 'install',
+      update: 'update',
+      remove: 'uninstall',
+      saveFlag: '--save',
+      saveDevFlag: '--save-dev',
+    };
+  }
+}

--- a/lib/runners/pnpm.runner.ts
+++ b/lib/runners/pnpm.runner.ts
@@ -1,0 +1,7 @@
+import { AbstractRunner } from './abstract.runner';
+
+export class PnpmRunner extends AbstractRunner {
+  constructor() {
+    super('pnpm');
+  }
+}

--- a/lib/runners/runner.factory.ts
+++ b/lib/runners/runner.factory.ts
@@ -3,6 +3,7 @@ import { NpmRunner } from './npm.runner';
 import { Runner } from './runner';
 import { SchematicRunner } from './schematic.runner';
 import { YarnRunner } from './yarn.runner';
+import { PnpmRunner } from './pnpm.runner';
 
 export class RunnerFactory {
   public static create(runner: Runner) {
@@ -15,6 +16,9 @@ export class RunnerFactory {
 
       case Runner.YARN:
         return new YarnRunner();
+
+      case Runner.PNPM:
+        return new PnpmRunner();
 
       default:
         console.info(chalk.yellow(`[WARN] Unsupported runner: ${runner}`));

--- a/lib/runners/runner.ts
+++ b/lib/runners/runner.ts
@@ -2,4 +2,5 @@ export enum Runner {
   SCHEMATIC,
   NPM,
   YARN,
+  PNPM
 }

--- a/test/lib/package-managers/pnpm.package-manager.spec.ts
+++ b/test/lib/package-managers/pnpm.package-manager.spec.ts
@@ -1,0 +1,124 @@
+import { join } from 'path';
+import {
+  PnpmPackageManager,
+  PackageManagerCommands,
+} from '../../../lib/package-managers';
+import { PnpmRunner } from '../../../lib/runners/pnpm.runner';
+
+jest.mock('../../../lib/runners/pnpm.runner');
+
+describe('NpmPackageManager', () => {
+  let packageManager: PnpmPackageManager;
+  beforeEach(() => {
+    (PnpmRunner as any).mockClear();
+    (PnpmRunner as any).mockImplementation(() => {
+      return {
+        run: (): Promise<void> => Promise.resolve(),
+      };
+    });
+    packageManager = new PnpmPackageManager();
+  });
+  it('should be created', () => {
+    expect(packageManager).toBeInstanceOf(PnpmPackageManager);
+  });
+  it('should have the correct cli commands', () => {
+    const expectedValues: PackageManagerCommands = {
+      install: 'install',
+      add: 'install',
+      update: 'update',
+      remove: 'uninstall',
+      saveFlag: '--save',
+      saveDevFlag: '--save-dev',
+    };
+    expect(packageManager.cli).toMatchObject(expectedValues);
+  });
+  describe('install', () => {
+    it('should use the proper command for installing', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dirName = '/tmp';
+      const testDir = join(process.cwd(), dirName);
+      packageManager.install(dirName, 'pnpm');
+      expect(spy).toBeCalledWith('install --silent', true, testDir);
+    });
+  });
+  describe('addProduction', () => {
+    it('should use the proper command for adding production dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = '5.0.0';
+      const command = `install --save ${dependencies
+          .map((dependency) => `${dependency}@${tag}`)
+          .join(' ')}`;
+      packageManager.addProduction(dependencies, tag);
+      expect(spy).toBeCalledWith(command, true);
+    });
+  });
+  describe('addDevelopment', () => {
+    it('should use the proper command for adding development dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = '5.0.0';
+      const command = `install --save-dev ${dependencies
+          .map((dependency) => `${dependency}@${tag}`)
+          .join(' ')}`;
+      packageManager.addDevelopment(dependencies, tag);
+      expect(spy).toBeCalledWith(command, true);
+    });
+  });
+  describe('updateProduction', () => {
+    it('should use the proper command for updating production dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const command = `update ${dependencies.join(' ')}`;
+      packageManager.updateProduction(dependencies);
+      expect(spy).toBeCalledWith(command, true);
+    });
+  });
+  describe('updateDevelopment', () => {
+    it('should use the proper command for updating development dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const command = `update ${dependencies.join(' ')}`;
+      packageManager.updateDevelopement(dependencies);
+      expect(spy).toBeCalledWith(command, true);
+    });
+  });
+  describe('upgradeProduction', () => {
+    it('should use the proper command for upgrading production dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = '5.0.0';
+      const uninstallCommand = `uninstall --save ${dependencies.join(' ')}`;
+
+      const installCommand = `install --save ${dependencies
+          .map((dependency) => `${dependency}@${tag}`)
+          .join(' ')}`;
+
+      return packageManager.upgradeProduction(dependencies, tag).then(() => {
+        expect(spy.mock.calls).toEqual([
+          [uninstallCommand, true],
+          [installCommand, true],
+        ]);
+      });
+    });
+  });
+  describe('upgradeDevelopment', () => {
+    it('should use the proper command for upgrading production dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = '5.0.0';
+      const uninstallCommand = `uninstall --save-dev ${dependencies.join(' ')}`;
+
+      const installCommand = `install --save-dev ${dependencies
+          .map((dependency) => `${dependency}@${tag}`)
+          .join(' ')}`;
+
+      return packageManager.upgradeDevelopement(dependencies, tag).then(() => {
+        expect(spy.mock.calls).toEqual([
+          [uninstallCommand, true],
+          [installCommand, true],
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
nest-cli only offers `npm` and `yarn` as package managers. As `pnpm` is growing rapidly into a third major player in the JavaScript package manager ecosystem, nest-cli should support it both when running `nest new` and throughout for running nest scripts and installing dependencies.

## What is the new behavior?
pnpm is now available as a package manager, like npm and yarn. Since pnpm uses the same commands [requires no significant changes](https://pnpm.js.org/en/pnpm-vs-npm) compared to working with npm, there are no substantial changes to codebase other than the addition of new objects/references for pnpm (and one logic change). pnpm passes all tests, including when using nest-cli to run the default app using pnpm-installed packages.
![image](https://user-images.githubusercontent.com/31638829/87167152-8926e080-c29a-11ea-88aa-938499b58279.png)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
NOTE: Nest Official Documentation still requires updating [here](https://docs.nestjs.com/cli/usages). Please see docs PR [here](https://github.com/nestjs/docs.nestjs.com/pull/1347)