### PR TITLE
feat: Add Bun as supported package manager

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -168,6 +168,7 @@ const askForPackageManager = async (): Promise<Answers> => {
       PackageManager.NPM,
       PackageManager.YARN,
       PackageManager.PNPM,
+      PackageManager.BUN,
     ]),
   ];
   const prompt = inquirer.createPromptModule();

--- a/lib/package-managers/bun.package-manager.ts
+++ b/lib/package-managers/bun.package-manager.ts
@@ -1,0 +1,27 @@
+import { Runner, RunnerFactory } from '../runners';
+import { BunRunner } from '../runners/bun.runner';
+import { AbstractPackageManager } from './abstract.package-manager';
+import { PackageManager } from './package-manager';
+import { PackageManagerCommands } from './package-manager-commands';
+
+export class BunPackageManager extends AbstractPackageManager {
+  constructor() {
+    super(RunnerFactory.create(Runner.BUN) as BunRunner);
+  }
+
+  public get name() {
+    return PackageManager.BUN.toUpperCase();
+  }
+
+  get cli(): PackageManagerCommands {
+    return {
+      install: 'install',
+      add: 'add',
+      update: 'install --force',
+      remove: 'remove',
+      saveFlag: '',
+      saveDevFlag: '--development',
+      silentFlag: '--silent',
+    };
+  }
+}

--- a/lib/package-managers/index.ts
+++ b/lib/package-managers/index.ts
@@ -4,5 +4,6 @@ export * from './abstract.package-manager';
 export * from './npm.package-manager';
 export * from './yarn.package-manager';
 export * from './pnpm.package-manager';
+export * from './bun.package-manager';
 export * from './project.dependency';
 export * from './package-manager-commands';

--- a/lib/package-managers/package-manager.factory.ts
+++ b/lib/package-managers/package-manager.factory.ts
@@ -4,6 +4,7 @@ import { NpmPackageManager } from './npm.package-manager';
 import { PackageManager } from './package-manager';
 import { YarnPackageManager } from './yarn.package-manager';
 import { PnpmPackageManager } from './pnpm.package-manager';
+import { BunPackageManager } from './bun.package-manager';
 
 export class PackageManagerFactory {
   public static create(name: PackageManager | string): AbstractPackageManager {
@@ -14,6 +15,8 @@ export class PackageManagerFactory {
         return new YarnPackageManager();
       case PackageManager.PNPM:
         return new PnpmPackageManager();
+      case PackageManager.BUN:
+        return new BunPackageManager();
       default:
         throw new Error(`Package manager ${name} is not managed.`);
     }
@@ -33,6 +36,11 @@ export class PackageManagerFactory {
       const hasPnpmLockFile = files.includes('pnpm-lock.yaml');
       if (hasPnpmLockFile) {
         return this.create(PackageManager.PNPM);
+      }
+
+      const hasBunLockFile = files.includes('bun.lockb');
+      if (hasBunLockFile) {
+        return this.create(PackageManager.BUN);
       }
 
       return this.create(DEFAULT_PACKAGE_MANAGER);

--- a/lib/package-managers/package-manager.ts
+++ b/lib/package-managers/package-manager.ts
@@ -2,4 +2,5 @@ export enum PackageManager {
   NPM = 'npm',
   YARN = 'yarn',
   PNPM = 'pnpm',
+  BUN = 'bun',
 }

--- a/lib/runners/bun.runner.ts
+++ b/lib/runners/bun.runner.ts
@@ -1,0 +1,7 @@
+import { AbstractRunner } from './abstract.runner';
+
+export class BunRunner extends AbstractRunner {
+  constructor() {
+    super('bun');
+  }
+}

--- a/lib/runners/runner.factory.ts
+++ b/lib/runners/runner.factory.ts
@@ -4,6 +4,7 @@ import { Runner } from './runner';
 import { SchematicRunner } from './schematic.runner';
 import { YarnRunner } from './yarn.runner';
 import { PnpmRunner } from './pnpm.runner';
+import { BunRunner } from './bun.runner';
 
 export class RunnerFactory {
   public static create(runner: Runner) {
@@ -19,6 +20,9 @@ export class RunnerFactory {
 
       case Runner.PNPM:
         return new PnpmRunner();
+
+      case Runner.BUN:
+        return new BunRunner();
 
       default:
         console.info(chalk.yellow(`[WARN] Unsupported runner: ${runner}`));

--- a/lib/runners/runner.ts
+++ b/lib/runners/runner.ts
@@ -3,4 +3,5 @@ export enum Runner {
   NPM,
   YARN,
   PNPM,
+  BUN,
 }

--- a/test/lib/package-managers/bun.package-manager.spec.ts
+++ b/test/lib/package-managers/bun.package-manager.spec.ts
@@ -1,0 +1,125 @@
+import { join } from 'path';
+import {
+  PackageManagerCommands,
+  BunPackageManager,
+} from '../../../lib/package-managers';
+import { BunRunner } from '../../../lib/runners/bun.runner';
+
+jest.mock('../../../lib/runners/bun.runner');
+
+describe('BunPackageManager', () => {
+  let packageManager: BunPackageManager;
+  beforeEach(() => {
+    (BunRunner as any).mockClear();
+    (BunRunner as any).mockImplementation(() => {
+      return {
+        run: (): Promise<void> => Promise.resolve(),
+      };
+    });
+    packageManager = new BunPackageManager();
+  });
+  it('should be created', () => {
+    expect(packageManager).toBeInstanceOf(BunPackageManager);
+  });
+  it('should have the correct cli commands', () => {
+    const expectedValues: PackageManagerCommands = {
+      install: 'install',
+      add: 'add',
+      update: 'install --force',
+      remove: 'remove',
+      saveFlag: '',
+      saveDevFlag: '--development',
+      silentFlag: '--silent',
+    };
+    expect(packageManager.cli).toMatchObject(expectedValues);
+  });
+  describe('install', () => {
+    it('should use the proper command for installing', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dirName = '/tmp';
+      const testDir = join(process.cwd(), dirName);
+      packageManager.install(dirName, 'bun');
+      expect(spy).toBeCalledWith('install --silent', true, testDir);
+    });
+  });
+  describe('addProduction', () => {
+    it('should use the proper command for adding production dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = '5.0.0';
+      const command = `add ${dependencies
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
+      packageManager.addProduction(dependencies, tag);
+      expect(spy).toBeCalledWith(command, true);
+    });
+  });
+  describe('addDevelopment', () => {
+    it('should use the proper command for adding development dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = '5.0.0';
+      const command = `add --development ${dependencies
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
+      packageManager.addDevelopment(dependencies, tag);
+      expect(spy).toBeCalledWith(command, true);
+    });
+  });
+  describe('updateProduction', () => {
+    it('should use the proper command for updating production dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const command = `install --force ${dependencies.join(' ')}`;
+      packageManager.updateProduction(dependencies);
+      expect(spy).toBeCalledWith(command, true);
+    });
+  });
+  describe('updateDevelopment', () => {
+    it('should use the proper command for updating development dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const command = `install --force ${dependencies.join(' ')}`;
+      packageManager.updateDevelopment(dependencies);
+      expect(spy).toBeCalledWith(command, true);
+    });
+  });
+  describe('upgradeProduction', () => {
+    it('should use the proper command for upgrading production dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = '5.0.0';
+      const uninstallCommand = `remove ${dependencies.join(' ')}`;
+
+      const installCommand = `add ${dependencies
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
+
+      return packageManager.upgradeProduction(dependencies, tag).then(() => {
+        expect(spy.mock.calls).toEqual([
+          [uninstallCommand, true],
+          [installCommand, true],
+        ]);
+      });
+    });
+  });
+  describe('upgradeDevelopment', () => {
+    it('should use the proper command for upgrading production dependencies', () => {
+      const spy = jest.spyOn((packageManager as any).runner, 'run');
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = '5.0.0';
+      const uninstallCommand = `remove --development ${dependencies.join(' ')}`;
+
+      const installCommand = `add --development ${dependencies
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
+
+      return packageManager.upgradeDevelopment(dependencies, tag).then(() => {
+        expect(spy.mock.calls).toEqual([
+          [uninstallCommand, true],
+          [installCommand, true],
+        ]);
+      });
+    });
+  });
+});

--- a/test/lib/package-managers/package-manager.factory.spec.ts
+++ b/test/lib/package-managers/package-manager.factory.spec.ts
@@ -4,6 +4,7 @@ import {
   PackageManagerFactory,
   PnpmPackageManager,
   YarnPackageManager,
+  BunPackageManager,
 } from '../../../lib/package-managers';
 
 jest.mock('fs', () => ({
@@ -42,6 +43,15 @@ describe('PackageManagerFactory', () => {
       const whenPackageManager = PackageManagerFactory.find();
       await expect(whenPackageManager).resolves.toBeInstanceOf(
         PnpmPackageManager,
+      );
+    });
+
+    it('should return BunPackageManager when "bun.lockb" file is found', async () => {
+      (fs.promises.readdir as jest.Mock).mockResolvedValue(['bun.lockb']);
+
+      const whenPackageManager = PackageManagerFactory.find();
+      await expect(whenPackageManager).resolves.toBeInstanceOf(
+        BunPackageManager,
       );
     });
 


### PR DESCRIPTION
Associated docs PR: https://github.com/nestjs/docs.nestjs.com/pull/2820

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Adds `bun` as supported package manager. [Bun](https://bun.sh) is a toolkit that includes a [runtime-agnostic package manager](https://bun.sh/package-manager) that can be used in Node.js or Bun projects.

## What is the new behavior?
Bun is supported in `nest new --package-manager`. Also the Bun lockfile `bun.lockb` is auto-detected and used to pick the default package manager.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


Below are some successful runs on my local machine.

**CLI flag**

```sh
$ rm bun.lockb
$ node bin/nest.js new mynest --package-manager bun
⚡  We will scaffold your app in a few seconds..

CREATE mynest/.eslintrc.js (663 bytes)
CREATE mynest/.prettierrc (51 bytes)
CREATE mynest/README.md (3340 bytes)
CREATE mynest/nest-cli.json (171 bytes)
CREATE mynest/package.json (1947 bytes)
CREATE mynest/tsconfig.build.json (97 bytes)
CREATE mynest/tsconfig.json (546 bytes)
CREATE mynest/src/app.controller.spec.ts (617 bytes)
CREATE mynest/src/app.controller.ts (274 bytes)
CREATE mynest/src/app.module.ts (249 bytes)
CREATE mynest/src/app.service.ts (142 bytes)
CREATE mynest/src/main.ts (208 bytes)
CREATE mynest/test/app.e2e-spec.ts (630 bytes)
CREATE mynest/test/jest-e2e.json (183 bytes)

✔ Installation in progress... ☕

🚀  Successfully created project mynest
👉  Get started with the following commands:

$ cd mynest
$ bun run start

                                         
                          Thanks for installing Nest 🙏
                 Please consider donating to our open collective
                        to help us maintain this package.
                                         
                                         
               🍷  Donate: https://opencollective.com/nest
                                         
```

Inference based on `bun.lockb`:

```
$ node bin/nest.js new mynest
⚡  We will scaffold your app in a few seconds..

? Which package manager would you ❤️  to use? bun
CREATE mynest/.eslintrc.js (663 bytes)
CREATE mynest/.prettierrc (51 bytes)
CREATE mynest/README.md (3340 bytes)
CREATE mynest/nest-cli.json (171 bytes)
CREATE mynest/package.json (1947 bytes)
CREATE mynest/tsconfig.build.json (97 bytes)
CREATE mynest/tsconfig.json (546 bytes)
CREATE mynest/src/app.controller.spec.ts (617 bytes)
CREATE mynest/src/app.controller.ts (274 bytes)
CREATE mynest/src/app.module.ts (249 bytes)
CREATE mynest/src/app.service.ts (142 bytes)
CREATE mynest/src/main.ts (208 bytes)
CREATE mynest/test/app.e2e-spec.ts (630 bytes)
CREATE mynest/test/jest-e2e.json (183 bytes)

✔ Installation in progress... ☕

🚀  Successfully created project mynest
👉  Get started with the following commands:

$ cd mynest
$ bun run start

                                         
                          Thanks for installing Nest 🙏
                 Please consider donating to our open collective
                        to help us maintain this package.
                                         
                                         
               🍷  Donate: https://opencollective.com/nest
```

