### PR TITLE
Fix support for package manager selection, and refactoring `new` command/action 

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -118,7 +118,7 @@ const generateApplicationFiles = async (args: Input[], options: Input[]) => {
 };
 
 const mapSchematicOptions = (options: Input[]): SchematicOption[] => {
-  const optionsToExclude = ['skip-install', 'skip-git', 'package-manager'];
+  const optionsToExclude = ['skip-install', 'skip-git'];
 
   return options.reduce(
     (schematicOptions: SchematicOption[], option: Input) => {
@@ -137,7 +137,7 @@ const installPackages = async (
   installDirectory: string,
 ) => {
   const inputPackageManager: string = options.find(
-    (option) => option.name === 'package-manager',
+    (option) => option.name === 'packageManager',
   )!.value as string;
 
   let packageManager: AbstractPackageManager;
@@ -167,12 +167,12 @@ const installPackages = async (
 
 const selectPackageManager = async (): Promise<AbstractPackageManager> => {
   const answers: Answers = await askForPackageManager();
-  return PackageManagerFactory.create(answers['package-manager']);
+  return PackageManagerFactory.create(answers['packageManager']);
 };
 
 const askForPackageManager = async (): Promise<Answers> => {
   const questions: Question[] = [
-    generateSelect('package-manager')(MESSAGES.PACKAGE_MANAGER_QUESTION)([
+    generateSelect('packageManager')(MESSAGES.PACKAGE_MANAGER_QUESTION)([
       PackageManager.NPM,
       PackageManager.YARN,
       PackageManager.PNPM

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -3,20 +3,14 @@ import * as chalk from 'chalk';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as inquirer from 'inquirer';
-import { Answers, Question } from 'inquirer';
 import { join } from 'path';
 import { promisify } from 'util';
 import { Input } from '../commands';
 import { defaultGitIgnore } from '../lib/configuration/defaults';
-import {
-  AbstractPackageManager,
-  PackageManager,
-  PackageManagerFactory,
-} from '../lib/package-managers';
+import { PackageManager, PackageManagerFactory } from '../lib/package-managers';
 import { generateInput, generateSelect } from '../lib/questions/questions';
 import { GitRunner } from '../lib/runners/git.runner';
 import {
-  AbstractCollection,
   Collection,
   CollectionFactory,
   SchematicOption,
@@ -32,7 +26,7 @@ export class NewAction extends AbstractAction {
     const dryRunOption = options.find((option) => option.name === 'dry-run');
     const isDryRunEnabled = dryRunOption && dryRunOption.value;
 
-    await askForMissingInformation(inputs);
+    await askForMissingInformation(inputs, options);
     await generateApplicationFiles(inputs, options).catch(exit);
 
     const shouldSkipInstall = options.some(
@@ -65,9 +59,6 @@ export class NewAction extends AbstractAction {
   }
 }
 
-const getApplicationNameInput = (inputs: Input[]) =>
-  inputs.find((input) => input.name === 'name');
-
 const getProjectDirectory = (
   applicationName: Input,
   directoryOption?: Input,
@@ -78,25 +69,47 @@ const getProjectDirectory = (
   );
 };
 
-const askForMissingInformation = async (inputs: Input[]) => {
+const getApplicationNameInput = (inputs: Input[]): Input | undefined =>
+  inputs.find((input) => input.name === 'name');
+
+const getPackageManagerOption = (options: Input[]): Input | undefined =>
+  options.find((option) => option.name === 'packageManager');
+
+const getPackageManagerName = (options: Input[]): string => {
+  const packageManager = getPackageManagerOption(options);
+  return (
+    (packageManager?.value as string) || PackageManager.NPM
+  ).toLowerCase();
+};
+
+/**
+ * Prompt the user to ask for mandatory inputs/options values, which are:
+ * application name and package manager name.
+ */
+const askForMissingInformation = async (inputs: Input[], options: Input[]) => {
   console.info(MESSAGES.PROJECT_INFORMATION_START);
   console.info();
 
-  const prompt: inquirer.PromptModule = inquirer.createPromptModule();
+  const prompt = inquirer.createPromptModule();
+
   const nameInput = getApplicationNameInput(inputs);
   if (!nameInput!.value) {
-    const message = 'What name would you like to use for the new project?';
-    const questions = [generateInput('name', message)('nest-app')];
-    const answers: Answers = await prompt(questions as ReadonlyArray<Question>);
+    const answers = await askForApplicationNameUsingPrompt(prompt);
     replaceInputMissingInformation(inputs, answers);
+  }
+
+  const packageManagerInput = getPackageManagerOption(options);
+  if (!packageManagerInput!.value) {
+    const answers = await askForPackageManagerUsingPrompt(prompt);
+    replaceInputMissingInformation(options, answers);
   }
 };
 
 const replaceInputMissingInformation = (
   inputs: Input[],
-  answers: Answers,
-): Input[] => {
-  return inputs.map(
+  answers: inquirer.Answers,
+): void => {
+  inputs.forEach(
     (input) =>
       (input.value =
         input.value !== undefined ? input.value : answers[input.name]),
@@ -107,12 +120,10 @@ const generateApplicationFiles = async (args: Input[], options: Input[]) => {
   const collectionName = options.find(
     (option) => option.name === 'collection' && option.value != null,
   )!.value;
-  const collection: AbstractCollection = CollectionFactory.create(
+  const collection = CollectionFactory.create(
     (collectionName as Collection) || Collection.NESTJS,
   );
-  const schematicOptions: SchematicOption[] = mapSchematicOptions(
-    args.concat(options),
-  );
+  const schematicOptions = mapSchematicOptions(args.concat(options));
   await collection.execute('application', schematicOptions);
   console.info();
 };
@@ -120,15 +131,12 @@ const generateApplicationFiles = async (args: Input[], options: Input[]) => {
 const mapSchematicOptions = (options: Input[]): SchematicOption[] => {
   const optionsToExclude = ['skip-install', 'skip-git'];
 
-  return options.reduce(
-    (schematicOptions: SchematicOption[], option: Input) => {
-      if (!optionsToExclude.includes(option.name)) {
-        schematicOptions.push(new SchematicOption(option.name, option.value));
-      }
-      return schematicOptions;
-    },
-    [],
-  );
+  return options.reduce((schematicOptions, option: Input) => {
+    if (!optionsToExclude.includes(option.name)) {
+      schematicOptions.push(new SchematicOption(option.name, option.value));
+    }
+    return schematicOptions;
+  }, [] as SchematicOption[]);
 };
 
 const installPackages = async (
@@ -136,50 +144,46 @@ const installPackages = async (
   dryRunMode: boolean,
   installDirectory: string,
 ) => {
-  const inputPackageManager: string = options.find(
-    (option) => option.name === 'packageManager',
-  )!.value as string;
-
-  let packageManager: AbstractPackageManager;
   if (dryRunMode) {
     console.info();
     console.info(chalk.green(MESSAGES.DRY_RUN_MODE));
     console.info();
     return;
   }
-  if (inputPackageManager !== undefined) {
-    try {
-      packageManager = PackageManagerFactory.create(inputPackageManager);
-      await packageManager.install(installDirectory, inputPackageManager);
-    } catch (error) {
-      if (error && error.message) {
-        console.error(chalk.red(error.message));
-      }
+
+  try {
+    const inputPackageManager = getPackageManagerName(options);
+    const packageManager = PackageManagerFactory.create(inputPackageManager);
+    await packageManager.install(installDirectory, inputPackageManager);
+  } catch (error: any) {
+    if (error && error.message) {
+      console.error(chalk.red(error.message));
     }
-  } else {
-    packageManager = await selectPackageManager();
-    await packageManager.install(
-      installDirectory,
-      packageManager.name.toLowerCase(),
-    );
   }
 };
 
-const selectPackageManager = async (): Promise<AbstractPackageManager> => {
-  const answers: Answers = await askForPackageManager();
-  return PackageManagerFactory.create(answers['packageManager']);
+const askForApplicationNameUsingPrompt = async (
+  prompt: inquirer.PromptModule,
+): Promise<inquirer.Answers> => {
+  const questions: inquirer.Question[] = [
+    generateInput('name', MESSAGES.APPLICATION_NAME_QUESTION)('nest-app'),
+  ];
+
+  return prompt(questions as ReadonlyArray<inquirer.Question>);
 };
 
-const askForPackageManager = async (): Promise<Answers> => {
-  const questions: Question[] = [
+const askForPackageManagerUsingPrompt = async (
+  prompt: inquirer.PromptModule,
+): Promise<inquirer.Answers> => {
+  const questions: inquirer.Question[] = [
     generateSelect('packageManager')(MESSAGES.PACKAGE_MANAGER_QUESTION)([
       PackageManager.NPM,
       PackageManager.YARN,
-      PackageManager.PNPM
+      PackageManager.PNPM,
     ]),
   ];
-  const prompt = inquirer.createPromptModule();
-  return await prompt(questions);
+
+  return prompt(questions);
 };
 
 const initializeGitRepository = async (dir: string) => {
@@ -224,16 +228,18 @@ const printCollective = () => {
   emptyLine();
 };
 
-const print = (color: string | null = null) => (str = '') => {
-  const terminalCols = retrieveCols();
-  const strLength = str.replace(/\u001b\[[0-9]{2}m/g, '').length;
-  const leftPaddingLength = Math.floor((terminalCols - strLength) / 2);
-  const leftPadding = ' '.repeat(Math.max(leftPaddingLength, 0));
-  if (color) {
-    str = (chalk as any)[color](str);
-  }
-  console.log(leftPadding, str);
-};
+const print =
+  (color: string | null = null) =>
+  (str = '') => {
+    const terminalCols = retrieveCols();
+    const strLength = str.replace(/\u001b\[[0-9]{2}m/g, '').length;
+    const leftPaddingLength = Math.floor((terminalCols - strLength) / 2);
+    const leftPadding = ' '.repeat(Math.max(leftPaddingLength, 0));
+    if (color) {
+      str = (chalk as any)[color](str);
+    }
+    console.log(leftPadding, str);
+  };
 
 export const retrieveCols = () => {
   const defaultCols = 80;

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -118,12 +118,11 @@ const generateApplicationFiles = async (args: Input[], options: Input[]) => {
 };
 
 const mapSchematicOptions = (options: Input[]): SchematicOption[] => {
+  const optionsToExclude = ['skip-install', 'skip-git', 'package-manager'];
+
   return options.reduce(
     (schematicOptions: SchematicOption[], option: Input) => {
-      if (
-        option.name !== 'skip-install' &&
-        option.value !== 'package-manager'
-      ) {
+      if (!optionsToExclude.includes(option.name)) {
         schematicOptions.push(new SchematicOption(option.name, option.value));
       }
       return schematicOptions;

--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -39,11 +39,15 @@ export class NewCommand extends AbstractCommand {
         options.push({ name: 'strict', value: !!command.strict });
         options.push({
           name: 'packageManager',
-          value: command.packageManager,
+          value: command.packageManager?.trim().toLowerCase(),
+        });
+        options.push({
+          name: 'collection',
+          value: command.collection || Collection.NESTJS,
         });
 
         if (!!command.language) {
-          const lowercasedLanguage = command.language.toLowerCase();
+          const lowercasedLanguage = (command.language as string).toLowerCase();
           const langMatch = availableLanguages.includes(lowercasedLanguage);
           if (!langMatch) {
             throw new Error(
@@ -65,10 +69,6 @@ export class NewCommand extends AbstractCommand {
         options.push({
           name: 'language',
           value: !!command.language ? command.language : 'ts',
-        });
-        options.push({
-          name: 'collection',
-          value: command.collection || Collection.NESTJS,
         });
 
         const inputs: Input[] = [];

--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -17,7 +17,7 @@ export class NewCommand extends AbstractCommand {
       .option('-g, --skip-git', 'Skip git repository initialization.')
       .option('-s, --skip-install', 'Skip package installation.')
       .option(
-        '-p, --package-manager [package-manager]',
+        '-p, --package-manager [packageManager]',
         'Specify package manager.',
       )
       .option(
@@ -38,7 +38,7 @@ export class NewCommand extends AbstractCommand {
         options.push({ name: 'skip-install', value: !!command.skipInstall });
         options.push({ name: 'strict', value: !!command.strict });
         options.push({
-          name: 'package-manager',
+          name: 'packageManager',
           value: command.packageManager,
         });
 

--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -2,6 +2,8 @@ import * as chalk from 'chalk';
 import { EMOJIS } from './emojis';
 
 export const MESSAGES = {
+  APPLICATION_NAME_QUESTION:
+    'What name would you like to use for the new project?',
   PROJECT_SELECTION_QUESTION: 'Which project would you like to generate to?',
   LIBRARY_PROJECT_SELECTION_QUESTION:
     'Which project would you like to add the library to?',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: closes https://github.com/nestjs/schematics/issues/249 (and #500)

due to the usage of `package-manager` key instead of `packageManager` as defined at https://github.com/nestjs/schematics/blob/08a4ecc0b738debaeb08ef97a64556bcb2c75f3f/src/lib/application/schema.json#L44-L46

## What is the new behavior?

The `packageManager` option on `application` schematics is defined by `-p`/`--package-manager` or by the selector prompted to the user. Using `npm` by default, as usual

https://user-images.githubusercontent.com/13461315/146497197-f089fbbe-fc4b-4c64-a586-693e4416510e.mp4

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
