### PR TITLE
feat: pass `compilerOptions.watchOptions` to Typescript compiler

### DIFF
--- a/lib/compiler/watch-compiler.ts
+++ b/lib/compiler/watch-compiler.ts
@@ -42,6 +42,11 @@ export class WatchCompiler {
       tsBin.sys,
       true,
     );
+    const tsWatchOptions = getValueOrDefault<ts.WatchOptions>(
+        configuration,
+        'compilerOptions.watchOptions',
+        appName,
+    );
     const host = tsBin.createWatchCompilerHost(
       configPath,
       tsCompilerOptions,
@@ -49,6 +54,7 @@ export class WatchCompiler {
       createProgram,
       this.createDiagnosticReporter(origDiagnosticReporter),
       this.createWatchStatusChanged(origWatchStatusReporter, onSuccess),
+      tsWatchOptions,
     );
 
     const pluginsConfig = getValueOrDefault(


### PR DESCRIPTION
Typescript watch options are documented here: https://www.typescriptlang.org/tsconfig#watch-options

Watching a large number of files can eat significant CPU, particularly in containerized and emulated environments. This change is designed to give developers several levers to adjust the watch behavior.

Docs will be added in a separate PR if this change is approved.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Watch mode is not configurable.

## What is the new behavior?

Watch mode is configurable via `compilerOptions.watchOptions`, e.g.

```
{
  "collection": "@nestjs/schematics",
  "sourceRoot": "src",
  "compilerOptions": {
    "watchOptions": {
      "fallbackPolling": "dynamicPriority"
    }
  }
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
