### PR TITLE
fix: remove deprecated decorator passing in tsconfig path hooks

### DIFF
--- a/lib/compiler/hooks/tsconfig-paths.hook.ts
+++ b/lib/compiler/hooks/tsconfig-paths.hook.ts
@@ -55,7 +55,6 @@ export function tsconfigPathsBeforeHookFactory(
                   )
                 : tsBinary.factory.updateImportDeclaration(
                     node,
-                    node.decorators,
                     node.modifiers,
                     node.importClause,
                     moduleSpecifier,
@@ -75,7 +74,6 @@ export function tsconfigPathsBeforeHookFactory(
                   )
                 : tsBinary.factory.updateExportDeclaration(
                     node,
-                    node.decorators,
                     node.modifiers,
                     node.isTypeOnly,
                     node.exportClause,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
nest-cli passes decorators to `updateImportDeclaration` which has been deprecated since typescript v4.8 now that decorators are placed on `modifiers` in the syntax tree.
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#decorators-are-placed-on-modifiers-on-typescripts-syntax-trees

nest-cli fails to build with typescript 5 with errors like https://github.com/nestjs/nest-cli/pull/1986/checks?check_run_id=12600352096
```
> @nestjs/cli@9.3.0 build
> tsc

lib/compiler/hooks/tsconfig-paths.hook.ts:58:26 - error TS2339: Property 'decorators' does not exist on type 'ImportDeclaration'.

58                     node.decorators,
                            ~~~~~~~~~~

lib/compiler/hooks/tsconfig-paths.hook.ts:62:21 - error TS2554: Expected 5 arguments, but got 6.

62                     node.assertClause,
                       ~~~~~~~~~~~~~~~~~

lib/compiler/hooks/tsconfig-paths.hook.ts:78:26 - error TS2339: Property 'decorators' does not exist on type 'ExportDeclaration'.

78                     node.decorators,
                            ~~~~~~~~~~

lib/compiler/hooks/tsconfig-paths.hook.ts:83:21 - error TS2554: Expected 6 arguments, but got 7.

83                     node.assertClause,
                       ~~~~~~~~~~~~~~~~~


Found 4 errors in the same file, starting at: lib/compiler/hooks/tsconfig-paths.hook.ts:58


Exited with code exit status 2
```

Issue Number: N/A


## What is the new behavior?
nest-cli no longer emits deprecation warnings and also now successfully builds with typescript 5

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

Decorators are now placed on `modifiers` on TypeScript's syntax trees.
Passing decorators separately has been deprecated since v4.8 and removed completely in v5.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#decorators-are-placed-on-modifiers-on-typescripts-syntax-trees
https://github.com/microsoft/TypeScript/pull/49089