### PR TITLE
fix: load the entry file supplied via command-line option

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -124,6 +124,7 @@ export class BuildAction extends AbstractAction {
       );
       return this.webpackCompiler.run(
         configuration,
+        options,
         webpackConfigFactoryOrConfig,
         pathToTsconfig,
         appName,

--- a/lib/compiler/webpack-compiler.ts
+++ b/lib/compiler/webpack-compiler.ts
@@ -6,6 +6,7 @@ import { AssetsManager } from './assets-manager';
 import { webpackDefaultsFactory } from './defaults/webpack-defaults';
 import { getValueOrDefault } from './helpers/get-value-or-default';
 import { PluginsLoader } from './plugins-loader';
+import { Input } from '../../commands';
 import webpack = require('webpack');
 
 type WebpackConfigFactory = (
@@ -22,6 +23,7 @@ export class WebpackCompiler {
 
   public run(
     configuration: Required<Configuration>,
+    options: Input[],
     webpackConfigFactoryOrConfig:
       | WebpackConfigFactoryOrConfig
       | WebpackConfigFactoryOrConfig[],
@@ -51,6 +53,8 @@ export class WebpackCompiler {
       configuration,
       'sourceRoot',
       appName,
+      'sourceRoot',
+      options,
     );
     const pathToSource =
       normalize(sourceRoot).indexOf(normalize(relativeRootPath)) >= 0
@@ -61,6 +65,8 @@ export class WebpackCompiler {
       configuration,
       'entryFile',
       appName,
+      'entryFile',
+      options,
     );
     const entryFileRoot =
       getValueOrDefault<string>(configuration, 'root', appName) || '';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #2039

## What is the new behavior?

when the `--entryFile` CLI option is supplied, it will be used by webpack compiler

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
