### PR TITLE
fix: package name selection for `application` schematics

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -32,7 +32,7 @@ export class NewAction extends AbstractAction {
     const dryRunOption = options.find((option) => option.name === 'dry-run');
     const isDryRunEnabled = dryRunOption && dryRunOption.value;
 
-    await askForMissingInformation(inputs);
+    await askForMissingInformation(inputs, options);
     await generateApplicationFiles(inputs, options).catch(exit);
 
     const shouldSkipInstall = options.some(
@@ -68,6 +68,9 @@ export class NewAction extends AbstractAction {
 const getApplicationNameInput = (inputs: Input[]) =>
   inputs.find((input) => input.name === 'name');
 
+const getPackageManagerInput = (inputs: Input[]) =>
+  inputs.find((options) => options.name === 'packageManager');
+
 const getProjectDirectory = (
   applicationName: Input,
   directoryOption?: Input,
@@ -78,17 +81,24 @@ const getProjectDirectory = (
   );
 };
 
-const askForMissingInformation = async (inputs: Input[]) => {
+const askForMissingInformation = async (inputs: Input[], options: Input[]) => {
   console.info(MESSAGES.PROJECT_INFORMATION_START);
   console.info();
 
   const prompt: inquirer.PromptModule = inquirer.createPromptModule();
+
   const nameInput = getApplicationNameInput(inputs);
   if (!nameInput!.value) {
     const message = 'What name would you like to use for the new project?';
     const questions = [generateInput('name', message)('nest-app')];
     const answers: Answers = await prompt(questions as ReadonlyArray<Question>);
     replaceInputMissingInformation(inputs, answers);
+  }
+
+  const packageManagerInput = getPackageManagerInput(options);
+  if (!packageManagerInput!.value) {
+    const answers = await askForPackageManager();
+    replaceInputMissingInformation(options, answers);
   }
 };
 

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -144,9 +144,7 @@ const installPackages = async (
   dryRunMode: boolean,
   installDirectory: string,
 ) => {
-  const inputPackageManager: string = options.find(
-    (option) => option.name === 'packageManager',
-  )!.value as string;
+  const inputPackageManager = getPackageManagerInput(options)!.value as string;
 
   let packageManager: AbstractPackageManager;
   if (dryRunMode) {
@@ -155,27 +153,14 @@ const installPackages = async (
     console.info();
     return;
   }
-  if (inputPackageManager !== undefined) {
-    try {
-      packageManager = PackageManagerFactory.create(inputPackageManager);
-      await packageManager.install(installDirectory, inputPackageManager);
-    } catch (error) {
-      if (error && error.message) {
-        console.error(chalk.red(error.message));
-      }
+  try {
+    packageManager = PackageManagerFactory.create(inputPackageManager);
+    await packageManager.install(installDirectory, inputPackageManager);
+  } catch (error) {
+    if (error && error.message) {
+      console.error(chalk.red(error.message));
     }
-  } else {
-    packageManager = await selectPackageManager();
-    await packageManager.install(
-      installDirectory,
-      packageManager.name.toLowerCase(),
-    );
   }
-};
-
-const selectPackageManager = async (): Promise<AbstractPackageManager> => {
-  const answers: Answers = await askForPackageManager();
-  return PackageManagerFactory.create(answers['packageManager']);
 };
 
 const askForPackageManager = async (): Promise<Answers> => {

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -120,10 +120,7 @@ const generateApplicationFiles = async (args: Input[], options: Input[]) => {
 const mapSchematicOptions = (options: Input[]): SchematicOption[] => {
   return options.reduce(
     (schematicOptions: SchematicOption[], option: Input) => {
-      if (
-        option.name !== 'skip-install' &&
-        option.value !== 'package-manager'
-      ) {
+      if (option.name !== 'skip-install') {
         schematicOptions.push(new SchematicOption(option.name, option.value));
       }
       return schematicOptions;
@@ -138,7 +135,7 @@ const installPackages = async (
   installDirectory: string,
 ) => {
   const inputPackageManager: string = options.find(
-    (option) => option.name === 'package-manager',
+    (option) => option.name === 'packageManager',
   )!.value as string;
 
   let packageManager: AbstractPackageManager;
@@ -168,12 +165,12 @@ const installPackages = async (
 
 const selectPackageManager = async (): Promise<AbstractPackageManager> => {
   const answers: Answers = await askForPackageManager();
-  return PackageManagerFactory.create(answers['package-manager']);
+  return PackageManagerFactory.create(answers['packageManager']);
 };
 
 const askForPackageManager = async (): Promise<Answers> => {
   const questions: Question[] = [
-    generateSelect('package-manager')(MESSAGES.PACKAGE_MANAGER_QUESTION)([
+    generateSelect('packageManager')(MESSAGES.PACKAGE_MANAGER_QUESTION)([
       PackageManager.NPM,
       PackageManager.YARN,
       PackageManager.PNPM,

--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -18,8 +18,8 @@ export class NewCommand extends AbstractCommand {
       .option('-g, --skip-git', 'Skip git repository initialization.', false)
       .option('-s, --skip-install', 'Skip package installation.', false)
       .option(
-        '-p, --package-manager [package-manager]',
-        'Specify package manager.'
+        '-p, --package-manager [packageManager]',
+        'Specify package manager.',
       )
       .option(
         '-l, --language [language]',
@@ -41,7 +41,7 @@ export class NewCommand extends AbstractCommand {
         options.push({ name: 'skip-install', value: command.skipInstall });
         options.push({ name: 'strict', value: command.strict });
         options.push({
-          name: 'package-manager',
+          name: 'packageManager',
           value: command.packageManager,
         });
         options.push({ name: 'collection', value: command.collection });


### PR DESCRIPTION
(it is #1585 but now I'm trying to participate on Hacktoberfest 2022 haha)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes https://github.com/nestjs/schematics/issues/249 (and closes #500)

<details><summary>demo</summary>

https://user-images.githubusercontent.com/13461315/160044611-3072c698-7ad5-480b-84fb-ec6502fb89f6.mp4

</details>

## What is the new behavior?

The `packageManager` option on `application` schematics is defined by `-p`/`--package-manager` or by the selector prompted to the user. Using `npm` by default, as usual

<details><summary>demo</summary>

https://user-images.githubusercontent.com/13461315/160044632-4a6e6792-444d-48a6-81e4-01a76aad77f0.mp4

</details>

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

I choose to not apply any refactoring to the code (like I did on PR #1457) to make diff cleaner and easy to follow