### PR TITLE
fix: allow to remove type only imports including alias path

### DIFF
--- a/lib/compiler/hooks/tsconfig-paths.hook.ts
+++ b/lib/compiler/hooks/tsconfig-paths.hook.ts
@@ -35,6 +35,7 @@ export function tsconfigPathsBeforeHookFactory(
               return node;
             }
             (newNode as any).moduleSpecifier = tsBinary.createLiteral(result);
+            (newNode as any).moduleSpecifier.parent = (node as any).moduleSpecifier.parent;
             return newNode;
           } catch {
             return node;


### PR DESCRIPTION
The current behaviour is that type only imports don't get removed if they contain a tsconfig alias.

Closes #1145

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1145


## What is the new behavior?

Type only imports get removed if they contain a tsconfig path alias.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
