### PR TITLE
Fix hanging assets watchers

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -129,7 +129,6 @@ export class BuildAction extends AbstractAction {
         appName,
         isDebugEnabled,
         watchMode,
-        this.assetsManager,
         onSuccess,
       );
 

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -122,21 +122,25 @@ export class BuildAction extends AbstractAction {
         webpackPath,
         configuration.compilerOptions!.webpackConfigPath!,
       );
-      this.webpackCompiler.run(
+
+      const onSuccessWrapper = () => {
+        if (onSuccess) {
+          onSuccess();
+        }
+        if (!watchMode) {
+          this.assetsManager.closeWatchers();
+        }
+      }
+
+      return this.webpackCompiler.run(
         configuration,
         webpackConfigFactoryOrConfig,
         pathToTsconfig,
         appName,
         isDebugEnabled,
         watchMode,
-        onSuccess,
+        onSuccessWrapper,
       );
-
-      if (!watchMode) {
-        this.assetsManager.closeWatchers();
-      }
-
-      return;
     }
 
     if (watchMode) {

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -122,7 +122,7 @@ export class BuildAction extends AbstractAction {
         webpackPath,
         configuration.compilerOptions!.webpackConfigPath!,
       );
-      return this.webpackCompiler.run(
+      this.webpackCompiler.run(
         configuration,
         webpackConfigFactoryOrConfig,
         pathToTsconfig,
@@ -132,6 +132,12 @@ export class BuildAction extends AbstractAction {
         this.assetsManager,
         onSuccess,
       );
+
+      if (!watchMode) {
+        this.assetsManager.closeWatchers();
+      }
+
+      return;
     }
 
     if (watchMode) {

--- a/lib/compiler/webpack-compiler.ts
+++ b/lib/compiler/webpack-compiler.ts
@@ -29,7 +29,6 @@ export class WebpackCompiler {
     appName: string,
     isDebugEnabled = false,
     watchMode = false,
-    assetsManager: AssetsManager,
     onSuccess?: () => void,
   ) {
     const cwd = process.cwd();
@@ -130,9 +129,7 @@ export class WebpackCompiler {
         assets: false,
       });
       if (!err && !stats!.hasErrors()) {
-        if (!onSuccess) {
-          assetsManager.closeWatchers();
-        } else {
+        if (onSuccess) {
           onSuccess();
         }
       } else if (!watchMode && !watch) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When starting an unwatched webpack compile on a project with assets (e.g. with `nest start`) the process never exits. `nest build` works as expected.

## What is the new behavior?

It exits as expected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

When starting an app with webpack, the `closeWatchers()` function is not called like it is with the `tsc` compiler. This turned up for me once I switched to a monorepo project, but can be reproduced on a standard project by setting `"webpack": true` in the compiler configuration along with assets.

While digging into this I also noticed a difference in the way that the webpack compiler is called for the "build" vs "start" action. For "start", an `onSuccess` callback is provided (which ultimately starts the application). For "build", no callback is provided. If no callback is provided the `WebpackCompiler` calls `closeWatchers()` on `AssetsManager` (presumably, the code is assuming it's in "build" mode). See #609

The `Compiler` and `WatchCompiler` don't have any references to `AssetsManager`.

This PR removes the functionality from `WebpackCompiler` and centralizes the behavior in the build action.