### PR TITLE
attempt at optionally enabling server reload for non-ts files 

### DIFF
--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -6,6 +6,7 @@ export interface AssetEntry {
   exclude?: string;
   outDir?: string;
   watchAssets?: boolean;
+  reload: boolean;
 }
 
 export interface ActionOnFile {
@@ -14,6 +15,7 @@ export interface ActionOnFile {
   path: string;
   sourceRoot: string;
   watchAssetsMode: boolean;
+  reload: boolean;
 }
 
 interface CompilerOptions {
@@ -23,6 +25,7 @@ interface CompilerOptions {
   plugins?: string[];
   assets?: string[];
   deleteOutDir?: boolean;
+  loadTimeout?: number;
 }
 
 interface GenerateOptions {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/nestjs/nest-cli/issues/1140

Issue Number: 1140


## What is the new behavior?

Added optional configuration:

`compilerOptions.loadTimeout` (number, milliseconds. 60sec by default) - time that the cli treats as the 'initial asset loading phase'. Any watched non-ts assets that are added or modified after this timeout will trigger a server reload.

`compilerOptions.assets[i].reload` (boolean, `false` by default) - set to true in order to enable server reloads for this asset if an addition or modification is detected after the initial asset loading phase.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information
Documentation to be updated