### PR TITLE
fix getRemainingFlags for arguments with multiple '--' in them

### DIFF
--- a/lib/utils/remaining-flags.ts
+++ b/lib/utils/remaining-flags.ts
@@ -20,7 +20,7 @@ export function getRemainingFlags(cli: CommanderStatic) {
       const prevKeyRaw = array[index - 1];
       if (prevKeyRaw) {
         const previousKey = camelCase(
-          prevKeyRaw.replace('--', '').replace('no', ''),
+          prevKeyRaw.replace(/--/g, '').replace('no', ''),
         );
         if (cli[previousKey] === item) {
           return false;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`nest start --exec "node --experimental-specifier-resolution=node --no-warnings" --debug` fails with `TypeError: Cannot read properties of undefined (reading 'toUpperCase')`, because the `camelCase` function gets `"de experimental-specifier-resolution=node --no-warnings"` as input. splitting `--` will result in an empty string, and `''[0]` is undefined.

## What is the new behavior?

It doesn't break.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Alternatives might be to skip all `item` values that don't start with '--' or that contain spaces or something. But I figured changing it to `/--/g` is the smallest change and has the least chance of breaking stuff that I'm not aware of.

To avoid this error, either remove `--no-warnings` or move `--exec ...` to the end.

Doesn't affect version 9.1.3, affects 9.5.0