### PR TITLE
fix: Resolve absolute path for `start` action

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -154,6 +154,9 @@ export class StartAction extends BuildAction {
       outputFilePath = join(outDirName, entryFile);
     }
 
+    // resolve to real file path
+    outputFilePath = require.resolve(outputFilePath);
+
     let childProcessArgs: string[] = [];
     const argsStartIndex = process.argv.indexOf('--');
     if (argsStartIndex >= 0) {

--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -154,7 +154,7 @@ export class StartAction extends BuildAction {
       outputFilePath = join(outDirName, entryFile);
     }
 
-    // resolve to real file path
+    // Resolve to real file path
     outputFilePath = require.resolve(outputFilePath);
 
     let childProcessArgs: string[] = [];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `start` command breaks when `nest start` is executed with bun (`bunx nest start`). This is because Node supports running a file w/o an extension (`node /path/to/dist/main`) but Bun requires an extension.
Issue Number: N/A

## What is the new behavior?
Per https://github.com/nestjs/nest-cli/pull/2223

This uses `require.resolve` to resolve the entrypoint to an absolute file path before starting the child process. 

Before: `/Users/colinmcd94/Documents/repos/nest-cli/nest-app/dist/main`
After: `/Users/colinmcd94/Documents/repos/nest-cli/nest-app/dist/main.js`

This will behave identically to before when using Node, and fixes the command for Bun.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information