### PR TITLE
feat(new): support to skip install

### DIFF
--- a/lib/package-managers/package-manager.ts
+++ b/lib/package-managers/package-manager.ts
@@ -1,5 +1,6 @@
 export enum PackageManager {
   NPM = 'npm',
   YARN = 'yarn',
-  PNPM = 'pnpm'
+  PNPM = 'pnpm',
+  NONE = 'none (skip installing packages)',
 }


### PR DESCRIPTION
If I run command `nest new some-project` (some one new may don't know `--skip-install` option), nest-cli always force me to select a package manager. I have to press `ctrl` + `c` to skip, which is not elegant. Otherwise I have to waste my time to wait it.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://user-images.githubusercontent.com/35495628/146567806-8e1edfce-018a-45ff-879f-f8984648d0a5.png)


Issue Number: N/A


## What is the new behavior?
![image](https://user-images.githubusercontent.com/35495628/146567582-ed1ffba7-2795-43df-b107-b038e4af07c3.png)



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
