### PR TITLE
feat: add `--preserveWatchOutput` to 'build' command and support using this option from tsconfig file

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -232,12 +232,12 @@ export class BuildAction extends AbstractAction {
       const isPreserveWatchOutputEnabled = options.find(
         (option) =>
           option.name === 'preserveWatchOutput' && option.value === true,
-      );
+      )?.value as boolean | undefined;
       watchCompiler.run(
         configuration,
         pathToTsconfig,
         appName,
-        { preserveWatchOutput: !!isPreserveWatchOutputEnabled },
+        { preserveWatchOutput: isPreserveWatchOutputEnabled },
         onSuccess,
       );
     } else {

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -186,7 +186,9 @@ export class BuildAction extends AbstractAction {
     watchMode: boolean,
     onSuccess: (() => void) | undefined,
   ) {
-    const { WebpackCompiler } = await import('../lib/compiler/webpack-compiler')
+    const { WebpackCompiler } = await import(
+      '../lib/compiler/webpack-compiler'
+    );
     const webpackCompiler = new WebpackCompiler(this.pluginsLoader);
 
     const webpackPath =

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -18,7 +18,11 @@ export class BuildCommand extends AbstractCommand {
       )
       .option('--type-check', 'Enable type checking (when SWC is used).')
       .option('--webpackPath [path]', 'Path to webpack configuration.')
-      .option('--tsc', 'Use tsc for compilation.')
+      .option('--tsc', 'Use typescript compiler for compilation.')
+      .option(
+        '--preserveWatchOutput',
+        'Use "preserveWatchOutput" option when using tsc watch mode.',
+      )
       .description('Build Nest application.')
       .action(async (app: string, command: Command) => {
         const options: Input[] = [];
@@ -65,6 +69,14 @@ export class BuildCommand extends AbstractCommand {
         options.push({
           name: 'typeCheck',
           value: command.typeCheck,
+        });
+
+        options.push({
+          name: 'preserveWatchOutput',
+          value:
+            !!command.preserveWatchOutput &&
+            !!command.watch &&
+            !isWebpackEnabled,
         });
 
         const inputs: Input[] = [];

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -23,7 +23,7 @@ export class StartCommand extends AbstractCommand {
       )
       .option('--webpackPath [path]', 'Path to webpack configuration.')
       .option('--type-check', 'Enable type checking (when SWC is used).')
-      .option('--tsc', 'Use tsc for compilation.')
+      .option('--tsc', 'Use typescript compiler for compilation.')
       .option(
         '--sourceRoot [sourceRoot]',
         'Points at the root of the source code for the single project in standard mode structures, or the default project in monorepo mode structures.',
@@ -35,7 +35,7 @@ export class StartCommand extends AbstractCommand {
       .option('-e, --exec [binary]', 'Binary to run (default: "node").')
       .option(
         '--preserveWatchOutput',
-        'Use "preserveWatchOutput" option when tsc watch mode.',
+        'Use "preserveWatchOutput" option when using tsc watch mode.',
       )
       .description('Run Nest application.')
       .action(async (app: string, command: Command) => {

--- a/lib/compiler/defaults/swc-defaults.ts
+++ b/lib/compiler/defaults/swc-defaults.ts
@@ -25,7 +25,7 @@ export const swcDefaultsFactory = (
         transform: {
           legacyDecorator: true,
           decoratorMetadata: true,
-          useDefineForClassFields: false
+          useDefineForClassFields: false,
         },
         keepClassNames: true,
         baseUrl: tsOptions?.baseUrl,

--- a/lib/compiler/watch-compiler.ts
+++ b/lib/compiler/watch-compiler.ts
@@ -16,7 +16,11 @@ import {
 import { TypeScriptBinaryLoader } from './typescript-loader';
 
 type TypescriptWatchCompilerExtras = {
-  preserveWatchOutput: boolean;
+  /**
+   * If `undefined`, the value of 'preserveWatchOutput' option from tsconfig
+   * file will be used instead.
+   */
+  preserveWatchOutput: boolean | undefined;
 };
 
 export class WatchCompiler extends BaseCompiler<TypescriptWatchCompilerExtras> {
@@ -60,7 +64,8 @@ export class WatchCompiler extends BaseCompiler<TypescriptWatchCompilerExtras> {
       configPath,
       {
         ...options,
-        preserveWatchOutput: extras.preserveWatchOutput,
+        preserveWatchOutput:
+          extras.preserveWatchOutput ?? options.preserveWatchOutput,
       },
       tsBin.sys,
       createProgram,

--- a/lib/runners/abstract.runner.ts
+++ b/lib/runners/abstract.runner.ts
@@ -3,7 +3,10 @@ import { ChildProcess, spawn, SpawnOptions } from 'child_process';
 import { MESSAGES } from '../ui';
 
 export class AbstractRunner {
-  constructor(protected binary: string, protected args: string[] = []) {}
+  constructor(
+    protected binary: string,
+    protected args: string[] = [],
+  ) {}
 
   public async run(
     command: string,

--- a/lib/schematics/abstract.collection.ts
+++ b/lib/schematics/abstract.collection.ts
@@ -3,7 +3,10 @@ import { Schematic } from './nest.collection';
 import { SchematicOption } from './schematic.option';
 
 export abstract class AbstractCollection {
-  constructor(protected collection: string, protected runner: AbstractRunner) {}
+  constructor(
+    protected collection: string,
+    protected runner: AbstractRunner,
+  ) {}
 
   public async execute(
     name: string,

--- a/lib/schematics/schematic.option.ts
+++ b/lib/schematics/schematic.option.ts
@@ -1,7 +1,10 @@
 import { normalizeToKebabOrSnakeCase } from '../utils/formatting';
 
 export class SchematicOption {
-  constructor(private name: string, private value: boolean | string) {}
+  constructor(
+    private name: string,
+    private value: boolean | string,
+  ) {}
 
   get normalizedName() {
     return normalizeToKebabOrSnakeCase(this.name);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #2205


## What is the new behavior?

- feat: support `nest build --watch --preserveWatchOutput`
- fix: use `preserveWatchOutput` option from the tsconfig file loaded by the CLI if the flag `--preserveWatchOutput` was not supplied

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

