### PR TITLE
feat: add options `entryFile` and `sourceRoot` to `start` command

### DIFF
--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -17,6 +17,14 @@ export class StartCommand extends AbstractCommand {
       .option('--webpack', 'Use webpack for compilation.')
       .option('--webpackPath [path]', 'Path to webpack configuration.')
       .option('--tsc', 'Use tsc for compilation.')
+      .option(
+        '--sourceRoot [sourceRoot]',
+        'Points at the root of the source code for the single project in standard mode structures, or the default project in monorepo mode structures.',
+      )
+      .option(
+        '--entryFile [entryFile]',
+        "Path to the entry file where this command will work with. Defaults to the one defined at your Nest's CLI config file.",
+      )
       .option('-e, --exec [binary]', 'Binary to run (default: "node").')
       .option(
         '--preserveWatchOutput',
@@ -47,6 +55,14 @@ export class StartCommand extends AbstractCommand {
         options.push({
           name: 'exec',
           value: command.exec,
+        });
+        options.push({
+          name: 'sourceRoot',
+          value: command.sourceRoot,
+        });
+        options.push({
+          name: 'entryFile',
+          value: command.entryFile,
         });
         options.push({
           name: 'preserveWatchOutput',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`nest start` is locked to `nest-cli.json` 

## What is the new behavior?

two new options

- `nest start --entryFile <path>`
- `nest start --sourceRoot <path>`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

![image](https://user-images.githubusercontent.com/13461315/174926861-7b98dc6d-b8de-4cee-8631-dda1792542f1.png)

