### PR TITLE
feat: exec in configuration

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -30,9 +30,6 @@ export class StartAction extends BuildAction {
         options,
       );
 
-      const binaryToRunOption = options.find(
-        (option) => option.name === 'exec',
-      );
       const debugModeOption = options.find((option) => option.name === 'debug');
       const watchModeOption = options.find((option) => option.name === 'watch');
       const isWatchEnabled = !!(watchModeOption && watchModeOption.value);
@@ -43,34 +40,34 @@ export class StartAction extends BuildAction {
         watchAssetsModeOption && watchAssetsModeOption.value
       );
       const debugFlag = debugModeOption && debugModeOption.value;
-      const binaryToRun =
-        binaryToRunOption && (binaryToRunOption.value as string | undefined);
+      const binaryToRun = getValueOrDefault(
+        configuration,
+        'exec',
+        appName,
+        'exec',
+        options,
+        defaultConfiguration.exec,
+      );
 
       const { options: tsOptions } =
         this.tsConfigProvider.getByConfigFilename(pathToTsconfig);
       const outDir = tsOptions.outDir || defaultOutDir;
-      const entryFile =
-        (options.find((option) => option.name === 'entryFile')
-          ?.value as string) ||
-        getValueOrDefault(
-          configuration,
-          'entryFile',
-          appName,
-          undefined,
-          undefined,
-          defaultConfiguration.entryFile,
-        );
-      const sourceRoot =
-        (options.find((option) => option.name === 'sourceRoot')
-          ?.value as string) ||
-        getValueOrDefault(
-          configuration,
-          'sourceRoot',
-          appName,
-          undefined,
-          undefined,
-          defaultConfiguration.sourceRoot,
-        );
+      const entryFile = getValueOrDefault(
+        configuration,
+        'entryFile',
+        appName,
+        'entryFile',
+        options,
+        defaultConfiguration.entryFile,
+      );
+      const sourceRoot = getValueOrDefault(
+        configuration,
+        'sourceRoot',
+        appName,
+        'sourceRoot',
+        options,
+        defaultConfiguration.sourceRoot,
+      );
       const onSuccess = this.createOnSuccessHook(
         entryFile,
         sourceRoot,
@@ -101,7 +98,7 @@ export class StartAction extends BuildAction {
     sourceRoot: string,
     debugFlag: boolean | string | undefined,
     outDirName: string,
-    binaryToRun = 'node',
+    binaryToRun: string,
   ) {
     let childProcessRef: any;
     process.on(

--- a/lib/compiler/helpers/get-value-or-default.ts
+++ b/lib/compiler/helpers/get-value-or-default.ts
@@ -5,7 +5,7 @@ export function getValueOrDefault<T = any>(
   configuration: Required<Configuration>,
   propertyPath: string,
   appName: string,
-  key?: 'path' | 'webpack' | 'webpackPath',
+  key?: 'path' | 'webpack' | 'webpackPath' | 'entryFile' | 'sourceRoot' | 'exec',
   options: Input[] = [],
   defaultValue?: T,
 ): T {

--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -39,6 +39,7 @@ export interface ProjectConfiguration {
   type?: string;
   root?: string;
   entryFile?: string;
+  exec?: string;
   sourceRoot?: string;
   compilerOptions?: CompilerOptions;
 }
@@ -49,6 +50,7 @@ export interface Configuration {
   collection?: string;
   sourceRoot?: string;
   entryFile?: string;
+  exec?: string;
   monorepo?: boolean;
   compilerOptions?: CompilerOptions;
   generateOptions?: GenerateOptions;

--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -6,6 +6,7 @@ export const defaultConfiguration: Required<Configuration> = {
   sourceRoot: 'src',
   collection: '@nestjs/schematics',
   entryFile: 'main',
+  exec: 'node',
   projects: {},
   monorepo: false,
   compilerOptions: {

--- a/test/lib/compiler/helpers/get-value-or-default.spec.ts
+++ b/test/lib/compiler/helpers/get-value-or-default.spec.ts
@@ -7,6 +7,7 @@ describe('Get Value or Default', () => {
       monorepo: true,
       sourceRoot: '',
       entryFile: '',
+      exec: '',
       projects: {},
       language: '',
       collection: '',
@@ -20,6 +21,7 @@ describe('Get Value or Default', () => {
       monorepo: false,
       sourceRoot: '',
       entryFile: '',
+      exec: '',
       projects: {},
       language: '',
       collection: '',
@@ -38,6 +40,7 @@ describe('Get Value or Default', () => {
       monorepo: true,
       sourceRoot: '',
       entryFile: '',
+      exec: '',
       projects: {
         'test-project': {
           compilerOptions: {
@@ -61,6 +64,7 @@ describe('Get Value or Default', () => {
       monorepo: true,
       sourceRoot: '',
       entryFile: '',
+      exec: '',
       projects: {
         'test-project': {
           compilerOptions: {
@@ -84,6 +88,7 @@ describe('Get Value or Default', () => {
       monorepo: true,
       sourceRoot: '',
       entryFile: '',
+      exec: '',
       projects: {
         'test-project': {
           compilerOptions: {},
@@ -107,6 +112,7 @@ describe('Get Value or Default', () => {
       monorepo: true,
       sourceRoot: '',
       entryFile: '',
+      exec: '',
       projects: {
         'test-project': {
           compilerOptions: {},
@@ -130,6 +136,7 @@ describe('Get Value or Default', () => {
       monorepo: true,
       sourceRoot: '',
       entryFile: '',
+      exec: '',
       projects: {
         'test-project': {
           compilerOptions: {},
@@ -153,6 +160,7 @@ describe('Get Value or Default', () => {
       monorepo: true,
       sourceRoot: '',
       entryFile: '',
+      exec: '',
       projects: {
         'test-project': {
           compilerOptions: {},
@@ -176,6 +184,7 @@ describe('Get Value or Default', () => {
       monorepo: true,
       sourceRoot: '',
       entryFile: '',
+      exec: '',
       projects: {
         'test.project.v1.api': {
           sourceRoot: 'apps/test.project.v1.api/src',

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -43,6 +43,7 @@ describe('Nest Configuration Loader', () => {
       collection: '@nestjs/schematics',
       sourceRoot: 'src',
       entryFile: 'main',
+      exec: 'node',
       monorepo: false,
       projects: {},
       compilerOptions: {
@@ -66,6 +67,7 @@ describe('Nest Configuration Loader', () => {
       collection: '@nestjs/schematics',
       sourceRoot: 'src',
       entryFile: 'secondary',
+      exec: 'node',
       monorepo: false,
       projects: {},
       compilerOptions: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, I can change the default node process by giving --exec as a start command option.  
However, this can make the npm run command too long in the package.json.


## What is the new behavior?

So I suggest adding the `exec` option can be set also in the nest-cli.json configuration file like this PR changes.  
This can be also helpful for monorepo project if each of the apps that has different execution behavior.

In my case, I use a lot of --exec option in my package.json:  
```
"scripts": {
    "dev": "nest start -e 'node --preserve-symlinks' --watch --preserveWatchOutput",
    "debug": "nest start -e 'node --preserve-symlinks' --debug",
    "export:api": "nest start -e 'node --preserve-symlinks' --entryFile scripts/export-api",
    "console": "IS_CONSOLE=true nest start -e 'node --preserve-symlinks' --entryFile scripts/console",
    ...
}
```
I really want to reduce this just like this.
```
"scripts": {
    "dev": "nest start --watch --preserveWatchOutput",
    "debug": "nest start --debug",
    "export:api": "nest start --entryFile scripts/export-api",
    "console": "IS_CONSOLE=true nest start --entryFile scripts/console",
    ...
}
```
in nest-cli.json:
```
{
  "exec": "node --preserve-symlinks",
   ...
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
