### PR TITLE
fix(new): fix language bug

### DIFF
--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -30,6 +30,7 @@ export class NewCommand extends AbstractCommand {
       )
       .action(async (name: string, command: Command) => {
         const options: Input[] = [];
+        const availableLanguages = ['js', 'ts', 'javascript', 'typescript'];
         options.push({ name: 'directory', value: command.directory });
         options.push({ name: 'dry-run', value: !!command.dryRun });
         options.push({ name: 'skip-git', value: !!command.skipGit });
@@ -38,6 +39,27 @@ export class NewCommand extends AbstractCommand {
           name: 'package-manager',
           value: command.packageManager,
         });
+
+        if (!!command.language) {
+          const langMatch = availableLanguages.includes(
+            command.language.toLowerCase(),
+          );
+          if (!langMatch) {
+            throw new Error(
+              `Invalid language "${command.language}" selected. Available languages are "typescript" or "javascript"`,
+            );
+          }
+          switch (command.language) {
+            case 'javascript':
+              command.language = 'js';
+              break;
+            case 'typescript':
+              command.language = 'ts';
+              break;
+            default:
+              break;
+          }
+        }
         options.push({
           name: 'language',
           value: !!command.language ? command.language : 'ts',


### PR DESCRIPTION
## PR Type
```
[x] Bugfix
```

## What is the current behavior?

`nest n -l typescript` (or `javascript`, or any language that doesn't exist errors out without giving information.

Issue Number: https://github.com/nestjs/nest/issues/4854 (closed ticket bug related issue)


## What is the new behavior?

`nest n -l javascript` works (as well as `typescript`) and any languages that _don't exist_ throw errors letting users know.

![image](https://user-images.githubusercontent.com/2574412/89111929-d0cc0280-d429-11ea-86f6-ae54573782f7.png)



## Does this PR introduce a breaking change?
```
[x] No
```
