### PR TITLE
fix: replace aliased imports for tsx and jsx files

### DIFF
--- a/lib/compiler/hooks/tsconfig-paths.hook.ts
+++ b/lib/compiler/hooks/tsconfig-paths.hook.ts
@@ -54,7 +54,12 @@ function getNotAliasedPath(
   matcher: tsPaths.MatchPath,
   text: string,
 ) {
-  let result = matcher(text, undefined, undefined, ['.ts', '.js']);
+  let result = matcher(text, undefined, undefined, [
+    '.ts',
+    '.tsx',
+    '.js',
+    '.jsx',
+  ]);
   if (!result) {
     return;
   }

--- a/test/lib/compiler/hooks/__snapshots__/tsconfig-paths.hook.spec.ts.snap
+++ b/test/lib/compiler/hooks/__snapshots__/tsconfig-paths.hook.spec.ts.snap
@@ -21,3 +21,48 @@ Object.defineProperty(exports, \\"__esModule\\", { value: true });
 ",
 }
 `;
+
+exports[`tsconfig paths hooks should replace path of every import using a path alias by its relative path 1`] = `
+Map {
+  "dist/foo.js" => "\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.Foo = void 0;
+class Foo {
+}
+exports.Foo = Foo;
+",
+  "dist/bar.jsx" => "\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.Bar = void 0;
+class Bar {
+}
+exports.Bar = Bar;
+",
+  "dist/baz.js" => "\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.Baz = void 0;
+class Baz {
+}
+exports.Baz = Baz;
+",
+  "dist/qux.jsx" => "\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.Qux = void 0;
+class Qux {
+}
+exports.Qux = Qux;
+",
+  "dist/main.js" => "\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+const foo_1 = require(\\"./foo\\");
+const bar_1 = require(\\"~/bar\\");
+const baz_1 = require(\\"./baz\\");
+const qux_1 = require(\\"~/qux\\");
+// use the imports so they do not get eliminated
+console.log(foo_1.Foo);
+console.log(bar_1.Bar);
+console.log(baz_1.Baz);
+console.log(qux_1.Qux);
+",
+}
+`;

--- a/test/lib/compiler/hooks/__snapshots__/tsconfig-paths.hook.spec.ts.snap
+++ b/test/lib/compiler/hooks/__snapshots__/tsconfig-paths.hook.spec.ts.snap
@@ -55,9 +55,9 @@ exports.Qux = Qux;
   "dist/main.js" => "\\"use strict\\";
 Object.defineProperty(exports, \\"__esModule\\", { value: true });
 const foo_1 = require(\\"./foo\\");
-const bar_1 = require(\\"~/bar\\");
+const bar_1 = require(\\"./bar\\");
 const baz_1 = require(\\"./baz\\");
-const qux_1 = require(\\"~/qux\\");
+const qux_1 = require(\\"./qux\\");
 // use the imports so they do not get eliminated
 console.log(foo_1.Foo);
 console.log(bar_1.Bar);

--- a/test/lib/compiler/hooks/fixtures/aliased-imports/src/bar.tsx
+++ b/test/lib/compiler/hooks/fixtures/aliased-imports/src/bar.tsx
@@ -1,0 +1,1 @@
+export class Bar {}

--- a/test/lib/compiler/hooks/fixtures/aliased-imports/src/baz.js
+++ b/test/lib/compiler/hooks/fixtures/aliased-imports/src/baz.js
@@ -1,0 +1,1 @@
+export class Baz {}

--- a/test/lib/compiler/hooks/fixtures/aliased-imports/src/foo.ts
+++ b/test/lib/compiler/hooks/fixtures/aliased-imports/src/foo.ts
@@ -1,0 +1,1 @@
+export class Foo {}

--- a/test/lib/compiler/hooks/fixtures/aliased-imports/src/main.ts
+++ b/test/lib/compiler/hooks/fixtures/aliased-imports/src/main.ts
@@ -1,0 +1,10 @@
+import { Foo } from '~/foo';
+import { Bar } from '~/bar';
+import { Baz } from '~/baz';
+import { Qux } from '~/qux';
+
+// use the imports so they do not get eliminated
+console.log(Foo);
+console.log(Bar);
+console.log(Baz);
+console.log(Qux);

--- a/test/lib/compiler/hooks/fixtures/aliased-imports/src/qux.jsx
+++ b/test/lib/compiler/hooks/fixtures/aliased-imports/src/qux.jsx
@@ -1,0 +1,1 @@
+export class Qux {}

--- a/test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts
+++ b/test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts
@@ -1,13 +1,19 @@
 import * as path from 'path';
 import * as ts from 'typescript';
+import { JsxEmit } from 'typescript';
 import { tsconfigPathsBeforeHookFactory } from '../../../../lib/compiler/hooks/tsconfig-paths.hook';
 
-function createSpec(baseUrl: string, fileNames: string[]) {
+function createSpec(
+  baseUrl: string,
+  fileNames: string[],
+  compilerOptions?: ts.CompilerOptions,
+) {
   const options: ts.CompilerOptions = {
     baseUrl,
     outDir: path.join(baseUrl, 'dist'),
     target: ts.ScriptTarget.ESNext,
     module: ts.ModuleKind.CommonJS,
+    ...compilerOptions,
   };
 
   const program = ts.createProgram({
@@ -49,6 +55,15 @@ describe('tsconfig paths hooks', () => {
     const output = createSpec(
       path.join(__dirname, './fixtures/unused-imports'),
       ['src/main.ts', 'src/foo.ts', 'src/bar.ts'],
+    );
+    expect(output).toMatchSnapshot();
+  });
+
+  it('should replace path of every import using a path alias by its relative path', async () => {
+    const output = createSpec(
+      path.join(__dirname, './fixtures/aliased-imports'),
+      ['src/main.ts', 'src/foo.ts', 'src/bar.ts'],
+      { paths: { '~/*': ['./src/*'] }, jsx: JsxEmit.Preserve, allowJs: true },
     );
     expect(output).toMatchSnapshot();
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Commands like `nest start` and `nest build` replace the path of imports using path aliases with its relative path.   
But this currently fails for imports pointing to a `.tsx` or `jsx` file.

Issue Number: #1547


## What is the new behavior?

Path aliases are replaced not only for imports pointing to `.ts` and `.js` files, but for `.tsx` or `jsx` also.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

