### PR TITLE
feat(core): show defaults in CLI output

### DIFF
--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -13,34 +13,38 @@ export class NewCommand extends AbstractCommand {
       .option(
         '-d, --dry-run',
         'Report actions that would be performed without writing out results.',
+        false
       )
-      .option('-g, --skip-git', 'Skip git repository initialization.')
-      .option('-s, --skip-install', 'Skip package installation.')
+      .option('-g, --skip-git', 'Skip git repository initialization.', false)
+      .option('-s, --skip-install', 'Skip package installation.', false)
       .option(
         '-p, --package-manager [package-manager]',
-        'Specify package manager.',
+        'Specify package manager.'
       )
       .option(
         '-l, --language [language]',
-        'Programming language to be used (TypeScript or JavaScript).',
+        'Programming language to be used (TypeScript or JavaScript)',
+        'TypeScript',
       )
       .option(
         '-c, --collection [collectionName]',
-        'Schematics collection to use.',
+        'Schematics collection to use',
+        Collection.NESTJS,
       )
-      .option('--strict', 'Enables strict mode in TypeScript.')
+      .option('--strict', 'Enables strict mode in TypeScript.', false)
       .action(async (name: string, command: Command) => {
         const options: Input[] = [];
         const availableLanguages = ['js', 'ts', 'javascript', 'typescript'];
         options.push({ name: 'directory', value: command.directory });
-        options.push({ name: 'dry-run', value: !!command.dryRun });
-        options.push({ name: 'skip-git', value: !!command.skipGit });
-        options.push({ name: 'skip-install', value: !!command.skipInstall });
-        options.push({ name: 'strict', value: !!command.strict });
+        options.push({ name: 'dry-run', value: command.dryRun });
+        options.push({ name: 'skip-git', value: command.skipGit });
+        options.push({ name: 'skip-install', value: command.skipInstall });
+        options.push({ name: 'strict', value: command.strict });
         options.push({
           name: 'package-manager',
           value: command.packageManager,
         });
+        options.push({ name: 'collection', value: command.collection });
 
         if (!!command.language) {
           const lowercasedLanguage = command.language.toLowerCase();
@@ -64,11 +68,7 @@ export class NewCommand extends AbstractCommand {
         }
         options.push({
           name: 'language',
-          value: !!command.language ? command.language : 'ts',
-        });
-        options.push({
-          name: 'collection',
-          value: command.collection || Collection.NESTJS,
+          value: command.language,
         });
 
         const inputs: Input[] = [];


### PR DESCRIPTION
Prior to this change option defaults were not visible to a CLI user:

```
Options:
  --directory [directory]                  Specify the destination directory
  -d, --dry-run                            Report actions that would be performed without writing out results.
  -g, --skip-git                           Skip git repository initialization.
  -s, --skip-install                       Skip package installation.
  -p, --package-manager [package-manager]  Specify package manager.
  -l, --language [language]                Programming language to be used (TypeScript or JavaScript).
  -c, --collection [collectionName]        Schematics collection to use.
  --strict                                 Enables strict mode in TypeScript.
  -h, --help                               Output usage information.
```

After this change:

```
Options:
  --directory [directory]                  Specify the destination directory
  -d, --dry-run                            Report actions that would be performed without writing out results. (default: false)
  -g, --skip-git                           Skip git repository initialization. (default: false)
  -s, --skip-install                       Skip package installation. (default: false)
  -p, --package-manager [package-manager]  Specify package manager.
  -l, --language [language]                Programming language to be used (TypeScript or JavaScript) (default: "TypeScript")
  -c, --collection [collectionName]        Schematics collection to use (default: "@nestjs/schematics")
  --strict                                 Enables strict mode in TypeScript. (default: false)
  -h, --help                               Output usage information.
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
