### PR TITLE
chore(deps): drop @types/webpack dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2171,25 +2171,6 @@
         }
       }
     },
-    "@types/webpack": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-5.0.0.tgz",
-      "integrity": "sha512-ZCS1DkyB403u76fCCjEIzdSYbL139Ed6ppHEUem20M+IBIldJHrI585lSxQYne9k6juTtgI5GA05PcoW2KLw/g==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "tapable": "^2.2.0",
-        "webpack": "^5"
-      },
-      "dependencies": {
-        "tapable": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
-          "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
-          "dev": true
-        }
-      }
-    },
     "@types/webpack-node-externals": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@types/webpack-node-externals/-/webpack-node-externals-2.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/os-name": "3.1.0",
     "@types/rimraf": "3.0.0",
     "@types/shelljs": "0.8.8",
-    "@types/webpack": "5.0.0",
     "@types/webpack-node-externals": "2.5.1",
     "@typescript-eslint/eslint-plugin": "4.19.0",
     "@typescript-eslint/parser": "4.19.0",


### PR DESCRIPTION
`webpack@5` is now direct dependency of `@nestjs/cli` and it's pure TS (native) with it's own `.d.ts`.
Package `@types/webpback@5` is now direct passhtrough to `webpack` itself.

Thanks!

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Other

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
You should be albe to better see possible impact, say when somehone is still using a mix of outdated deps and using Yarn resolution.

## Other information

TL;DR;
`@types/webpack` is no longer required to be referenced rirectly, it's handled properly as you're on the `webpack@5`

lng:
The community around the TS and definitey typed is working on improving TS expeerience when using DefinitelyTyped definition, which was under huge impact after `webpack` migrated to native TS implementaion (which, huh, differs from DT definition, even if compatibility changes were added in retrospection).
you've been hit by side effect of those ongoing changes yesterday:
https://github.com/nestjs/nest/issues/6764#issuecomment-808056980
(sorry for the probs, btw).
this change is about to be polished out:
DefinitelyTyped/DefinitelyTyped#52030
In the essence: @types/webpack are required for ecosystem out-there, to ease problems of different versions consumed in projects with webpack or webpack plugins dependencies,
I've run local test and re-created scenario from the bug (`npm start -- new test-webpack` from wtihin repo, etc)

Thanks!
