### PR TITLE
fix: Prevent need for double escaping strings

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -160,7 +160,13 @@ export class StartAction extends BuildAction {
     let childProcessArgs: string[] = [];
     const argsStartIndex = process.argv.indexOf('--');
     if (argsStartIndex >= 0) {
-      childProcessArgs = process.argv.slice(argsStartIndex + 1);
+      // Prevents the need for users to double escape strings
+      // i.e. I can run the more natural
+      //   nest start -- '{"foo": "bar"}'
+      // instead of
+      //   nest start -- '\'{"foo": "bar"}\''
+      childProcessArgs = process.argv.slice(argsStartIndex + 1)
+        .map(arg => JSON.stringify(arg));
     }
     outputFilePath =
       outputFilePath.indexOf(' ') >= 0 ? `"${outputFilePath}"` : outputFilePath;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2242 

The spawn command takes an array of strings, which are no longer escaped and passes them through like this:

```
/Users/me/.local/share/nvm/v18.16.1/bin/node /Users/me/app/dist/main.js json-command --json {"foo": "bar"}
```

## What is the new behavior?

All arguments are passed through quoted so the `spawn` command runs this instead:

```
/Users/me/.local/share/nvm/v18.16.1/bin/node /Users/me/app/dist/main.js "json-command" "--json" "{\\"foo\\": \\"bar\\"}"
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[x] Maybe?
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If it's determined that it does, people will just need to replace places where they were doing the double escape (such as `package.json` scripts) and remove the extra escape. For example, change the following:

```
nest start -- json-command --json '\'{"foo": "bar"}\''
```

to

```
nest start -- json-command --json '{"foo": "bar"}'
```

However, since this is basically using a bug as a feature, I'll leave it up to the maintainers to decide if it's actually a breaking change.

## Other information
