### PR TITLE
fix(cli): Update start.command.ts to allowUnknownOption

### DIFF
--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -8,6 +8,7 @@ export class StartCommand extends AbstractCommand {
   public load(program: CommanderStatic): void {
     program
       .command('start [app]')
+      .allowUnknownOption()
       .option('-c, --config [path]', 'Path to nest-cli configuration file.')
       .option('-p, --path [path]', 'Path to tsconfig file.')
       .option('-w, --watch', 'Run in watch mode (live-reload).')


### PR DESCRIPTION
Commander requires an explicit call to `allowUnknownOption` to allow and not error on options it does not recognize. This causes an issue with [this functionality](https://github.com/nestjs/nest-cli/pull/1847) because any user-defined flags are blocked at the command level.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) - no because the bug is in the usage of commander
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
This is a proposal for a fix to restore the behavior of forwarding flags on to the `nest start` command. Currently, commander fails any calls with `--xxxx` flags it doesn't recognize, so that functionality doesn't work.

Issue Number: https://github.com/nestjs/nest-cli/issues/1844

## What is the new behavior?
This adds the `allowUnknownOption` behavior so commander will no longer fail calls with `--xxxx` flags it does not recognize.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Refer to initial PR on this work: https://github.com/nestjs/nest-cli/pull/1847