### PR TITLE
feat(config): allow for flat generate option configuration

### DIFF
--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -32,6 +32,7 @@ interface PluginOptions {
 
 interface GenerateOptions {
   spec?: boolean | Record<string, boolean>;
+  flat?: boolean;
 }
 
 export interface ProjectConfiguration {

--- a/lib/utils/project-utils.ts
+++ b/lib/utils/project-utils.ts
@@ -67,6 +67,27 @@ export function shouldGenerateSpec(
   return specValue;
 }
 
+export function shouldGenerateFlat(
+    configuration: Required<Configuration>,
+    appName: string,
+    flatValue: boolean,
+): boolean {
+  // CLI parameters have the highest priority
+  if (flatValue === true) {
+    return flatValue;
+  }
+
+  const flatConfiguration = getValueOrDefault(
+      configuration,
+      'generateOptions.flat',
+      appName || '',
+  );
+  if (typeof flatConfiguration === 'boolean') {
+    return flatConfiguration;
+  }
+  return flatValue;
+}
+
 export async function askForProjectName(
   promptQuestion: string,
   projects: string[],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
currently a user needs to pass a `--flat` flag every time desired when running a generate command

Issue Number: closes #1518


## What is the new behavior?
allows for `flat` to be set in generateOptions configuration. defaults to `false`

```json
{
  "generateOptions": {
    "flat": true
  }
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information

