### PR TITLE
chore: upgrade to fork-ts-checker-webpack-plugin v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "chokidar": "3.5.3",
         "cli-table3": "0.6.3",
         "commander": "4.1.1",
-        "fork-ts-checker-webpack-plugin": "8.0.0",
+        "fork-ts-checker-webpack-plugin": "9.0.0",
         "inquirer": "8.2.6",
         "node-emoji": "1.11.0",
         "ora": "5.4.1",
@@ -8590,9 +8590,9 @@
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz",
-      "integrity": "sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-9.0.0.tgz",
+      "integrity": "sha512-Kw3JjsfGs0piB0V2Em8gCuo51O3p4KyCOK0Tn8X57oq2mSNBrMmONALRBw5frcmWsOVU7iELXXsJ+FVxJeQuhA==",
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
         "chalk": "^4.1.2",
@@ -25113,9 +25113,9 @@
       }
     },
     "fork-ts-checker-webpack-plugin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-8.0.0.tgz",
-      "integrity": "sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-9.0.0.tgz",
+      "integrity": "sha512-Kw3JjsfGs0piB0V2Em8gCuo51O3p4KyCOK0Tn8X57oq2mSNBrMmONALRBw5frcmWsOVU7iELXXsJ+FVxJeQuhA==",
       "requires": {
         "@babel/code-frame": "^7.16.7",
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chokidar": "3.5.3",
     "cli-table3": "0.6.3",
     "commander": "4.1.1",
-    "fork-ts-checker-webpack-plugin": "8.0.0",
+    "fork-ts-checker-webpack-plugin": "9.0.0",
     "inquirer": "8.2.6",
     "node-emoji": "1.11.0",
     "ora": "5.4.1",


### PR DESCRIPTION
This version drops support for node v12, paving the way for future upgrades that can remove it's dependency on vulnerable `yaml` package versions. See https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/pull/818#issuecomment-1710157139

Since there are no functional changes and `@nestjs/cli` itself only supports engine version >= 16, this update should not cause any issues.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

