### PR TITLE
fix: assets copying from 'nest build' is problematic

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -13,13 +13,25 @@ import { getValueOrDefault } from './helpers/get-value-or-default';
 export class AssetsManager {
   private watchAssetsKeyValue: { [key: string]: boolean } = {};
   private watchers: chokidar.FSWatcher[] = [];
+  private actionInProgress = false;
 
   /**
    * Using on `nest build` to close file watch or the build process will not end
+   * Interval like process
+   * If no action has been taken recently close watchers
+   * If action has been taken recently flag and try again
    */
   public closeWatchers() {
-    const timeoutMs = 300;
-    const closeFn = () => this.watchers.forEach((watcher) => watcher.close());
+    // Consider adjusting this for larger files
+    const timeoutMs = 500;
+    const closeFn = () => {
+      if (this.actionInProgress) {
+        this.actionInProgress = false;
+        setTimeout(closeFn, timeoutMs);
+      } else {
+        this.watchers.forEach((watcher) => watcher.close());
+      }
+    };
 
     setTimeout(closeFn, timeoutMs);
   }
@@ -101,9 +113,10 @@ export class AssetsManager {
     if (!isWatchEnabled && this.watchAssetsKeyValue[path]) {
       return;
     }
-
     // Set path value to true for watching the first time
     this.watchAssetsKeyValue[path] = true;
+    // Set action to true to avoid watches getting cutoff
+    this.actionInProgress = true;
 
     const dest = copyPathResolve(
       path,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the closeWatcher executes midway of copying assets. Very notisable in a file structure with a lot of subfolders/files.

Issue Number: #1117 


## What is the new behavior?

Refactored closeWatchers to check if a recent action has been exectued in order to reduce race conditions and reset the timer. Additional timeout will trigger repeating the process until a recent action has not been executed, at which it will close the watchers.

Note: The race condition could still be a problematic factor when copying bigger files, I'd assume, for which a more clever/robust solution should be applied. Additionally the timeout of 300 was increased to 500 to lessen the timeout spam on the event loop. Could be increased further upon analysing or set dynamically based on file sizes/files count ratio to reduce spam.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This was a pickle to investigate. Good find.