### PR TITLE
feat: tsconfig.json by default if tsconfig.build.json not exist

### DIFF
--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -1,4 +1,5 @@
 import { Configuration } from './configuration';
+import { getDefaultTsconfigPath } from '../utils/get-default-tsconfig-path';
 
 export const defaultConfiguration: Required<Configuration> = {
   language: 'ts',
@@ -8,7 +9,7 @@ export const defaultConfiguration: Required<Configuration> = {
   projects: {},
   monorepo: false,
   compilerOptions: {
-    tsConfigPath: 'tsconfig.build.json',
+    tsConfigPath: getDefaultTsconfigPath(),
     webpack: false,
     webpackConfigPath: 'webpack.config.js',
     plugins: [],

--- a/lib/utils/get-default-tsconfig-path.ts
+++ b/lib/utils/get-default-tsconfig-path.ts
@@ -1,0 +1,11 @@
+import * as fs from 'fs';
+import { join } from 'path';
+
+const TSCONFIG_BUILD_JSON = 'tsconfig.build.json';
+const TSCONFIG_JSON = 'tsconfig.json';
+
+export function getDefaultTsconfigPath() {
+  return fs.existsSync(join(process.cwd(), TSCONFIG_BUILD_JSON))
+    ? TSCONFIG_BUILD_JSON
+    : TSCONFIG_JSON;
+}

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -1,6 +1,7 @@
 import { Configuration, ConfigurationLoader } from '../../../lib/configuration';
 import { NestConfigurationLoader } from '../../../lib/configuration/nest-configuration.loader';
 import { Reader } from '../../../lib/readers';
+import { getDefaultTsconfigPath } from '../../../lib/utils/get-default-tsconfig-path';
 
 describe('Nest Configuration Loader', () => {
   let reader: Reader;
@@ -48,7 +49,7 @@ describe('Nest Configuration Loader', () => {
       compilerOptions: {
         assets: [],
         plugins: [],
-        tsConfigPath: 'tsconfig.build.json',
+        tsConfigPath: getDefaultTsconfigPath(),
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
       },
@@ -71,7 +72,7 @@ describe('Nest Configuration Loader', () => {
       compilerOptions: {
         assets: [],
         plugins: [],
-        tsConfigPath: 'tsconfig.build.json',
+        tsConfigPath: getDefaultTsconfigPath(),
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
       },

--- a/test/lib/utils/get-default-tsconfig-path.spec.ts
+++ b/test/lib/utils/get-default-tsconfig-path.spec.ts
@@ -1,0 +1,24 @@
+import * as fs from 'fs';
+import { getDefaultTsconfigPath } from '../../../lib/utils/get-default-tsconfig-path';
+
+jest.mock('fs', () => {
+  return {
+    existsSync: jest.fn(),
+  };
+});
+
+describe('get default tsconfig path', () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+  it('should get tsconfig.json when tsconfig.build.json not exist', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const result = getDefaultTsconfigPath();
+    expect(result).toBe('tsconfig.json');
+  });
+  it('should get tsconfig.build.json when tsconfig.build.json exist', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const result = getDefaultTsconfigPath();
+    expect(result).toBe('tsconfig.build.json');
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Some simple and small project only use `tsconfig.json` and have no `tsconfig.build.json` on the root of project. It will throw an error if developer execute `nest build` on the root. They have to execute `nest build -p tsconfig.json`, which is not simple and clean. Moreover, some developer who is new to TypeScript only know `tsconfig.json` and don't know what is `tsconfig.build.json`.

## What is the new behavior?

Execute `nest build` will not throw error if there is only `tsconfig.json`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
