### PR TITLE
fix: Application did not exit on watch process abnormal exit

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -3,6 +3,7 @@ import { spawn } from 'child_process';
 import * as fs from 'fs';
 import { join } from 'path';
 import * as killProcess from 'tree-kill';
+import { treeKillSync as killProcessSync } from '../lib/utils/tree-kill';
 import { Input } from '../commands';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
 import { Configuration } from '../lib/configuration';
@@ -85,7 +86,7 @@ export class StartAction extends BuildAction {
     let childProcessRef: any;
     process.on(
       'exit',
-      () => childProcessRef && killProcess(childProcessRef.pid),
+      () => childProcessRef && killProcessSync(childProcessRef.pid),
     );
 
     return () => {

--- a/lib/utils/tree-kill.ts
+++ b/lib/utils/tree-kill.ts
@@ -1,0 +1,81 @@
+import { execSync } from 'child_process';
+
+export function treeKillSync(pid: number, signal?: string | number): void {
+
+    if (process.platform === "win32") {
+        execSync('taskkill /pid ' + pid + ' /T /F');
+        return;
+    }
+
+    const childs = getAllChilds(pid);
+
+    childs.forEach(function (pid) {
+        killPid(pid, signal);
+    });
+
+    killPid(pid, signal);
+    return
+}
+
+function getAllPid(): {
+    pid: number,
+    ppid: number
+}[] {
+    const rows = execSync('ps -A -o pid,ppid')
+        .toString()
+        .trim()
+        .split('\n')
+        .slice(1);
+
+    return rows.map(function (row) {
+        var parts = row.match(/\s*(\d+)\s*(\d+)/);
+
+        if (parts === null) {
+            return null;
+        }
+
+        return {
+            pid: Number(parts[1]),
+            ppid: Number(parts[2])
+        };
+    }).filter(<T extends Object>(input: null | undefined | T): input is T => {
+        return input != null;
+    });
+}
+
+function getAllChilds(pid: number) {
+    const allpid = getAllPid();
+
+    let ppidHash: {
+        [key: number]: number[]
+    } = {};
+
+    let result: number[] = [];
+
+    allpid.forEach(function (item) {
+        ppidHash[item.ppid] = ppidHash[item.ppid] || [];
+        ppidHash[item.ppid].push(item.pid);
+    });
+
+    const find = function (pid: number) {
+        ppidHash[pid] = ppidHash[pid] || [];
+        ppidHash[pid].forEach(function (childPid) {
+            result.push(childPid);
+            find(childPid);
+        });
+    };
+
+    find(pid);
+
+    return result;
+}
+
+function killPid(pid: number, signal?: string | number) {
+    try {
+        process.kill(pid, signal);
+    } catch (err) {
+        if (err.code !== 'ESRCH') {
+            throw err;
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

fix #1124 

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

![image](https://user-images.githubusercontent.com/20190812/114393536-b3605280-9bcc-11eb-850b-e9150cfd931c.png)

When running `nest start --watch`, edit `tsconfig.json`. It will report an error and exit.
 running `nest start --watch` again, it will prompt that the `Error: listen EADDRINUSE: address already in use :::3000`

![image](https://user-images.githubusercontent.com/20190812/114394210-85c7d900-9bcd-11eb-9b6e-bf0339d3c980.png)


 > Listener functions must only perform synchronous operations. The Node.js process will exit immediately after calling the 'exit' event listeners causing any additional work still queued in the event loop to be abandoned. In the following example, for instance, the timeout will never occur:

https://nodejs.org/dist/latest-v14.x/docs/api/process.html#process_event_exit 

Issue Number: #1124 

## What is the new behavior?

When running `nest start --watch`, edit `tsconfig.json`. It will report an error and exit.
 running `nest start --watch` again,   start application on normal status.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
