### PR TITLE
feat(): add webpackSourceMap option to build and start commands

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -46,6 +46,9 @@ export class BuildAction extends AbstractAction {
   public async handle(inputs: Input[], options: Input[]) {
     try {
       const watchModeOption = options.find((option) => option.name === 'watch');
+      const webpackSourceMapOption = options.find(
+        (option) => option.name === 'webpackSourceMap',
+      );
       const watchMode = !!(watchModeOption && watchModeOption.value);
 
       const watchAssetsModeOption = options.find(
@@ -55,7 +58,13 @@ export class BuildAction extends AbstractAction {
         watchAssetsModeOption && watchAssetsModeOption.value
       );
 
-      await this.runBuild(inputs, options, watchMode, watchAssetsMode);
+      await this.runBuild(
+        inputs,
+        options,
+        watchMode,
+        watchAssetsMode,
+        webpackSourceMapOption?.value as string | undefined,
+      );
     } catch (err) {
       if (err instanceof Error) {
         console.log(`\n${ERROR_PREFIX} ${err.message}\n`);
@@ -70,7 +79,7 @@ export class BuildAction extends AbstractAction {
     options: Input[],
     watchMode: boolean,
     watchAssetsMode: boolean,
-    isDebugEnabled = false,
+    webpackSourceMap?: string,
     onSuccess?: () => void,
   ) {
     const configFileName = options.find((option) => option.name === 'config')!
@@ -127,7 +136,7 @@ export class BuildAction extends AbstractAction {
         webpackConfigFactoryOrConfig,
         pathToTsconfig,
         appName,
-        isDebugEnabled,
+        webpackSourceMap ?? false,
         watchMode,
         this.assetsManager,
         onSuccess,

--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -31,6 +31,9 @@ export class StartAction extends BuildAction {
         (option) => option.name === 'exec',
       );
       const debugModeOption = options.find((option) => option.name === 'debug');
+      const webpackSourceMapOption = options.find(
+        (option) => option.name === 'webpackSourceMap',
+      );
       const watchModeOption = options.find((option) => option.name === 'watch');
       const isWatchEnabled = !!(watchModeOption && watchModeOption.value);
       const watchAssetsModeOption = options.find(
@@ -43,9 +46,11 @@ export class StartAction extends BuildAction {
       const binaryToRun =
         binaryToRunOption && (binaryToRunOption.value as string | undefined);
 
-      const { options: tsOptions } = this.tsConfigProvider.getByConfigFilename(
-        pathToTsconfig,
-      );
+      // If the webpackSourceMap is provided, use that. If it isn't and debug is set to true, use inline-sourcemap
+      const sourceMapType = (webpackSourceMapOption?.value as string | undefined) ?? (!!debugFlag ? 'inline-source-map' : undefined);
+
+      const { options: tsOptions } =
+        this.tsConfigProvider.getByConfigFilename(pathToTsconfig);
       const outDir = tsOptions.outDir || defaultOutDir;
       const onSuccess = this.createOnSuccessHook(
         configuration,
@@ -60,7 +65,7 @@ export class StartAction extends BuildAction {
         options,
         isWatchEnabled,
         isWatchAssetsEnabled,
-        !!debugFlag,
+        sourceMapType,
         onSuccess,
       );
     } catch (err) {

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -12,6 +12,7 @@ export class BuildCommand extends AbstractCommand {
       .option('--watchAssets', 'Watch non-ts (e.g., .graphql) files mode.')
       .option('--webpack', 'Use webpack for compilation.')
       .option('--webpackPath [path]', 'Path to webpack configuration.')
+      .option('--webpackSourceMap  [type]', 'Type of webpack source map to output.')
       .option('--tsc', 'Use tsc for compilation.')
       .description('Build Nest application.')
       .action(async (app: string, command: Command) => {
@@ -33,6 +34,10 @@ export class BuildCommand extends AbstractCommand {
         options.push({
           name: 'webpackPath',
           value: command.webpackPath,
+        });
+        options.push({
+          name: 'webpackSourceMap',
+          value: command.webpackSourceMap,
         });
 
         const inputs: Input[] = [];

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -16,6 +16,7 @@ export class StartCommand extends AbstractCommand {
       )
       .option('--webpack', 'Use webpack for compilation.')
       .option('--webpackPath [path]', 'Path to webpack configuration.')
+      .option('--webpackSourceMap  [type]', 'Type of webpack source map to output.')
       .option('--tsc', 'Use tsc for compilation.')
       .option('-e, --exec [binary]', 'Binary to run (default: "node").')
       .option(
@@ -43,6 +44,10 @@ export class StartCommand extends AbstractCommand {
         options.push({
           name: 'webpackPath',
           value: command.webpackPath,
+        });
+        options.push({
+          name: 'webpackSourceMap',
+          value: command.webpackSourceMap,
         });
         options.push({
           name: 'exec',

--- a/lib/compiler/defaults/webpack-defaults.ts
+++ b/lib/compiler/defaults/webpack-defaults.ts
@@ -11,12 +11,12 @@ export const webpackDefaultsFactory = (
   sourceRoot: string,
   relativeSourceRoot: string,
   entryFilename: string,
-  isDebugEnabled = false,
+  sourceMapType: string | false = false,
   tsConfigFile = defaultConfiguration.compilerOptions.tsConfigPath,
   plugins: MultiNestCompilerPlugins,
 ): webpack.Configuration => ({
   entry: appendTsExtension(join(sourceRoot, entryFilename)),
-  devtool: isDebugEnabled ? 'inline-source-map' : false,
+  devtool: sourceMapType,
   target: 'node',
   output: {
     filename: join(relativeSourceRoot, `${entryFilename}.js`),

--- a/lib/compiler/webpack-compiler.ts
+++ b/lib/compiler/webpack-compiler.ts
@@ -19,7 +19,7 @@ export class WebpackCompiler {
     ) => webpack.Configuration,
     tsConfigPath: string,
     appName: string,
-    isDebugEnabled = false,
+    sourceMapType: string | false = false,
     watchMode = false,
     assetsManager: AssetsManager,
     onSuccess?: () => void,
@@ -60,7 +60,7 @@ export class WebpackCompiler {
       pathToSource,
       entryFileRoot,
       entryFile,
-      isDebugEnabled,
+      sourceMapType,
       tsConfigPath,
       plugins,
     );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Right now, only the `--debug` option on the `start` command allows the generation of source maps by webpack.

Issue Number: N/A


## What is the new behavior?
A `--webpackSourceMap` option has been added to the `build` and `start` commands. This allows the generation of webpack source maps based on the user provided type. In addition, the `debug` option on `nest start` will continue to generate `inline-source-map`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
