### PR TITLE
refactor(): load configuration via same entry

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -10,13 +10,14 @@ import { Configuration } from '../lib/configuration';
 import { defaultOutDir } from '../lib/configuration/defaults';
 import { ERROR_PREFIX } from '../lib/ui';
 import { BuildAction } from './build.action';
+import { loadConfiguration } from '../lib/utils/load-configuration';
 
 export class StartAction extends BuildAction {
   public async handle(inputs: Input[], options: Input[]) {
     try {
       const configFileName = options.find((option) => option.name === 'config')!
         .value as string;
-      const configuration = await this.loader.load(configFileName);
+      const configuration = await loadConfiguration(configFileName);
       const appName = inputs.find((input) => input.name === 'app')!
         .value as string;
 

--- a/lib/utils/load-configuration.ts
+++ b/lib/utils/load-configuration.ts
@@ -1,10 +1,15 @@
-import { Configuration, ConfigurationLoader } from '../configuration';
-import { NestConfigurationLoader } from '../configuration/nest-configuration.loader';
+import {
+  Configuration,
+  ConfigurationLoader,
+  NestConfigurationLoader,
+} from '../configuration';
 import { FileSystemReader } from '../readers';
 
-export async function loadConfiguration(): Promise<Required<Configuration>> {
+export async function loadConfiguration(
+  name?: string,
+): Promise<Required<Configuration>> {
   const loader: ConfigurationLoader = new NestConfigurationLoader(
     new FileSystemReader(process.cwd()),
   );
-  return loader.load();
+  return loader.load(name);
 }


### PR DESCRIPTION
As the commit msg, this PR is to let actions load nest-cli configuration via same entrance.

If you don't like it, please let me know. Thanks a lot.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The attribute `loader` in BuildAction class is protected and I deleted it. Therefore, it may cause breaking change if third-party cli action has extended BuildAction.