### PR TITLE
feat: better instructions on package manager installation failure

### DIFF
--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -21,11 +21,11 @@ export abstract class AbstractPackageManager {
     });
     spinner.start();
     try {
-      const commandArguments = `${this.cli.install} --silent`;
+      const commandArgs = `${this.cli.install} ${this.cli.silentFlag}`;
       const collect = true;
-      const dasherizedDirectory: string = dasherize(directory);
+      const dasherizedDirectory = dasherize(directory);
       await this.runner.run(
-        commandArguments,
+        commandArgs,
         collect,
         join(process.cwd(), dasherizedDirectory),
       );
@@ -39,7 +39,15 @@ export abstract class AbstractPackageManager {
       console.info();
     } catch {
       spinner.fail();
-      console.error(chalk.red(MESSAGES.PACKAGE_MANAGER_INSTALLATION_FAILED));
+      const commandArgs = this.cli.install;
+      const commandToRun = this.runner.rawFullCommand(commandArgs);
+      console.error(
+        chalk.red(
+          MESSAGES.PACKAGE_MANAGER_INSTALLATION_FAILED(
+            chalk.bold(commandToRun),
+          ),
+        ),
+      );
     }
   }
 

--- a/lib/package-managers/npm.package-manager.ts
+++ b/lib/package-managers/npm.package-manager.ts
@@ -21,6 +21,7 @@ export class NpmPackageManager extends AbstractPackageManager {
       remove: 'uninstall',
       saveFlag: '--save',
       saveDevFlag: '--save-dev',
+      silentFlag: '--silent',
     };
   }
 }

--- a/lib/package-managers/package-manager-commands.ts
+++ b/lib/package-managers/package-manager-commands.ts
@@ -5,4 +5,5 @@ export interface PackageManagerCommands {
   remove: string;
   saveFlag: string;
   saveDevFlag: string;
+  silentFlag: string;
 }

--- a/lib/package-managers/pnpm.package-manager.ts
+++ b/lib/package-managers/pnpm.package-manager.ts
@@ -22,6 +22,7 @@ export class PnpmPackageManager extends AbstractPackageManager {
       remove: 'uninstall',
       saveFlag: '--save',
       saveDevFlag: '--save-dev',
+      silentFlag: '--reporter=silent',
     };
   }
 }

--- a/lib/package-managers/yarn.package-manager.ts
+++ b/lib/package-managers/yarn.package-manager.ts
@@ -21,6 +21,7 @@ export class YarnPackageManager extends AbstractPackageManager {
       remove: 'remove',
       saveFlag: '',
       saveDevFlag: '-D',
+      silentFlag: '--silent',
     };
   }
 }

--- a/lib/runners/abstract.runner.ts
+++ b/lib/runners/abstract.runner.ts
@@ -41,4 +41,13 @@ export class AbstractRunner {
       });
     });
   }
+
+  /**
+   * @param command
+   * @returns The entire command that will be ran when calling `run(command)`.
+   */
+  public rawFullCommand(command: string): string {
+    const commandArgs: string[] = [...this.args, command];
+    return `${this.binary} ${commandArgs.join(' ')}`;
+  }
 }

--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -22,7 +22,8 @@ export const MESSAGES = {
   GET_STARTED_INFORMATION: `${EMOJIS.POINT_RIGHT}  Get started with the following commands:`,
   CHANGE_DIR_COMMAND: (name: string) => `$ cd ${name}`,
   START_COMMAND: (name: string) => `$ ${name} run start`,
-  PACKAGE_MANAGER_INSTALLATION_FAILED: `${EMOJIS.SCREAM}  Packages installation failed, see above`,
+  PACKAGE_MANAGER_INSTALLATION_FAILED: (commandToRunManually: string) =>
+    `${EMOJIS.SCREAM}  Packages installation failed!\nIn case you don't see any errors above, consider manually running the failed command ${commandToRunManually} to see more details on why it errored out.`,
   // tslint:disable-next-line:max-line-length
   NEST_INFORMATION_PACKAGE_MANAGER_FAILED: `${EMOJIS.SMIRK}  cannot read your project package.json file, are you inside your project directory?`,
   LIBRARY_INSTALLATION_FAILED_BAD_PACKAGE: (name: string) =>

--- a/test/lib/package-managers/npm.package-manager.spec.ts
+++ b/test/lib/package-managers/npm.package-manager.spec.ts
@@ -29,6 +29,7 @@ describe('NpmPackageManager', () => {
       remove: 'uninstall',
       saveFlag: '--save',
       saveDevFlag: '--save-dev',
+      silentFlag: '--silent',
     };
     expect(packageManager.cli).toMatchObject(expectedValues);
   });

--- a/test/lib/package-managers/pnpm.package-manager.spec.ts
+++ b/test/lib/package-managers/pnpm.package-manager.spec.ts
@@ -7,7 +7,7 @@ import { PnpmRunner } from '../../../lib/runners/pnpm.runner';
 
 jest.mock('../../../lib/runners/pnpm.runner');
 
-describe('NpmPackageManager', () => {
+describe('PnpmPackageManager', () => {
   let packageManager: PnpmPackageManager;
   beforeEach(() => {
     (PnpmRunner as any).mockClear();
@@ -29,6 +29,7 @@ describe('NpmPackageManager', () => {
       remove: 'uninstall',
       saveFlag: '--save',
       saveDevFlag: '--save-dev',
+      silentFlag: '--reporter=silent',
     };
     expect(packageManager.cli).toMatchObject(expectedValues);
   });
@@ -38,7 +39,7 @@ describe('NpmPackageManager', () => {
       const dirName = '/tmp';
       const testDir = join(process.cwd(), dirName);
       packageManager.install(dirName, 'pnpm');
-      expect(spy).toBeCalledWith('install --silent', true, testDir);
+      expect(spy).toBeCalledWith('install --reporter=silent', true, testDir);
     });
   });
   describe('addProduction', () => {
@@ -47,8 +48,8 @@ describe('NpmPackageManager', () => {
       const dependencies = ['@nestjs/common', '@nestjs/core'];
       const tag = '5.0.0';
       const command = `install --save ${dependencies
-          .map((dependency) => `${dependency}@${tag}`)
-          .join(' ')}`;
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
       packageManager.addProduction(dependencies, tag);
       expect(spy).toBeCalledWith(command, true);
     });
@@ -59,8 +60,8 @@ describe('NpmPackageManager', () => {
       const dependencies = ['@nestjs/common', '@nestjs/core'];
       const tag = '5.0.0';
       const command = `install --save-dev ${dependencies
-          .map((dependency) => `${dependency}@${tag}`)
-          .join(' ')}`;
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
       packageManager.addDevelopment(dependencies, tag);
       expect(spy).toBeCalledWith(command, true);
     });
@@ -91,8 +92,8 @@ describe('NpmPackageManager', () => {
       const uninstallCommand = `uninstall --save ${dependencies.join(' ')}`;
 
       const installCommand = `install --save ${dependencies
-          .map((dependency) => `${dependency}@${tag}`)
-          .join(' ')}`;
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
 
       return packageManager.upgradeProduction(dependencies, tag).then(() => {
         expect(spy.mock.calls).toEqual([
@@ -110,8 +111,8 @@ describe('NpmPackageManager', () => {
       const uninstallCommand = `uninstall --save-dev ${dependencies.join(' ')}`;
 
       const installCommand = `install --save-dev ${dependencies
-          .map((dependency) => `${dependency}@${tag}`)
-          .join(' ')}`;
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
 
       return packageManager.upgradeDevelopment(dependencies, tag).then(() => {
         expect(spy.mock.calls).toEqual([

--- a/test/lib/package-managers/yarn.package-manager.spec.ts
+++ b/test/lib/package-managers/yarn.package-manager.spec.ts
@@ -29,6 +29,7 @@ describe('YarnPackageManager', () => {
       remove: 'remove',
       saveFlag: '',
       saveDevFlag: '-D',
+      silentFlag: '--silent',
     };
     expect(packageManager.cli).toMatchObject(expectedValues);
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: close #1499 

## What is the new behavior?

display this message instead (taking PNPM as example):

```
🙀  Packages installation failed!
In case you don't see any errors above, consider manually running the failed command pnpm install to see more details on why it errored out
```

![image](https://user-images.githubusercontent.com/13461315/153695990-cde38028-c0a5-495a-928a-19dd1c842ded.png)

Also, I've replaced the `--silent` of PNPM by [`--reporter=silent`](https://pnpm.io/pt/cli/install#--reportername) (v6)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Instead of hard coding the full instalation command that might not be wrong by itself, I think is better to rely on the failed command.

As we couldn't access the binary name directly (nor its args) due to how it was defined on `AbstractRunner` abstract class and build the command by yourself, I've added another method on `AbstractRunner`  class to expose a 'raw' version of some command