### PR TITLE
feat(schematics): list schematics from extended collections

### DIFF
--- a/lib/schematics/custom.collection.ts
+++ b/lib/schematics/custom.collection.ts
@@ -24,7 +24,9 @@ export class CustomCollection extends AbstractCollection {
         if (usedNames.has(name)) continue;
         usedNames.add(name);
         const alias = aliases.find((a) => !usedNames.has(a)) ?? name;
-        for (const alias of aliases) usedNames.add(alias);
+        for (const alias of aliases) {
+           usedNames.add(alias);
+        }
         schematics.push({ name, alias, description });
       }
     }

--- a/lib/schematics/custom.collection.ts
+++ b/lib/schematics/custom.collection.ts
@@ -21,7 +21,9 @@ export class CustomCollection extends AbstractCollection {
     for (const collectionDesc of collectionDescs) {
       const schematicsDescs = Object.entries(collectionDesc.schematics);
       for (const [name, { description, aliases = [] }] of schematicsDescs) {
-        if (usedNames.has(name)) continue;
+        if (usedNames.has(name)) {
+            continue;
+        }
         usedNames.add(name);
         const alias = aliases.find((a) => !usedNames.has(a)) ?? name;
         for (const alias of aliases) {

--- a/test/jest-config.json
+++ b/test/jest-config.json
@@ -5,5 +5,6 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "coverageDirectory": "../coverage"
+  "coverageDirectory": "../coverage",
+  "modulePaths": ["<rootDir>/test/lib/schematics/fixtures"]
 }

--- a/test/lib/schematics/custom.collection.spec.ts
+++ b/test/lib/schematics/custom.collection.spec.ts
@@ -1,0 +1,76 @@
+import { resolve } from 'path';
+import { AbstractRunner } from '../../../lib/runners';
+import { CustomCollection } from '../../../lib/schematics/custom.collection';
+
+describe('Custom Collection', () => {
+  it(`should list schematics from simple collection`, async () => {
+    const mock = jest.fn();
+    mock.mockImplementation(() => {
+      return {
+        logger: {},
+        run: jest.fn().mockImplementation(() => Promise.resolve()),
+      };
+    });
+    const mockedRunner = mock();
+    const collection = new CustomCollection(
+      require.resolve('./fixtures/simple/collection.json'),
+      mockedRunner as AbstractRunner,
+    );
+    const schematics = collection.getSchematics();
+    expect(schematics).toEqual([
+      { name: 'simple1', alias: 's1', description: 'Simple schematic 1' },
+      { name: 'simple2', alias: 's2', description: 'Simple schematic 2' },
+      { name: 'simple3', alias: 's3', description: 'Simple schematic 3' },
+    ]);
+  });
+
+  it(`should list schematics from extended collection`, async () => {
+    const mock = jest.fn();
+    mock.mockImplementation(() => {
+      return {
+        logger: {},
+        run: jest.fn().mockImplementation(() => Promise.resolve()),
+      };
+    });
+    const mockedRunner = mock();
+    const collection = new CustomCollection(
+      require.resolve('./fixtures/extended/collection.json'),
+      mockedRunner as AbstractRunner,
+    );
+    const schematics = collection.getSchematics();
+    expect(schematics).toEqual([
+      { name: 'extend1', alias: 'x1', description: 'Extended schematic 1' },
+      { name: 'extend2', alias: 'x2', description: 'Extended schematic 2' },
+      { name: 'simple1', alias: 's1', description: 'Override schematic 1' },
+      {
+        name: 'simple2',
+        alias: 'os2',
+        description: 'Override schematic 2',
+      },
+      {
+        name: 'simple3',
+        alias: 'simple3',
+        description: 'Simple schematic 3',
+      },
+    ]);
+  });
+
+  it(`should list schematics from package with collection.json path in package.json`, async () => {
+    const mock = jest.fn();
+    mock.mockImplementation(() => {
+      return {
+        logger: {},
+        run: jest.fn().mockImplementation(() => Promise.resolve()),
+      };
+    });
+    const mockedRunner = mock();
+    const collection = new CustomCollection(
+      'package',
+      mockedRunner as AbstractRunner,
+    );
+    const schematics = collection.getSchematics();
+    expect(schematics).toEqual([
+      { name: 'package1', alias: 'pkg1', description: 'Package schematic 1' },
+    ]);
+  });
+});

--- a/test/lib/schematics/fixtures/extended/collection.json
+++ b/test/lib/schematics/fixtures/extended/collection.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "extends": ["../simple/collection.json"],
+  "schematics": {
+    "simple1": {
+      "factory": "factory",
+      "description": "Override schematic 1",
+      "aliases": ["s1", "simp1"]
+    },
+    "simple2": {
+      "factory": "factory",
+      "description": "Override schematic 2",
+      "aliases": ["os2", "s2", "simp2"]
+    },
+    "extend1": {
+      "factory": "factory",
+      "description": "Extended schematic 1",
+      "aliases": ["x1", "ext1"]
+    },
+    "extend2": {
+      "factory": "factory",
+      "description": "Extended schematic 2",
+      "aliases": ["x2", "ext2", "s3", "simp3"]
+    }
+  }
+}

--- a/test/lib/schematics/fixtures/package/a/b/c/collection.json
+++ b/test/lib/schematics/fixtures/package/a/b/c/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../../../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "package1": {
+      "factory": "factory",
+      "description": "Package schematic 1",
+      "aliases": ["pkg1"]
+    }
+  }
+}

--- a/test/lib/schematics/fixtures/package/package.json
+++ b/test/lib/schematics/fixtures/package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package",
+  "version": "0.0.0",
+  "schematics": "./a/b/c/collection.json"
+}

--- a/test/lib/schematics/fixtures/simple/collection.json
+++ b/test/lib/schematics/fixtures/simple/collection.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "simple1": {
+      "factory": "factory",
+      "description": "Simple schematic 1",
+      "aliases": ["s1", "simp1"]
+    },
+    "simple2": {
+      "factory": "factory",
+      "description": "Simple schematic 2",
+      "aliases": ["s2", "simp2"]
+    },
+    "simple3": {
+      "factory": "factory",
+      "description": "Simple schematic 3",
+      "aliases": ["s3", "simp3"]
+    }
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The CLI lists available schematics from custom collections by parsing the `collection.json` file directly. This list does not include schematics that may be available via an `extends` key in the `collection.json`. It also looks for `collection.json` in a fixed location, rather than supporting the `schematics` key of `package.json`.

Issue Number: N/A


## What is the new behavior?

The CLI lists *all* available schematics (with `extends` support) and locates the `collection.json` using the `schematics` key of `package.json`. Additionally, schematic names and aliases are deduped and merged to better reflect the actual configuration that will be used by `@angular-devkit/schematics`: Collections using `extends` can overwrite extended collection schematics and re-map aliases. An alias may also override a schematic name, causing it to be effectively excluded from the collection.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Has allowing multiple schematic aliases in nest-cli been considered? I think it would make it more clear what is going on with how `@angular-devkit/schematics` merges schematic names and aliases. Right now there are hidden aliases defined by the schematics that can be used but not listed by the CLI.
