### PR TITLE
chore: update Node.js minimum version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 16.14"
   },
   "bin": {
     "nest": "bin/nest.js"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```

## What is the current behavior?

This commit addresses a dependency compatibility issue in the `@nestjs/cli` npm module. 
The `engine` field in the `package.json` has been updated to align with the minimum Node.js version requirement ("14 || >=16.14") specified by the `lru-cache` module (version ^9.0.0), an indirect dependency via `path-scurry`.

This change ensures that the `@nestjs/cli`'s Node.js version requirement remains consistent throughout its dependency chain, thereby preventing potential compatibility issues for developers.

BREAKING CHANGE: update package.json engines

Before
```
"engines": {
    "node": ">= 16"
},
```
After
```
"engines": {
    "node": ">= 16.14"
},
```

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

The proposed changes to update the minimum version in the `engine` field of `@nestjs/cli`'s `package.json` file could potentially be a breaking change for developers who are currently using older versions of Node.js which do not meet the minimum version requirement ("14 || >=16.14") specified by `lru-cache`.

These developers will either need to update their Node.js version to continue using `@nestjs/cli` without compatibility issues, or they will have to avoid updating `@nestjs/cli` to the latest version until they can upgrade their Node.js environment.

While this may cause some disruption, the change is necessary to ensure the compatibility of `@nestjs/cli` with all its dependencies, specifically `lru-cache` through `path-scurry`, and to prevent potential issues during installation via `yarn`.

## Other information

In addition, when making modifications to `@nestjs/cli` itself, I've noticed that some modules under `@angular-devkit` as well as the `execa` module point to a Node.js version of '^16.14.0 || >=18.10.0'. 
Therefore, it's crucial to clearly specify the Node.js version requirement in `@nestjs/cli` to prevent compatibility issues and ensure smooth operation across all dependent modules.
