### PR TITLE
fix(cli): Resolve `jsc.baseUrl` before calling `@swc/cli`

### DIFF
--- a/test/lib/compiler/swc/swc-compiler.spec.ts
+++ b/test/lib/compiler/swc/swc-compiler.spec.ts
@@ -161,6 +161,7 @@ describe('SWC Compiler', () => {
       });
 
       expect(compiler['runSwc']).toHaveBeenCalledWith(
+        {},
         'swcOptionsTest',
         fixture.extras,
         'swcrcPathTest',
@@ -172,6 +173,7 @@ describe('SWC Compiler', () => {
       });
 
       expect(compiler['runSwc']).toHaveBeenCalledWith(
+        {},
         'swcOptionsTest',
         fixture.extras,
         'swcrcPathTest',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

This is an implicit bugfix.


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`@nest/cli` does not resolve `jsc.baseUrl` even though it reads `jsc.baseUrl` from `.swcrc`.

See https://github.com/swc-project/swc/pull/7827 for the reason that `@swc/core` cannot resolve `jsc.baseUrl` if it's not coming from `.swcrc`

Issue Number: N/A


## What is the new behavior?

It's resolved from the directory of `.swcrc`, if exists, and the project root (I guess?) if not.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information

I'm author of the SWC project