### PR TITLE
feat(): support cli hooks

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,4 @@
   "singleQuote": true,
   "trailingComma": "all",
   "quoteProps": "preserve",
-  "endOfLine": "crlf"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,4 +2,5 @@
   "singleQuote": true,
   "trailingComma": "all",
   "quoteProps": "preserve",
+  "endOfLine": "crlf"
 }

--- a/actions/add.action.ts
+++ b/actions/add.action.ts
@@ -3,19 +3,19 @@ import { Input } from '../commands';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
 import {
   AbstractPackageManager,
-  PackageManagerFactory
+  PackageManagerFactory,
 } from '../lib/package-managers';
 import {
   AbstractCollection,
   CollectionFactory,
-  SchematicOption
+  SchematicOption,
 } from '../lib/schematics';
 import { MESSAGES } from '../lib/ui';
 import { loadConfiguration } from '../lib/utils/load-configuration';
 import {
   askForProjectName,
   moveDefaultProjectToStart,
-  shouldAskForProject
+  shouldAskForProject,
 } from '../lib/utils/project-utils';
 import { AbstractAction } from './abstract.action';
 
@@ -44,7 +44,9 @@ export class AddAction extends AbstractAction {
           MESSAGES.LIBRARY_INSTALLATION_FAILED_BAD_PACKAGE(libraryName),
         ),
       );
-      throw new Error(MESSAGES.LIBRARY_INSTALLATION_FAILED_BAD_PACKAGE(libraryName));
+      throw new Error(
+        MESSAGES.LIBRARY_INSTALLATION_FAILED_BAD_PACKAGE(libraryName),
+      );
     }
   }
 

--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -13,13 +13,13 @@ export class NewCommand extends AbstractCommand {
       .option(
         '-d, --dry-run',
         'Report actions that would be performed without writing out results.',
-        false
+        false,
       )
       .option('-g, --skip-git', 'Skip git repository initialization.', false)
       .option('-s, --skip-install', 'Skip package installation.', false)
       .option(
         '-p, --package-manager [package-manager]',
-        'Specify package manager.'
+        'Specify package manager.',
       )
       .option(
         '-l, --language [language]',

--- a/lib/compiler/compiler.ts
+++ b/lib/compiler/compiler.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { Configuration } from '../configuration';
+import { Configuration, HooksOptions } from '../configuration';
 import { getValueOrDefault } from './helpers/get-value-or-default';
 import { TsConfigProvider } from './helpers/tsconfig-provider';
 import { tsconfigPathsBeforeHookFactory } from './hooks/tsconfig-paths.hook';
@@ -17,6 +17,7 @@ export class Compiler {
     configuration: Required<Configuration>,
     configFilename: string,
     appName: string,
+    hooks: HooksOptions,
     onSuccess?: () => void,
   ) {
     const tsBinary = this.typescriptLoader.load();
@@ -28,6 +29,8 @@ export class Compiler {
 
     const { options, fileNames, projectReferences } =
       this.tsConfigProvider.getByConfigFilename(configFilename);
+
+    hooks.beforeCompile.forEach((beforeCompileHook) => beforeCompileHook());
 
     const createProgram =
       tsBinary.createIncrementalProgram || tsBinary.createProgram;
@@ -77,6 +80,8 @@ export class Compiler {
     } else if (!errorsCount && onSuccess) {
       onSuccess();
     }
+
+    hooks.afterCompile.forEach((afterCompileHook) => afterCompileHook());
   }
 
   private reportAfterCompilationDiagnostic(

--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -54,4 +54,10 @@ export interface Configuration {
   projects?: {
     [key: string]: ProjectConfiguration;
   };
+  hooks: string[];
+}
+
+export interface HooksOptions {
+  beforeCompile: (() => any)[];
+  afterCompile: (() => any)[];
 }

--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -16,6 +16,7 @@ export const defaultConfiguration: Required<Configuration> = {
     assets: [],
   },
   generateOptions: {},
+  hooks: [],
 };
 
 export const defaultOutDir = 'dist';

--- a/test/lib/compiler/helpers/get-value-or-default.spec.ts
+++ b/test/lib/compiler/helpers/get-value-or-default.spec.ts
@@ -12,6 +12,7 @@ describe('Get Value or Default', () => {
       collection: '',
       compilerOptions: {},
       generateOptions: {},
+      hooks: [],
     };
     let value = getValueOrDefault(configuration, 'monorepo', '');
     expect(value).toEqual(true);
@@ -25,6 +26,7 @@ describe('Get Value or Default', () => {
       collection: '',
       compilerOptions: {},
       generateOptions: {},
+      hooks: [],
     };
     value = getValueOrDefault(configuration, 'monorepo', '');
     expect(value).toEqual(false);
@@ -49,6 +51,7 @@ describe('Get Value or Default', () => {
       collection: '',
       compilerOptions: {},
       generateOptions: {},
+      hooks: [],
     };
     let value = getValueOrDefault(
       configuration,
@@ -72,6 +75,7 @@ describe('Get Value or Default', () => {
       collection: '',
       compilerOptions: {},
       generateOptions: {},
+      hooks: [],
     };
     value = getValueOrDefault(
       configuration,
@@ -93,6 +97,7 @@ describe('Get Value or Default', () => {
       collection: '',
       compilerOptions: {},
       generateOptions: {},
+      hooks: [],
     };
     value = getValueOrDefault(
       configuration,
@@ -118,6 +123,7 @@ describe('Get Value or Default', () => {
         webpack: true,
       },
       generateOptions: {},
+      hooks: [],
     };
     let value = getValueOrDefault(
       configuration,
@@ -141,6 +147,7 @@ describe('Get Value or Default', () => {
         webpack: false,
       },
       generateOptions: {},
+      hooks: [],
     };
     value = getValueOrDefault(
       configuration,
@@ -162,6 +169,7 @@ describe('Get Value or Default', () => {
       collection: '',
       compilerOptions: {},
       generateOptions: {},
+      hooks: [],
     };
     value = getValueOrDefault(
       configuration,
@@ -190,6 +198,7 @@ describe('Get Value or Default', () => {
         webpack: true,
       },
       generateOptions: {},
+      hooks: [],
     };
     const sourceRoot = getValueOrDefault(
       configuration,

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -53,6 +53,7 @@ describe('Nest Configuration Loader', () => {
         webpackConfigPath: 'webpack.config.js',
       },
       generateOptions: {},
+      hooks: [],
     });
   });
   it('should call reader.read when load with filename', async () => {
@@ -76,6 +77,7 @@ describe('Nest Configuration Loader', () => {
         webpackConfigPath: 'webpack.config.js',
       },
       generateOptions: {},
+      hooks: [],
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1804 


## What is the new behavior?

Compiling hooks ts file before cli compile source code. Then import these files and running them at specific time.

The CLI will read `hooks` field of configuration file to run multiple hooks files.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Only `beforeCompile` and `afterCompile` hooks are supported now. I have no ways to implement `beforeCompileSource` and `afterCompileSource` hooks mentioned at #1804 . Hope anyone could help me on this.
