### PR TITLE
fix(core): upgrade @angular-devkit/schematics-cli to 13.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
   },
   "homepage": "https://github.com/nestjs/nest-cli#readme",
   "dependencies": {
-    "@angular-devkit/core": "13.3.0",
-    "@angular-devkit/schematics": "13.3.0",
-    "@angular-devkit/schematics-cli": "13.3.0",
+    "@angular-devkit/core": "13.3.1",
+    "@angular-devkit/schematics": "13.3.1",
+    "@angular-devkit/schematics-cli": "13.3.1",
     "@nestjs/schematics": "^8.0.3",
     "chalk": "3.0.0",
     "chokidar": "3.5.3",


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x] Other... Please describe:

schematics-cli depends on minimist 1.2.5 which is prone to vulnerability. 
Version 13.3.1 fixes the same by using minimist@1.2.6

Link: https://vuln.whitesourcesoftware.com/vulnerability/CVE-2021-44906
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
