### PR TITLE
perf(actions): only load the files of the used compiler on running `build` or `start` commands

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+*.d.ts
 src/**/*.test.ts
 src/**/files/**
 test/**

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -3,17 +3,13 @@ import { join } from 'path';
 import * as ts from 'typescript';
 import { Input } from '../commands';
 import { AssetsManager } from '../lib/compiler/assets-manager';
-import { Compiler } from '../lib/compiler/compiler';
 import { getBuilder } from '../lib/compiler/helpers/get-builder';
 import { getTscConfigPath } from '../lib/compiler/helpers/get-tsc-config.path';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
 import { getWebpackConfigPath } from '../lib/compiler/helpers/get-webpack-config-path';
 import { TsConfigProvider } from '../lib/compiler/helpers/tsconfig-provider';
 import { PluginsLoader } from '../lib/compiler/plugins/plugins-loader';
-import { SwcCompiler } from '../lib/compiler/swc/swc-compiler';
 import { TypeScriptBinaryLoader } from '../lib/compiler/typescript-loader';
-import { WatchCompiler } from '../lib/compiler/watch-compiler';
-import { WebpackCompiler } from '../lib/compiler/webpack-compiler';
 import { WorkspaceUtils } from '../lib/compiler/workspace-utils';
 import {
   Configuration,
@@ -159,6 +155,7 @@ export class BuildAction extends AbstractAction {
     tsOptions: ts.CompilerOptions,
     onSuccess: (() => void) | undefined,
   ) {
+    const { SwcCompiler } = await import('../lib/compiler/swc/swc-compiler');
     const swc = new SwcCompiler(this.pluginsLoader);
     await swc.run(
       configuration,
@@ -180,7 +177,7 @@ export class BuildAction extends AbstractAction {
     );
   }
 
-  private runWebpack(
+  private async runWebpack(
     configuration: Required<Configuration>,
     appName: string,
     commandOptions: Input[],
@@ -189,6 +186,7 @@ export class BuildAction extends AbstractAction {
     watchMode: boolean,
     onSuccess: (() => void) | undefined,
   ) {
+    const { WebpackCompiler } = await import('../lib/compiler/webpack-compiler')
     const webpackCompiler = new WebpackCompiler(this.pluginsLoader);
 
     const webpackPath =
@@ -214,7 +212,7 @@ export class BuildAction extends AbstractAction {
     );
   }
 
-  private runTsc(
+  private async runTsc(
     watchMode: boolean,
     options: Input[],
     configuration: Required<Configuration>,
@@ -223,6 +221,7 @@ export class BuildAction extends AbstractAction {
     onSuccess: (() => void) | undefined,
   ) {
     if (watchMode) {
+      const { WatchCompiler } = await import('../lib/compiler/watch-compiler');
       const watchCompiler = new WatchCompiler(
         this.pluginsLoader,
         this.tsConfigProvider,
@@ -240,6 +239,7 @@ export class BuildAction extends AbstractAction {
         onSuccess,
       );
     } else {
+      const { Compiler } = await import('../lib/compiler/compiler');
       const compiler = new Compiler(
         this.pluginsLoader,
         this.tsConfigProvider,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

since v10, if we use nodejs v14, we run the `build` command because of `path/posix` nodejs package, which is used in the newly added `swc` compiler integration  
Although expected, I found a bit odd that the swc compiler files are loaded even tho we are using `tsc`/`webpack` as they are not supposed to be used together

![image](https://github.com/nestjs/nest-cli/assets/13461315/986bcf3c-5630-43cf-95dd-0a9a3044209e)


## What is the new behavior?

lazily loads few files required for the compiler being used on `build` and `start` commands, which decreases the build time a bit

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
