### PR TITLE
fix(cli): add .vscode folder to .gitignore properly

### DIFF
--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -47,6 +47,7 @@ lerna-debug.log*
 *.sublime-workspace
 
 # IDE - VSCode
+.vscode
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
default gitignore setting, '.vscode/*', can't ignore .vscode folder 



## What is the new behavior?
.vscode is added to default gitignore setting 
.vscode can ignore .vscode folder

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information
