### PR TITLE
perf(lib)!: prioritize 'nest-cli.json' file over all the others name patterns

### DIFF
--- a/lib/configuration/nest-configuration.loader.ts
+++ b/lib/configuration/nest-configuration.loader.ts
@@ -10,9 +10,9 @@ export class NestConfigurationLoader implements ConfigurationLoader {
     const content: string | undefined = name
       ? await this.reader.read(name)
       : await this.reader.readAnyOf([
+          'nest-cli.json',
           '.nestcli.json',
           '.nest-cli.json',
-          'nest-cli.json',
           'nest.json',
         ]);
 

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -29,13 +29,13 @@ describe('Nest Configuration Loader', () => {
     });
     reader = mock();
   });
-  it('should call reader.readAnyOf when load', async () => {
+  it('should call reader.readAnyOf when load taking "nest-cli.json" as preferable', async () => {
     const loader: ConfigurationLoader = new NestConfigurationLoader(reader);
     const configuration: Configuration = await loader.load();
     expect(reader.readAnyOf).toHaveBeenCalledWith([
+      'nest-cli.json',
       '.nestcli.json',
       '.nest-cli.json',
-      'nest-cli.json',
       'nest.json',
     ]);
     expect(configuration).toEqual({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

I believe that the most common name for nestjs CLI config file is `nest-cli.json`. Still, it is the last one being looked up when loading the config file over 3 others patterns.

I can't tell if this is the desired behavior as it is not documented.

## What is the new behavior?

The file `nest-cli.json` is now the first one to be selected among all the others names which are:

- `.nestcli.json`
- `nest-cli.json`
- `nest.json`

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

for instance, people might be using a private/local `.nest-cli.json` (or any other config file) along with `nest-cli.json` (which is public) in their projects for whatever reason. We don't want to break them.

Since this was never documented(?), we could think that this isn't a breaking change as well tho.

