### PR TITLE
feat: added new generate option to control spec file name

### DIFF
--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -16,6 +16,7 @@ import {
   shouldAskForProject,
   shouldGenerateFlat,
   shouldGenerateSpec,
+  shouldGenerateSpecFileSuffix,
 } from '../lib/utils/project-utils';
 import { AbstractAction } from './abstract.action';
 
@@ -36,6 +37,7 @@ const generateFiles = async (inputs: Input[]) => {
     .value as string;
   const spec = inputs.find((option) => option.name === 'spec');
   const flat = inputs.find((option) => option.name === 'flat');
+  const specFileSuffix = inputs.find((option) => option.name === 'specFileSuffix');
 
   const collection: AbstractCollection = CollectionFactory.create(
     collectionOption || configuration.collection || Collection.NESTJS,
@@ -52,6 +54,7 @@ const generateFiles = async (inputs: Input[]) => {
 
   const specValue = spec!.value as boolean;
   const flatValue = !!flat as boolean;
+  const specFileSuffixValue = specFileSuffix!.value as string;
   const specOptions = spec!.options as any;
   let generateSpec = shouldGenerateSpec(
     configuration,
@@ -61,6 +64,7 @@ const generateFiles = async (inputs: Input[]) => {
     specOptions.passedAsInput,
   );
   let generateFlat = shouldGenerateFlat(configuration, appName, flatValue);
+  let generateSpecFileSuffix = shouldGenerateSpecFileSuffix(configuration, appName, specFileSuffixValue)
 
   // If you only add a `lib` we actually don't have monorepo: true BUT we do have "projects"
   // Ensure we don't run for new app/libs schematics
@@ -107,12 +111,14 @@ const generateFiles = async (inputs: Input[]) => {
         answers.appNames,
         flatValue,
       );
+      generateSpecFileSuffix = shouldGenerateSpecFileSuffix(configuration, appName, specFileSuffixValue)
     }
   }
 
   schematicOptions.push(new SchematicOption('sourceRoot', sourceRoot));
   schematicOptions.push(new SchematicOption('spec', generateSpec));
   schematicOptions.push(new SchematicOption('flat', generateFlat));
+  schematicOptions.push(new SchematicOption('specFileSuffix', generateSpecFileSuffix));
   try {
     const schematicInput = inputs.find((input) => input.name === 'schematic');
     if (!schematicInput) {
@@ -127,7 +133,7 @@ const generateFiles = async (inputs: Input[]) => {
 };
 
 const mapSchematicOptions = (inputs: Input[]): SchematicOption[] => {
-  const excludedInputNames = ['schematic', 'spec', 'flat'];
+  const excludedInputNames = ['schematic', 'spec', 'flat', 'specFileSuffix'];
   const options: SchematicOption[] = [];
   inputs.forEach((input) => {
     if (!excludedInputNames.includes(input.name) && input.value !== undefined) {

--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -16,7 +16,7 @@ import {
   shouldAskForProject,
   shouldGenerateFlat,
   shouldGenerateSpec,
-  shouldGenerateSpecFileSuffix,
+  getSpecFileSuffix,
 } from '../lib/utils/project-utils';
 import { AbstractAction } from './abstract.action';
 
@@ -64,7 +64,7 @@ const generateFiles = async (inputs: Input[]) => {
     specOptions.passedAsInput,
   );
   let generateFlat = shouldGenerateFlat(configuration, appName, flatValue);
-  let generateSpecFileSuffix = shouldGenerateSpecFileSuffix(configuration, appName, specFileSuffixValue)
+  let generateSpecFileSuffix = getSpecFileSuffix(configuration, appName, specFileSuffixValue)
 
   // If you only add a `lib` we actually don't have monorepo: true BUT we do have "projects"
   // Ensure we don't run for new app/libs schematics
@@ -111,7 +111,7 @@ const generateFiles = async (inputs: Input[]) => {
         answers.appNames,
         flatValue,
       );
-      generateSpecFileSuffix = shouldGenerateSpecFileSuffix(configuration, appName, specFileSuffixValue)
+      generateSpecFileSuffix = getSpecFileSuffix(configuration, appName, specFileSuffixValue)
     }
   }
 

--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -36,6 +36,10 @@ export class GenerateCommand extends AbstractCommand {
         },
         true,
       )
+      .option(
+        '--spec-file-suffix [suffix]',
+        'Use a custom suffix for spec files.',
+      )
       .option('--skip-import', 'Skip importing', () => true, false)
       .option('--no-spec', 'Disable spec files generation.', () => {
         return { value: false, passedAsInput: true };
@@ -70,6 +74,10 @@ export class GenerateCommand extends AbstractCommand {
                   ? false
                   : command.spec.passedAsInput,
             },
+          });
+          options.push({
+            name: 'specFileSuffix',
+            value: command.specFileSuffix,
           });
           options.push({
             name: 'collection',

--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -33,6 +33,7 @@ interface PluginOptions {
 interface GenerateOptions {
   spec?: boolean | Record<string, boolean>;
   flat?: boolean;
+  specFileSuffix?: string;
 }
 
 export interface ProjectConfiguration {

--- a/lib/schematics/custom.collection.ts
+++ b/lib/schematics/custom.collection.ts
@@ -1,4 +1,3 @@
-import { description } from 'commander';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { AbstractCollection } from './abstract.collection';

--- a/lib/utils/project-utils.ts
+++ b/lib/utils/project-utils.ts
@@ -89,6 +89,31 @@ export function shouldGenerateFlat(
   return flatValue;
 }
 
+export function shouldGenerateSpecFileSuffix(
+    configuration: Required<Configuration>,
+    appName: string,
+    specFileSuffixValue: string,
+): string {
+  // CLI parameters have the highest priority
+  if (specFileSuffixValue) {
+    return specFileSuffixValue;
+  }
+
+  const specFileSuffixConfiguration = getValueOrDefault(
+      configuration,
+      'generateOptions.specFileSuffix',
+      appName || '',
+      undefined,
+      undefined,
+      'spec',
+  );
+  if (typeof specFileSuffixConfiguration === 'string') {
+    return specFileSuffixConfiguration;
+  }
+  return specFileSuffixValue;
+}
+
+
 export async function askForProjectName(
   promptQuestion: string,
   projects: string[],

--- a/lib/utils/project-utils.ts
+++ b/lib/utils/project-utils.ts
@@ -89,7 +89,7 @@ export function shouldGenerateFlat(
   return flatValue;
 }
 
-export function shouldGenerateSpecFileSuffix(
+export function getSpecFileSuffix(
     configuration: Required<Configuration>,
     appName: string,
     specFileSuffixValue: string,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
currently, a generated spec file always ends with `.spec.ts`

Issue Number: #1683 


## What is the new behavior?
There should be a cli flag and config option to specify the suffix to be used, with the default being spec.

nest g res foo --spec-file-suffix=test
nest-cli.json:

{
	"generateOptions": {
		"spec": true,
		"specFileSuffix": "test"
	}
}

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
