### PR TITLE
feat: Add skip import option to generate command

### DIFF
--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -121,7 +121,10 @@ const mapSchematicOptions = (inputs: Input[]): SchematicOption[] => {
   const options: SchematicOption[] = [];
   inputs.forEach((input) => {
     if (!excludedInputNames.includes(input.name) && input.value !== undefined) {
-      options.push(new SchematicOption(input.name, input.value));
+      const keepInputName = input.options
+        ? 'keepInputNameFormat' in input.options
+        : false;
+      options.push(new SchematicOption(input.name, input.value, keepInputName));
     }
   });
   return options;

--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -34,6 +34,7 @@ export class GenerateCommand extends AbstractCommand {
         },
         true,
       )
+      .option('--skip-import', 'Skip importing', () => true, false)
       .option('--no-spec', 'Disable spec files generation.', () => {
         return { value: false, passedAsInput: true };
       })
@@ -75,6 +76,14 @@ export class GenerateCommand extends AbstractCommand {
           options.push({
             name: 'project',
             value: command.project,
+          });
+
+          options.push({
+            name: 'skipImport',
+            value: command.skipImport,
+            options: {
+              keepInputNameFormat: true,
+            },
           });
 
           const inputs: Input[] = [];

--- a/lib/schematics/schematic.option.ts
+++ b/lib/schematics/schematic.option.ts
@@ -1,7 +1,11 @@
 import { normalizeToKebabOrSnakeCase } from '../utils/formatting';
 
 export class SchematicOption {
-  constructor(private name: string, private value: boolean | string) {}
+  constructor(
+    private name: string,
+    private value: boolean | string,
+    private keepInputNameFormat: boolean = false,
+  ) {}
 
   public toCommandString(): string {
     if (typeof this.value === 'string') {
@@ -13,7 +17,9 @@ export class SchematicOption {
         return `--${this.name}="${this.value}"`;
       }
     } else if (typeof this.value === 'boolean') {
-      const str = normalizeToKebabOrSnakeCase(this.name);
+      const str = this.keepInputNameFormat
+        ? this.name
+        : normalizeToKebabOrSnakeCase(this.name);
       return this.value ? `--${str}` : `--no-${str}`;
     } else {
       return `--${normalizeToKebabOrSnakeCase(this.name)}=${this.value}`;

--- a/test/lib/schematics/schematic.option.spec.ts
+++ b/test/lib/schematics/schematic.option.spec.ts
@@ -120,4 +120,12 @@ describe('Schematic Option', () => {
     const option = new SchematicOption('dry-run', false);
     expect(option.toCommandString()).toEqual('--no-dry-run');
   });
+
+  it('should keep input name boolean option', () => {
+    const keepNameOption = new SchematicOption('noDryRunABcdEfg', true, true);
+    expect(keepNameOption.toCommandString()).toEqual('--noDryRunABcdEfg');
+
+    const disableKeepNameOption = new SchematicOption('dry-run', true, false);
+    expect(disableKeepNameOption.toCommandString()).toEqual('--dry-run');
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
When using the `generate` command you can skip the `service` `controller` automatic import into `module` by adding `--skip-import`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
