### PR TITLE
feat(): add --platform <platform> option on new command

### DIFF
--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -21,6 +21,10 @@ export class NewCommand extends AbstractCommand {
         'Specify package manager.',
       )
       .option(
+        '--platform [platform]',
+        'Specify the underlying HTTP platform to be used (express or fastify).',
+      )
+      .option(
         '-l, --language [language]',
         'Programming language to be used (TypeScript or JavaScript).',
       )
@@ -30,8 +34,10 @@ export class NewCommand extends AbstractCommand {
       )
       .option('--strict', 'Enables strict mode in TypeScript.')
       .action(async (name: string, command: Command) => {
-        const options: Input[] = [];
+        const availableHttpPlatforms = ['express', 'fastify'];
         const availableLanguages = ['js', 'ts', 'javascript', 'typescript'];
+
+        const options: Input[] = [];
         options.push({ name: 'directory', value: command.directory });
         options.push({ name: 'dry-run', value: !!command.dryRun });
         options.push({ name: 'skip-git', value: !!command.skipGit });
@@ -41,6 +47,20 @@ export class NewCommand extends AbstractCommand {
           name: 'package-manager',
           value: command.packageManager,
         });
+        options.push({
+          name: 'platform',
+          value: command.platform,
+        });
+
+        if (!!command.platform) {
+          const lowercasedPlatform = command.platform.toLowerCase();
+          if (!availableHttpPlatforms.includes(lowercasedPlatform)) {
+            throw new Error(
+              `Invalid HTTP platform "${command.platform}" selected. Available platforms are "express" or "fastify"`,
+            );
+          }
+          command.platform = lowercasedPlatform;
+        }
 
         if (!!command.language) {
           const lowercasedLanguage = command.language.toLowerCase();
@@ -62,6 +82,7 @@ export class NewCommand extends AbstractCommand {
               break;
           }
         }
+
         options.push({
           name: 'language',
           value: !!command.language ? command.language : 'ts',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After merging this PR from `@nestjs/schematics`: https://github.com/nestjs/schematics/pull/809 there's no way to use the new `--platform` option of it

## What is the new behavior?

Add `--platform <platform>` on `new` command

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is PR is done but it depends on the new version of `@nestjs/schematics` that isn't released. This is why it's marked as a draft.
