### PR TITLE
perf: cache loaded configuration file

### DIFF
--- a/lib/configuration/nest-configuration.loader.ts
+++ b/lib/configuration/nest-configuration.loader.ts
@@ -3,10 +3,24 @@ import { Configuration } from './configuration';
 import { ConfigurationLoader } from './configuration.loader';
 import { defaultConfiguration } from './defaults';
 
+/**
+ * A cache table that maps some reader (by its name along with the config path)
+ * to a loaded configuration.
+ * This was added because several commands relies on the app's config in order
+ * to generate some dynanmic content prior running the command itself.
+ */
+const loadedConfigsCache = new Map<string, Required<Configuration>>();
+
 export class NestConfigurationLoader implements ConfigurationLoader {
   constructor(private readonly reader: Reader) {}
 
   public async load(name?: string): Promise<Required<Configuration>> {
+    const cacheEntryKey = `${this.reader.constructor.name}:${name}`;
+    const cachedConfig = loadedConfigsCache.get(cacheEntryKey);
+    if (cachedConfig) return cachedConfig;
+
+    let loadedConfig: Required<Configuration> | undefined;
+
     const content: string | undefined = name
       ? await this.reader.read(name)
       : await this.reader.readAnyOf([
@@ -16,23 +30,28 @@ export class NestConfigurationLoader implements ConfigurationLoader {
           'nest.json',
         ]);
 
-    if (!content) {
-      return defaultConfiguration;
+    if (content) {
+      const fileConfig = JSON.parse(content);
+      if (fileConfig.compilerOptions) {
+        loadedConfig = {
+          ...defaultConfiguration,
+          ...fileConfig,
+          compilerOptions: {
+            ...defaultConfiguration.compilerOptions,
+            ...fileConfig.compilerOptions,
+          },
+        };
+      } else {
+        loadedConfig = {
+          ...defaultConfiguration,
+          ...fileConfig,
+        };
+      }
+    } else {
+      loadedConfig = defaultConfiguration;
     }
-    const fileConfig = JSON.parse(content);
-    if (fileConfig.compilerOptions) {
-      return {
-        ...defaultConfiguration,
-        ...fileConfig,
-        compilerOptions: {
-          ...defaultConfiguration.compilerOptions,
-          ...fileConfig.compilerOptions,
-        },
-      };
-    }
-    return {
-      ...defaultConfiguration,
-      ...fileConfig,
-    };
+
+    loadedConfigsCache.set(cacheEntryKey, loadedConfig!);
+    return loadedConfig!;
   }
 }

--- a/lib/configuration/nest-configuration.loader.ts
+++ b/lib/configuration/nest-configuration.loader.ts
@@ -17,7 +17,9 @@ export class NestConfigurationLoader implements ConfigurationLoader {
   public async load(name?: string): Promise<Required<Configuration>> {
     const cacheEntryKey = `${this.reader.constructor.name}:${name}`;
     const cachedConfig = loadedConfigsCache.get(cacheEntryKey);
-    if (cachedConfig) return cachedConfig;
+    if (cachedConfig) {
+       return cachedConfig;
+    }
 
     let loadedConfig: Required<Configuration> | undefined;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #2275 


## What is the new behavior?

now `#load` is being invoked only once instead of twice (`generate.command`, `build.action`) when running `nest build`. And only once instead of three times (`generate.command`, `start.action`, `build.action`) on `nest start`

The downside of this solution is that there's no way to bypass the cache. So a command cannot access a fresh version of the config file unless the CLI process restarts. But AFAIK (and tested) this isn't a feature of the `start --watch`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
