### PR TITLE
feat: Allow passing arguments to nest start <app>

### DIFF
--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -1,4 +1,5 @@
 import { Command, CommanderStatic } from 'commander';
+import { getRemainingFlags } from '../lib/utils/remaining-flags';
 import { AbstractCommand } from './abstract.command';
 import { Input } from './command.input';
 
@@ -74,7 +75,13 @@ export class StartCommand extends AbstractCommand {
 
         const inputs: Input[] = [];
         inputs.push({ name: 'app', value: app });
-        await this.action.handle(inputs, options);
+        const flags = getRemainingFlags(program);
+
+        try {
+          await this.action.handle(inputs, options, flags);
+        } catch (err) {
+          process.exit(1);
+        }
       });
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Before this `start` command was not able to pass additional arguments to `<app>`

Issue Number: #1844


## What is the new behavior?
You can now pass additional arguments to `<app>` after the `--` argument.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
