### PR TITLE
#2026 feat: nest build --all flag

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -82,9 +82,9 @@ export class BuildAction extends AbstractAction {
     const buildAll = commandOptions.find((opt) => opt.name === 'all')!
       .value as boolean;
 
-    let appNames: string[];
+    let appNames: (string | undefined)[];
     if (buildAll) {
-      appNames = [undefined!]; // always include the default project
+      appNames = [undefined]; // always include the default project
 
       if (configuration.projects) {
         appNames.push(...Object.keys(configuration.projects));
@@ -175,7 +175,7 @@ export class BuildAction extends AbstractAction {
 
   private async runSwc(
     configuration: Required<Configuration>,
-    appName: string,
+    appName: string | undefined,
     pathToTsconfig: string,
     watchMode: boolean,
     options: Input[],
@@ -212,7 +212,7 @@ export class BuildAction extends AbstractAction {
 
   private async runWebpack(
     configuration: Required<Configuration>,
-    appName: string,
+    appName: string | undefined,
     commandOptions: Input[],
     pathToTsconfig: string,
     debug: boolean,
@@ -258,7 +258,7 @@ export class BuildAction extends AbstractAction {
     options: Input[],
     configuration: Required<Configuration>,
     pathToTsconfig: string,
-    appName: string,
+    appName: string | undefined,
   ) {
     if (watchMode) {
       const { WatchCompiler } = await import('../lib/compiler/watch-compiler');

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -96,6 +96,18 @@ export class BuildAction extends AbstractAction {
     }
 
     for (const appName of appNames) {
+      // if we just always print the project name,
+      // it will change the output compared to previous version,
+      // and some clients may rely on that
+      // TODO: always print in next major version
+      if (appNames.length > 1) {
+        if (appName === undefined) {
+          console.log(`Building default project...`);
+        } else {
+          console.log(`Building project ${appName}`);
+        }
+      }
+
       const pathToTsconfig = getTscConfigPath(
         configuration,
         commandOptions,

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -79,9 +79,21 @@ export class BuildAction extends AbstractAction {
     )!.value as string;
     const configuration = await this.loader.load(configFileName);
 
-    const appNames = commandInputs
-      .filter((input) => input.name === 'app')
-      .map((input) => input.value) as string[];
+    const buildAll = commandOptions.find((opt) => opt.name === 'all')!
+      .value as boolean;
+
+    let appNames: string[];
+    if (buildAll) {
+      appNames = [undefined!]; // always include the default project
+
+      if (configuration.projects) {
+        appNames.push(...Object.keys(configuration.projects));
+      }
+    } else {
+      appNames = commandInputs
+        .filter((input) => input.name === 'app')
+        .map((input) => input.value) as string[];
+    }
 
     for (const appName of appNames) {
       const pathToTsconfig = getTscConfigPath(

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -6,7 +6,7 @@ import { Input } from './command.input';
 export class BuildCommand extends AbstractCommand {
   public load(program: CommanderStatic): void {
     program
-      .command('build [app]')
+      .command('build [apps...]')
       .option('-c, --config [path]', 'Path to nest-cli configuration file.')
       .option('-p, --path [path]', 'Path to tsconfig file.')
       .option('-w, --watch', 'Run in watch mode (live-reload).')
@@ -24,7 +24,7 @@ export class BuildCommand extends AbstractCommand {
         'Use "preserveWatchOutput" option when using tsc watch mode.',
       )
       .description('Build Nest application.')
-      .action(async (app: string, command: Command) => {
+      .action(async (apps: string[], command: Command) => {
         const options: Input[] = [];
 
         options.push({
@@ -79,8 +79,16 @@ export class BuildCommand extends AbstractCommand {
             !isWebpackEnabled,
         });
 
-        const inputs: Input[] = [];
-        inputs.push({ name: 'app', value: app });
+        const inputs: Input[] = apps.map((app) => ({
+          name: 'app',
+          value: app,
+        }));
+
+        // handle the default project for `nest build` with no args
+        if (inputs.length === 0) {
+          inputs.push({ name: 'app', value: undefined! });
+        }
+
         await this.action.handle(inputs, options);
       });
   }

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -23,6 +23,7 @@ export class BuildCommand extends AbstractCommand {
         '--preserveWatchOutput',
         'Use "preserveWatchOutput" option when using tsc watch mode.',
       )
+      .option('--all', 'Build all projects in a monorepo')
       .description('Build Nest application.')
       .action(async (apps: string[], command: Command) => {
         const options: Input[] = [];
@@ -78,6 +79,8 @@ export class BuildCommand extends AbstractCommand {
             !!command.watch &&
             !isWebpackEnabled,
         });
+
+        options.push({ name: 'all', value: !!command.all });
 
         const inputs: Input[] = apps.map((app) => ({
           name: 'app',

--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -39,7 +39,7 @@ export class AssetsManager {
 
   public copyAssets(
     configuration: Required<Configuration>,
-    appName: string,
+    appName: string | undefined,
     outDir: string,
     watchAssetsMode: boolean,
   ) {

--- a/lib/compiler/compiler.ts
+++ b/lib/compiler/compiler.ts
@@ -18,7 +18,7 @@ export class Compiler extends BaseCompiler {
   public run(
     configuration: Required<Configuration>,
     tsConfigPath: string,
-    appName: string,
+    appName: string | undefined,
     _extras: any,
     onSuccess?: () => void,
   ) {

--- a/lib/compiler/helpers/delete-out-dir.ts
+++ b/lib/compiler/helpers/delete-out-dir.ts
@@ -4,7 +4,7 @@ import { getValueOrDefault } from './get-value-or-default';
 
 export async function deleteOutDirIfEnabled(
   configuration: Required<Configuration>,
-  appName: string,
+  appName: string | undefined,
   dirPath: string,
 ) {
   const isDeleteEnabled = getValueOrDefault<boolean>(

--- a/lib/compiler/helpers/get-builder.ts
+++ b/lib/compiler/helpers/get-builder.ts
@@ -12,7 +12,7 @@ import { getValueOrDefault } from './get-value-or-default';
 export function getBuilder(
   configuration: Required<Configuration>,
   cmdOptions: Input[],
-  appName: string,
+  appName: string | undefined,
 ) {
   const builderValue = getValueOrDefault<Builder>(
     configuration,

--- a/lib/compiler/helpers/get-tsc-config.path.ts
+++ b/lib/compiler/helpers/get-tsc-config.path.ts
@@ -13,7 +13,7 @@ import { getValueOrDefault } from './get-value-or-default';
 export function getTscConfigPath(
   configuration: Required<Configuration>,
   cmdOptions: Input[],
-  appName: string,
+  appName: string | undefined,
 ) {
   let tsconfigPath = getValueOrDefault<string | undefined>(
     configuration,

--- a/lib/compiler/helpers/get-webpack-config-path.ts
+++ b/lib/compiler/helpers/get-webpack-config-path.ts
@@ -12,7 +12,7 @@ import { getValueOrDefault } from './get-value-or-default';
 export function getWebpackConfigPath(
   configuration: Required<Configuration>,
   cmdOptions: Input[],
-  appName: string,
+  appName: string | undefined,
 ) {
   let webpackPath = getValueOrDefault<string | undefined>(
     configuration,

--- a/lib/compiler/swc/swc-compiler.ts
+++ b/lib/compiler/swc/swc-compiler.ts
@@ -39,7 +39,7 @@ export class SwcCompiler extends BaseCompiler {
   public async run(
     configuration: Required<Configuration>,
     tsConfigPath: string,
-    appName: string,
+    appName: string | undefined,
     extras: SwcCompilerExtras,
     onSuccess?: () => void,
   ) {
@@ -79,13 +79,13 @@ export class SwcCompiler extends BaseCompiler {
   private runTypeChecker(
     configuration: Required<Configuration>,
     tsConfigPath: string,
-    appName: string,
+    appName: string | undefined,
     extras: SwcCompilerExtras,
   ) {
     if (extras.watch) {
       const args = [
         tsConfigPath,
-        appName,
+        appName ?? 'undefined',
         configuration.sourceRoot ?? 'src',
         JSON.stringify(configuration.compilerOptions.plugins ?? []),
       ];

--- a/lib/compiler/watch-compiler.ts
+++ b/lib/compiler/watch-compiler.ts
@@ -35,7 +35,7 @@ export class WatchCompiler extends BaseCompiler<TypescriptWatchCompilerExtras> {
   public run(
     configuration: Required<Configuration>,
     tsConfigPath: string,
-    appName: string,
+    appName: string | undefined,
     extras: TypescriptWatchCompilerExtras,
     onSuccess?: () => void,
   ) {

--- a/lib/compiler/webpack-compiler.ts
+++ b/lib/compiler/webpack-compiler.ts
@@ -37,7 +37,7 @@ export class WebpackCompiler extends BaseCompiler<WebpackCompilerExtras> {
   public run(
     configuration: Required<Configuration>,
     tsConfigPath: string,
-    appName: string,
+    appName: string | undefined,
     extras: WebpackCompilerExtras,
     onSuccess?: () => void,
   ) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

(checking the tests box since I don't see a way to add "high-level" tests for an `Action`, only for stuff in `/lib`)

(docs == `commander` option descriptions)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2026


## What is the new behavior?

- added an `--all` flag to `nest build` to build all projects in a monorepo
- as a bonus: added an ability to specify several projects as `nest build` args (the `--all` flag was easier to implement this way :)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
