### PR TITLE
fix(compiler): remove type in afterDeclarations property

### DIFF
--- a/lib/compiler/defaults/webpack-defaults.ts
+++ b/lib/compiler/defaults/webpack-defaults.ts
@@ -35,7 +35,7 @@ export const webpackDefaultsFactory = (
               getCustomTransformers: (program: any) => ({
                 before: plugins.beforeHooks.map((hook) => hook(program)),
                 after: plugins.afterHooks.map((hook) => hook(program)),
-                afterDeclaratqions: plugins.afterDeclarationsHooks.map((hook) =>
+                afterDeclarations: plugins.afterDeclarationsHooks.map((hook) =>
                   hook(program),
                 ),
               }),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`afterDeclarations` with Webpack compilation won't work because it was spelled `afterDeclaratqions`

Issue Number: N/A

## What is the new behavior?

`afterDeclarations` with Webpack compilation should work

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
