### PR TITLE
fix: display custom schematics in help

### DIFF
--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -102,7 +102,11 @@ const generateFiles = async (inputs: Input[]) => {
         specValue,
         specOptions.passedAsInput,
       );
-      generateFlat = shouldGenerateFlat(configuration, answers.appNames, flatValue);
+      generateFlat = shouldGenerateFlat(
+        configuration,
+        answers.appNames,
+        flatValue,
+      );
     }
   }
 

--- a/bin/nest.ts
+++ b/bin/nest.ts
@@ -7,7 +7,7 @@ import {
   localBinExists,
 } from '../lib/utils/local-binaries';
 
-const bootstrap = () => {
+const bootstrap = async () => {
   const program: CommanderStatic = commander;
   program
     .version(
@@ -20,11 +20,11 @@ const bootstrap = () => {
 
   if (localBinExists()) {
     const localCommandLoader = loadLocalBinCommandLoader();
-    localCommandLoader.load(program);
+    await localCommandLoader.load(program);
   } else {
-    CommandLoader.load(program);
+    await CommandLoader.load(program);
   }
-  commander.parse(process.argv);
+  commander.parseAsync(process.argv);
 
   if (!process.argv.slice(2).length) {
     program.outputHelp();

--- a/commands/command.loader.ts
+++ b/commands/command.loader.ts
@@ -16,13 +16,13 @@ import { InfoCommand } from './info.command';
 import { NewCommand } from './new.command';
 import { StartCommand } from './start.command';
 export class CommandLoader {
-  public static load(program: CommanderStatic): void {
+  public static async load(program: CommanderStatic): Promise<void> {
     new NewCommand(new NewAction()).load(program);
     new BuildCommand(new BuildAction()).load(program);
     new StartCommand(new StartAction()).load(program);
     new InfoCommand(new InfoAction()).load(program);
     new AddCommand(new AddAction()).load(program);
-    new GenerateCommand(new GenerateAction()).load(program);
+    await new GenerateCommand(new GenerateAction()).load(program);
 
     this.handleInvalidCommand(program);
   }

--- a/lib/schematics/abstract.collection.ts
+++ b/lib/schematics/abstract.collection.ts
@@ -1,7 +1,8 @@
 import { AbstractRunner } from '../runners';
+import { Schematic } from './nest.collection';
 import { SchematicOption } from './schematic.option';
 
-export class AbstractCollection {
+export abstract class AbstractCollection {
   constructor(protected collection: string, protected runner: AbstractRunner) {}
 
   public async execute(
@@ -13,6 +14,8 @@ export class AbstractCollection {
     command = extraFlags ? command.concat(` ${extraFlags}`) : command;
     await this.runner.run(command);
   }
+
+  public abstract getSchematics(): Schematic[];
 
   private buildCommandLine(name: string, options: SchematicOption[]): string {
     return `${this.collection}:${name}${this.buildOptions(options)}`;

--- a/lib/schematics/custom.collection.ts
+++ b/lib/schematics/custom.collection.ts
@@ -12,7 +12,6 @@ export interface CollectionSchematic {
 
 export class CustomCollection extends AbstractCollection {
   public getSchematics(): Schematic[] {
-    this.collection;
     const collectionPackagePath = dirname(require.resolve(this.collection));
     const collectionPath = join(collectionPackagePath, 'collection.json');
     const collection = JSON.parse(readFileSync(collectionPath).toString());

--- a/lib/schematics/custom.collection.ts
+++ b/lib/schematics/custom.collection.ts
@@ -1,3 +1,30 @@
+import { description } from 'commander';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 import { AbstractCollection } from './abstract.collection';
+import { Schematic } from './nest.collection';
 
-export class CustomCollection extends AbstractCollection {}
+export interface CollectionSchematic {
+  factory: string;
+  schema: string;
+  aliases: string[];
+}
+
+export class CustomCollection extends AbstractCollection {
+  public getSchematics(): Schematic[] {
+    this.collection;
+    const collectionPackagePath = dirname(require.resolve(this.collection));
+    const collectionPath = join(collectionPackagePath, 'collection.json');
+    const collection = JSON.parse(readFileSync(collectionPath).toString());
+    const schematics = Object.entries(collection.schematics).map(
+      ([name, value]) => {
+        const schematic = value as CollectionSchematic;
+        const description = schematic.description;
+        const alias = schematic?.aliases?.length ? schematic.aliases[0] : '';
+        return { name, description, alias };
+      },
+    );
+
+    return schematics;
+  }
+}

--- a/lib/schematics/custom.collection.ts
+++ b/lib/schematics/custom.collection.ts
@@ -14,7 +14,7 @@ export class CustomCollection extends AbstractCollection {
   public getSchematics(): Schematic[] {
     const collectionPackagePath = dirname(require.resolve(this.collection));
     const collectionPath = join(collectionPackagePath, 'collection.json');
-    const collection = JSON.parse(readFileSync(collectionPath).toString());
+    const collection = JSON.parse(readFileSync(collectionPath, 'utf8'));
     const schematics = Object.entries(collection.schematics).map(
       ([name, value]) => {
         const schematic = value as CollectionSchematic;

--- a/lib/schematics/custom.collection.ts
+++ b/lib/schematics/custom.collection.ts
@@ -5,8 +5,8 @@ import { AbstractCollection } from './abstract.collection';
 import { Schematic } from './nest.collection';
 
 export interface CollectionSchematic {
-  factory: string;
   schema: string;
+  description: string;
   aliases: string[];
 }
 

--- a/lib/schematics/nest.collection.ts
+++ b/lib/schematics/nest.collection.ts
@@ -121,7 +121,7 @@ export class NestCollection extends AbstractCollection {
     await super.execute(schematic, options);
   }
 
-  public static getSchematics(): Schematic[] {
+  public getSchematics(): Schematic[] {
     return NestCollection.schematics.filter(
       (item) => item.name !== 'angular-app',
     );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Related:
Issue Number: #1433 
PR: #1434 

Currently, when you run `nest generate --help`, it will only display schematics from the `@nestjs/schematics` package. If you have a custom collection configured in `nest-cl.json`, it doesn't display the schematics from your custom package.

Example:

![Screenshot 2023-02-02 at 22 05 56](https://user-images.githubusercontent.com/12231216/216460148-5f4c4232-45ed-44ec-9b06-4ae36c4c6057.png)



## What is the new behavior?
Example:

![Screenshot 2023-02-02 at 20 35 20](https://user-images.githubusercontent.com/12231216/216460184-1fde3ea6-f1db-48c8-aa37-6aa866a77bbd.png)

After this change, you can see which collection is being selected and a table of schematics from that collection

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No **
```

**It changes the commander to load async, and the getSchematics is no longer static, so sort of...

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I have manually tested the local command and the global command, and it seems to work. This change is important to me, as it allows me to easily train my team to use the custom schematics i have made.

 I am on the discord (verbing#6551)
