### PR TITLE
fix(deps): Typescript 4.1  breaking changes

### DIFF
--- a/actions/abstract.action.ts
+++ b/actions/abstract.action.ts
@@ -1,7 +1,7 @@
 import { Input } from '../commands';
 
 export abstract class AbstractAction {
-  public abstract async handle(
+  public abstract handle(
     inputs?: Input[],
     options?: Input[],
     extraFlags?: string[],

--- a/lib/compiler/workspace-utils.ts
+++ b/lib/compiler/workspace-utils.ts
@@ -16,7 +16,7 @@ export class WorkspaceUtils {
     if (!isDeleteEnabled) {
       return;
     }
-    await new Promise((resolve, reject) =>
+    await new Promise<void>((resolve, reject) =>
       rimraf(dirPath, (err) => (err ? reject(err) : resolve())),
     );
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Breaking changes in the Typescript 4.1.* related to async and promises.
```

## What is the current behavior?
Not changed.
Issue Number: N/A

## What is the new behavior?
Correcting "fix(deps): update dependency typescript to v4.1.3" #957 to successfully build nest-cli for v4.1.*

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
See, https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#abstract-members-cant-be-marked-async and https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#resolves-parameters-are-no-longer-optional-in-promises for more information.