### PR TITLE
docs(types) - update plugins configuration interface

### DIFF
--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -20,9 +20,14 @@ interface CompilerOptions {
   tsConfigPath?: string;
   webpack?: boolean;
   webpackConfigPath?: string;
-  plugins?: string[];
+  plugins?: string[] | PluginOptions[];
   assets?: string[];
   deleteOutDir?: boolean;
+}
+
+interface PluginOptions {
+  name: string;
+  options: object;
 }
 
 interface GenerateOptions {

--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -27,7 +27,7 @@ interface CompilerOptions {
 
 interface PluginOptions {
   name: string;
-  options: object;
+  options: Record<string, any>[];
 }
 
 interface GenerateOptions {


### PR DESCRIPTION
JSON Schema validation fails for nest-cli.json if an item in CompilerOptions.plugins[] uses the object notation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [✅] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [✅] Tests for the changes have been added (for bug fixes / features)
- [✅] Docs have been added / updated (for bug fixes / features)

I don't think tests or doc updates are applicable here. Backwards compatible as it just adds a union with the existing type `string[]` and does not affect the preferred default value. 

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[✅] Other... Please describe: Types/Documentation
```

## What is the current behavior?
When validating a local nest-cli.json via it's JSON Schema at [json.schemastore.org/nest-cli.json](https://json.schemastore.org/nest-cli.json), the plugin items will fail validation if using the [object notation](https://docs.nestjs.com/graphql/cli-plugin#using-the-cli-plugin) (see second code block). 

Side note, some IDEs (i.e. IntelliJ IDEA) have capabilities bundled-in that automatically reference schemastore.org for matching schemas based on local filenames, with the editor reporting invalid JSON as per the schema without any obvious indicators as to what or where the schema is being defined. 

Issue Number: N/A


## What is the new behavior?
JSON Schema now honors plugins defined in string or object format. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[✅ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I'm unsure if this is automated as part of this project's CI, but a new draft of the JSON Schema will need to be published to https://json.schemastore.org/nest-cli.json