### PR TITLE
fix(swc): don't set missing class fields

### DIFF
--- a/lib/compiler/defaults/swc-defaults.ts
+++ b/lib/compiler/defaults/swc-defaults.ts
@@ -25,6 +25,7 @@ export const swcDefaultsFactory = (
         transform: {
           legacyDecorator: true,
           decoratorMetadata: true,
+          useDefineForClassFields: false
         },
         keepClassNames: true,
         baseUrl: tsOptions?.baseUrl,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

SWC adopts ESNext behaviour of explicitly setting fields as `undefined` by default. Disabling this behaviour aligns better with TS that targets ES2021.

The result is as following:

```ts
import { plainToInstance } from "class-transformer";

class SomeClass {
  public aNumber: number;
  public aString: string;
}

const partialA = plainToInstance(SomeClass, { aNumber: 1 });
const partialB = plainToInstance(SomeClass, { aString: "abc" });
console.log({ ...partialA, ...partialB });
// Expected: { aNumber: 1, aString: 'abc' }
// Actual:   { aNumber: undefined, aString: 'abc' }
```

Issue Number: N/A


## What is the new behavior?

```ts
console.log({ ...partialA, ...partialB });
// Logs: { aNumber: 1, aString: 'abc' }
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Relates to https://github.com/swc-project/swc/pull/3459

Reproduction repo available https://github.com/tuxmachine/swc-class-transformer
