### PR TITLE
fix: update pnpm install flags

### DIFF
--- a/lib/package-managers/pnpm.package-manager.ts
+++ b/lib/package-managers/pnpm.package-manager.ts
@@ -16,8 +16,8 @@ export class PnpmPackageManager extends AbstractPackageManager {
   // As of PNPM v5.3, all commands are shared with NPM v6.14.5. See: https://pnpm.js.org/en/pnpm-vs-npm
   get cli(): PackageManagerCommands {
     return {
-      install: 'install',
-      add: 'install',
+      install: 'install --strict-peer-dependencies=false',
+      add: 'install --strict-peer-dependencies=false',
       update: 'update',
       remove: 'uninstall',
       saveFlag: '--save',

--- a/test/lib/package-managers/pnpm.package-manager.spec.ts
+++ b/test/lib/package-managers/pnpm.package-manager.spec.ts
@@ -23,8 +23,8 @@ describe('PnpmPackageManager', () => {
   });
   it('should have the correct cli commands', () => {
     const expectedValues: PackageManagerCommands = {
-      install: 'install',
-      add: 'install',
+      install: 'install --strict-peer-dependencies=false',
+      add: 'install --strict-peer-dependencies=false',
       update: 'update',
       remove: 'uninstall',
       saveFlag: '--save',
@@ -39,7 +39,7 @@ describe('PnpmPackageManager', () => {
       const dirName = '/tmp';
       const testDir = join(process.cwd(), dirName);
       packageManager.install(dirName, 'pnpm');
-      expect(spy).toBeCalledWith('install --reporter=silent', true, testDir);
+      expect(spy).toBeCalledWith('install --strict-peer-dependencies=false --reporter=silent', true, testDir);
     });
   });
   describe('addProduction', () => {
@@ -47,7 +47,7 @@ describe('PnpmPackageManager', () => {
       const spy = jest.spyOn((packageManager as any).runner, 'run');
       const dependencies = ['@nestjs/common', '@nestjs/core'];
       const tag = '5.0.0';
-      const command = `install --save ${dependencies
+      const command = `install --strict-peer-dependencies=false --save ${dependencies
         .map((dependency) => `${dependency}@${tag}`)
         .join(' ')}`;
       packageManager.addProduction(dependencies, tag);
@@ -59,7 +59,7 @@ describe('PnpmPackageManager', () => {
       const spy = jest.spyOn((packageManager as any).runner, 'run');
       const dependencies = ['@nestjs/common', '@nestjs/core'];
       const tag = '5.0.0';
-      const command = `install --save-dev ${dependencies
+      const command = `install --strict-peer-dependencies=false --save-dev ${dependencies
         .map((dependency) => `${dependency}@${tag}`)
         .join(' ')}`;
       packageManager.addDevelopment(dependencies, tag);
@@ -91,7 +91,7 @@ describe('PnpmPackageManager', () => {
       const tag = '5.0.0';
       const uninstallCommand = `uninstall --save ${dependencies.join(' ')}`;
 
-      const installCommand = `install --save ${dependencies
+      const installCommand = `install --strict-peer-dependencies=false --save ${dependencies
         .map((dependency) => `${dependency}@${tag}`)
         .join(' ')}`;
 
@@ -110,7 +110,7 @@ describe('PnpmPackageManager', () => {
       const tag = '5.0.0';
       const uninstallCommand = `uninstall --save-dev ${dependencies.join(' ')}`;
 
-      const installCommand = `install --save-dev ${dependencies
+      const installCommand = `install --strict-peer-dependencies=false --save-dev ${dependencies
         .map((dependency) => `${dependency}@${tag}`)
         .join(' ')}`;
 


### PR DESCRIPTION
pnpm v7.0.0 until 7.13.5 uses `--strict-peer-dependencies=true` which causes a failure when not all `peerDependencies` are installed. By setting the flag explicitly, this will no longer be a problem for new users.

fix: #1806

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When a user uses pnpm 7.0.0 to 7.13.5 the install portion of `nest new` fails because of the `strict-peer-dependencies` option being set inherently to `true`, as we do not add every peer dependency to the `package.json`

Issue Number: #1806


## What is the new behavior?

`nest new` will no longer fail for `pnpm` v7.0.0 to 7.13.5. Later versions it should be set to `false` by default anyways


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
