### PR TITLE
feat: allow disabling manual restart for ts watchmode

### DIFF
--- a/lib/compiler/watch-compiler.ts
+++ b/lib/compiler/watch-compiler.ts
@@ -58,9 +58,9 @@ export class WatchCompiler {
       this.createWatchStatusChanged(origWatchStatusReporter, onSuccess),
     );
 
-    const restartable = getValueOrDefault(
+    const manualRestart = getValueOrDefault(
       configuration,
-      'compilerOptions.restartable',
+      'compilerOptions.manualRestart',
       appName,
     );
 
@@ -78,7 +78,7 @@ export class WatchCompiler {
       host: ts.CompilerHost,
       oldProgram: ts.EmitAndSemanticDiagnosticsBuilderProgram,
     ) => {
-      if (restartable) {
+      if (manualRestart) {
         displayManualRestartTip();
       }
 
@@ -136,7 +136,7 @@ export class WatchCompiler {
 
     const watchProgram = tsBin.createWatchProgram(host);
 
-    if (restartable) {
+    if (manualRestart) {
       listenForManualRestart(() => {
         watchProgram.close();
         this.run(

--- a/lib/compiler/watch-compiler.ts
+++ b/lib/compiler/watch-compiler.ts
@@ -58,6 +58,12 @@ export class WatchCompiler {
       this.createWatchStatusChanged(origWatchStatusReporter, onSuccess),
     );
 
+    const restartable = getValueOrDefault(
+      configuration,
+      'compilerOptions.restartable',
+      appName,
+    );
+
     const pluginsConfig = getValueOrDefault(
       configuration,
       'compilerOptions.plugins',
@@ -72,7 +78,9 @@ export class WatchCompiler {
       host: ts.CompilerHost,
       oldProgram: ts.EmitAndSemanticDiagnosticsBuilderProgram,
     ) => {
-      displayManualRestartTip();
+      if (restartable) {
+        displayManualRestartTip();
+      }
 
       const tsconfigPathsPlugin = options
         ? tsconfigPathsBeforeHookFactory(options)
@@ -128,16 +136,18 @@ export class WatchCompiler {
 
     const watchProgram = tsBin.createWatchProgram(host);
 
-    listenForManualRestart(() => {
-      watchProgram.close();
-      this.run(
-        configuration,
-        configFilename,
-        appName,
-        tsCompilerOptions,
-        onSuccess,
-      );
-    });
+    if (restartable) {
+      listenForManualRestart(() => {
+        watchProgram.close();
+        this.run(
+          configuration,
+          configFilename,
+          appName,
+          tsCompilerOptions,
+          onSuccess,
+        );
+      });
+    }
   }
 
   private createDiagnosticReporter(

--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -23,7 +23,7 @@ interface CompilerOptions {
   plugins?: string[] | PluginOptions[];
   assets?: string[];
   deleteOutDir?: boolean;
-  restartable?: boolean;
+  manualRestart?: boolean;
 }
 
 interface PluginOptions {

--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -23,6 +23,7 @@ interface CompilerOptions {
   plugins?: string[] | PluginOptions[];
   assets?: string[];
   deleteOutDir?: boolean;
+  restartable?: boolean;
 }
 
 interface PluginOptions {

--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -15,6 +15,7 @@ export const defaultConfiguration: Required<Configuration> = {
     webpackConfigPath: 'webpack.config.js',
     plugins: [],
     assets: [],
+    restartable: true,
   },
   generateOptions: {},
 };

--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -15,7 +15,7 @@ export const defaultConfiguration: Required<Configuration> = {
     webpackConfigPath: 'webpack.config.js',
     plugins: [],
     assets: [],
-    manualRestart: true,
+    manualRestart: false,
   },
   generateOptions: {},
 };

--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -15,7 +15,7 @@ export const defaultConfiguration: Required<Configuration> = {
     webpackConfigPath: 'webpack.config.js',
     plugins: [],
     assets: [],
-    restartable: true,
+    manualRestart: true,
   },
   generateOptions: {},
 };

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -52,7 +52,7 @@ describe('Nest Configuration Loader', () => {
         tsConfigPath: 'tsconfig.json',
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
-        manualRestart: true,
+        manualRestart: false,
       },
       generateOptions: {},
     });
@@ -77,7 +77,7 @@ describe('Nest Configuration Loader', () => {
         tsConfigPath: 'tsconfig.json',
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
-        manualRestart: true,
+        manualRestart: false,
       },
       generateOptions: {},
     });

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -52,7 +52,7 @@ describe('Nest Configuration Loader', () => {
         tsConfigPath: 'tsconfig.json',
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
-        restartable: true,
+        manualRestart: true,
       },
       generateOptions: {},
     });
@@ -77,7 +77,7 @@ describe('Nest Configuration Loader', () => {
         tsConfigPath: 'tsconfig.json',
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
-        restartable: true,
+        manualRestart: true,
       },
       generateOptions: {},
     });

--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -52,6 +52,7 @@ describe('Nest Configuration Loader', () => {
         tsConfigPath: 'tsconfig.json',
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
+        restartable: true,
       },
       generateOptions: {},
     });
@@ -76,6 +77,7 @@ describe('Nest Configuration Loader', () => {
         tsConfigPath: 'tsconfig.json',
         webpack: false,
         webpackConfigPath: 'webpack.config.js',
+        restartable: true,
       },
       generateOptions: {},
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When running the REPL, the server interferes with the REPL especially when running REPL from within a docker container.

This is implemented in Nodemon: https://github.com/remy/nodemon/blob/main/faq.md#nodemon-doesnt-work-with-my-repl

Issue Number: N/A

## What is the new behavior?

Allow manual restart to be disabled, this will prevent nest from listening to STDIN and allow REPL to take over.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
