### PR TITLE
fix(): fatal errors during build won't prompt (webpack)

### DIFF
--- a/lib/compiler/webpack-compiler.ts
+++ b/lib/compiler/webpack-compiler.ts
@@ -75,6 +75,13 @@ export class WebpackCompiler {
     const compiler = webpack(webpackConfiguration);
 
     const afterCallback = (err: Error, stats: any) => {
+      if (err && stats === undefined) {
+        // Could not complete the compilation
+        // The error caught is most likely thrown by underlying tasks
+        console.log(err);
+        return process.exit(1);
+      }
+
       const statsOutput = stats.toString({
         chunks: false,
         colors: true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [-] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The err object was not checked and it was relied on defined stats. This results in a confusing type error that has nothing to do with the actual error.

Issue Number: #868 


## What is the new behavior?

Now early exit when err object is set but stats remains undefined.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
