### PR TITLE
refactor: find typescript using `require.resolve`

### DIFF
--- a/lib/compiler/typescript-loader.ts
+++ b/lib/compiler/typescript-loader.ts
@@ -10,7 +10,7 @@ export class TypeScriptBinaryLoader {
 
     try {
       const tsBinaryPath = require.resolve('typescript', {
-        paths: this.getModulePaths(),
+        paths: [process.cwd(), ...this.getModulePaths()],
       });
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const tsBinary = require(tsBinaryPath);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #885

The fix in #748 will incorrectly load the version installed with @nest/cli when using PnP. Additionally, hardcoding node_modules and searching for typescript within it can fail with yarn workspaces depending on hoisting layout, even without using PnP - or it can lead to unexpected results (wrong typescript version being found/used)

## What is the new behavior?

Use `require.resolve` to find `typescript`, and load it using `require`

A special case to handle Yarn PnP is no longer required and #748 is obsoleted.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
