### PR TITLE
fix(@nestjs/cli): convert --language shortcode to lowercase

### DIFF
--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -55,6 +55,9 @@ export class NewCommand extends AbstractCommand {
             case 'typescript':
               command.language = 'ts';
               break;
+            default:
+              command.language = lowercasedLanguage;
+              break;
           }
         }
         options.push({


### PR DESCRIPTION
Following the docs for the --language option will result in:
https://github.com/nestjs/nest-cli/issues/1030. This change fixes the error by converting language
shortcodes to lowercase.

#1030

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #1030 


## What is the new behavior?
The new behavior is the expected behavior as described in #1030.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I did not see any tests for any of the commands, and so did not write a test for this bug. If I have overlooked those tests, would be happy to add a test for the language option shortcode containing an uppercase character.

I do not see the need for any docs updates anywhere.