### PR TITLE
feat: add warning message for the info command

### DIFF
--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -26,6 +26,13 @@ export const MESSAGES = {
     `${EMOJIS.SCREAM}  Packages installation failed!\nIn case you don't see any errors above, consider manually running the failed command ${commandToRunManually} to see more details on why it errored out.`,
   // tslint:disable-next-line:max-line-length
   NEST_INFORMATION_PACKAGE_MANAGER_FAILED: `${EMOJIS.SMIRK}  cannot read your project package.json file, are you inside your project directory?`,
+  NEST_INFORMATION_PACKAGE_WARNING_FAILED: (nestDependencies: string[]) =>
+    `${
+      EMOJIS.SMIRK
+    }  failed to compare dependencies versions, please check that following packages are in the same minor version : \n ${nestDependencies.join(
+      '\n',
+    )}`,
+
   LIBRARY_INSTALLATION_FAILED_BAD_PACKAGE: (name: string) =>
     `Unable to install library ${name} because package did not install. Please check package name.`,
   LIBRARY_INSTALLATION_FAILED_NO_LIBRARY: 'No library found.',

--- a/test/actions/info.action.spec.ts
+++ b/test/actions/info.action.spec.ts
@@ -23,63 +23,163 @@ describe('InfoAction', () => {
   describe('buildNestVersionsWarningMessage', () => {
     it('should return an empty object for one or zero minor versions', () => {
       const dependencies = [
-        { fullName: '@nestjs/core', name: 'core', value: '1.2.3' },
-        { fullName: '@nestjs/common', name: 'common', value: '1.2.4' },
+        { packageName: '@nestjs/core', name: 'core', value: '1.2.3' },
+        { packageName: '@nestjs/common', name: 'common', value: '1.2.4' },
       ];
       const result = infoAction.buildNestVersionsWarningMessage(dependencies);
       expect(result).toEqual({});
-
     });
 
     it('should return an object only with whitelisted dependencies', () => {
       const dependencies = [
-        { fullName: '@nestjs/core', name: 'core', value: '1.2.3' },
-        { fullName: '@nestjs/common', name: 'common', value: '1.2.4' },
-        { fullName: '@nestjs/schematics', name: 'schematics', value: '1.2.4' },
-        { fullName: '@nestjs/platform-express', name: 'platform-express', value: '1.2.4' },
-        { fullName: '@nestjs/platform-fastify', name: 'platform-fastify', value: '1.2.4' },
-        { fullName: '@nestjs/platform-socket.io', name: 'platform-socket.io', value: '1.2.4' },
-        { fullName: '@nestjs/platform-ws', name: 'platform-ws', value: '2.1.0' },
-        { fullName: '@nestjs/websockets', name: 'websockets', value: '2.1.0' },
-        { fullName: '@nestjs/test1', name: 'test1', value: '1.2.4' },
-        { fullName: '@nestjs/test2', name: 'test2', value: '1.2.4' },
+        { packageName: '@nestjs/core', name: 'core', value: '1.2.3' },
+        { packageName: '@nestjs/common', name: 'common', value: '1.2.4' },
+        {
+          packageName: '@nestjs/schematics',
+          name: 'schematics',
+          value: '1.2.4',
+        },
+        {
+          packageName: '@nestjs/platform-express',
+          name: 'platform-express',
+          value: '1.2.4',
+        },
+        {
+          packageName: '@nestjs/platform-fastify',
+          name: 'platform-fastify',
+          value: '1.2.4',
+        },
+        {
+          packageName: '@nestjs/platform-socket.io',
+          name: 'platform-socket.io',
+          value: '1.2.4',
+        },
+        {
+          packageName: '@nestjs/platform-ws',
+          name: 'platform-ws',
+          value: '2.1.0',
+        },
+        {
+          packageName: '@nestjs/websockets',
+          name: 'websockets',
+          value: '2.1.0',
+        },
+        { packageName: '@nestjs/test1', name: 'test1', value: '1.2.4' },
+        { packageName: '@nestjs/test2', name: 'test2', value: '1.2.4' },
       ];
       const result = infoAction.buildNestVersionsWarningMessage(dependencies);
       const expected = {
         '1.2': [
-          { fullName: '@nestjs/core', name: 'core', value: '1.2.3' },
-          { fullName: '@nestjs/common', name: 'common', value: '1.2.4' },
-          { fullName: '@nestjs/schematics', name: 'schematics', value: '1.2.4' },
-          { fullName: '@nestjs/platform-express', name: 'platform-express', value: '1.2.4' },
-          { fullName: '@nestjs/platform-fastify', name: 'platform-fastify', value: '1.2.4' },
-          { fullName: '@nestjs/platform-socket.io', name: 'platform-socket.io', value: '1.2.4' },
+          { packageName: '@nestjs/core', name: 'core', value: '1.2.3' },
+          { packageName: '@nestjs/common', name: 'common', value: '1.2.4' },
+          {
+            packageName: '@nestjs/schematics',
+            name: 'schematics',
+            value: '1.2.4',
+          },
+          {
+            packageName: '@nestjs/platform-express',
+            name: 'platform-express',
+            value: '1.2.4',
+          },
+          {
+            packageName: '@nestjs/platform-fastify',
+            name: 'platform-fastify',
+            value: '1.2.4',
+          },
+          {
+            packageName: '@nestjs/platform-socket.io',
+            name: 'platform-socket.io',
+            value: '1.2.4',
+          },
         ],
-        '2.1':[
-          { fullName: '@nestjs/platform-ws', name: 'platform-ws', value: '2.1.0' },
-          { fullName: '@nestjs/websockets', name: 'websockets', value: '2.1.0' },
+        '2.1': [
+          {
+            packageName: '@nestjs/platform-ws',
+            name: 'platform-ws',
+            value: '2.1.0',
+          },
+          {
+            packageName: '@nestjs/websockets',
+            name: 'websockets',
+            value: '2.1.0',
+          },
         ],
       };
       expect(result).toEqual(expected);
-
     });
 
     it('should group dependencies by minor versions and sort them in descending order', () => {
       const dependencies = [
-        { name: 'schematics', fullName: '@nestjs/schematics', value: '1.2.3' },
-        { name: 'platform-express', fullName: '@nestjs/platform-express', value: '1.2.4' },
-        { name: 'platform-fastify', fullName: '@nestjs/platform-fastify', value: '2.1.0' },
-        { name: 'platform-socket.io', fullName: '@nestjs/platform-socket.io', value: '2.0.1' },
+        {
+          name: 'schematics',
+          packageName: '@nestjs/schematics',
+          value: '1.2.3',
+        },
+        {
+          name: 'platform-express',
+          packageName: '@nestjs/platform-express',
+          value: '1.2.4',
+        },
+        {
+          name: 'platform-fastify',
+          packageName: '@nestjs/platform-fastify',
+          value: '2.1.0',
+        },
+        {
+          packageName: '@nestjs/platform-socket.io',
+          name: 'platform-socket.io',
+          value: '1.2$$.4',
+        },
+        {
+          name: 'platform-socket.io',
+          packageName: '@nestjs/platform-socket.io',
+          value: '2.0.1',
+        },
+        {
+          packageName: '@nestjs/websockets',
+          name: 'websockets',
+          value: '^2.*&1.0',
+        },
       ];
 
       const result = infoAction.buildNestVersionsWarningMessage(dependencies);
       const expected = {
-        '2.1': [{ name: 'platform-fastify', fullName: '@nestjs/platform-fastify', value: '2.1.0' }],
+        '2.1': [
+          {
+            name: 'platform-fastify',
+            packageName: '@nestjs/platform-fastify',
+            value: '2.1.0',
+          },
+          {
+            packageName: '@nestjs/websockets',
+            name: 'websockets',
+            value: '^2.*&1.0',
+          },
+        ],
         '2.0': [
-          { name: 'platform-socket.io', fullName: '@nestjs/platform-socket.io', value: '2.0.1' },
+          {
+            name: 'platform-socket.io',
+            packageName: '@nestjs/platform-socket.io',
+            value: '2.0.1',
+          },
         ],
         '1.2': [
-          { name: 'schematics', fullName: '@nestjs/schematics', value: '1.2.3' },
-          { name: 'platform-express', fullName: '@nestjs/platform-express', value: '1.2.4' },
+          {
+            name: 'schematics',
+            packageName: '@nestjs/schematics',
+            value: '1.2.3',
+          },
+          {
+            name: 'platform-express',
+            packageName: '@nestjs/platform-express',
+            value: '1.2.4',
+          },
+          {
+            packageName: '@nestjs/platform-socket.io',
+            name: 'platform-socket.io',
+            value: '1.2$$.4',
+          },
         ],
       };
 
@@ -87,4 +187,3 @@ describe('InfoAction', () => {
     });
   });
 });
-

--- a/test/actions/info.action.spec.ts
+++ b/test/actions/info.action.spec.ts
@@ -1,0 +1,90 @@
+import { InfoAction } from '../../actions/info.action';
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(() => '{"version": "1.2.3"}'),
+}));
+
+jest.mock('../../lib/package-managers', () => ({
+  PackageManagerFactory: {
+    find: jest.fn(() => ({
+      name: 'MockedPackageManager',
+      version: jest.fn(() => '1.0.0'),
+    })),
+  },
+}));
+
+describe('InfoAction', () => {
+  let infoAction: InfoAction;
+
+  beforeEach(() => {
+    infoAction = new InfoAction();
+  });
+
+  describe('buildNestVersionsWarningMessage', () => {
+    it('should return an empty object for one or zero minor versions', () => {
+      const dependencies = [
+        { fullName: '@nestjs/core', name: 'core', value: '1.2.3' },
+        { fullName: '@nestjs/common', name: 'common', value: '1.2.4' },
+      ];
+      const result = infoAction.buildNestVersionsWarningMessage(dependencies);
+      expect(result).toEqual({});
+
+    });
+
+    it('should return an object only with whitelisted dependencies', () => {
+      const dependencies = [
+        { fullName: '@nestjs/core', name: 'core', value: '1.2.3' },
+        { fullName: '@nestjs/common', name: 'common', value: '1.2.4' },
+        { fullName: '@nestjs/schematics', name: 'schematics', value: '1.2.4' },
+        { fullName: '@nestjs/platform-express', name: 'platform-express', value: '1.2.4' },
+        { fullName: '@nestjs/platform-fastify', name: 'platform-fastify', value: '1.2.4' },
+        { fullName: '@nestjs/platform-socket.io', name: 'platform-socket.io', value: '1.2.4' },
+        { fullName: '@nestjs/platform-ws', name: 'platform-ws', value: '2.1.0' },
+        { fullName: '@nestjs/websockets', name: 'websockets', value: '2.1.0' },
+        { fullName: '@nestjs/test1', name: 'test1', value: '1.2.4' },
+        { fullName: '@nestjs/test2', name: 'test2', value: '1.2.4' },
+      ];
+      const result = infoAction.buildNestVersionsWarningMessage(dependencies);
+      const expected = {
+        '1.2': [
+          { fullName: '@nestjs/core', name: 'core', value: '1.2.3' },
+          { fullName: '@nestjs/common', name: 'common', value: '1.2.4' },
+          { fullName: '@nestjs/schematics', name: 'schematics', value: '1.2.4' },
+          { fullName: '@nestjs/platform-express', name: 'platform-express', value: '1.2.4' },
+          { fullName: '@nestjs/platform-fastify', name: 'platform-fastify', value: '1.2.4' },
+          { fullName: '@nestjs/platform-socket.io', name: 'platform-socket.io', value: '1.2.4' },
+        ],
+        '2.1':[
+          { fullName: '@nestjs/platform-ws', name: 'platform-ws', value: '2.1.0' },
+          { fullName: '@nestjs/websockets', name: 'websockets', value: '2.1.0' },
+        ],
+      };
+      expect(result).toEqual(expected);
+
+    });
+
+    it('should group dependencies by minor versions and sort them in descending order', () => {
+      const dependencies = [
+        { name: 'schematics', fullName: '@nestjs/schematics', value: '1.2.3' },
+        { name: 'platform-express', fullName: '@nestjs/platform-express', value: '1.2.4' },
+        { name: 'platform-fastify', fullName: '@nestjs/platform-fastify', value: '2.1.0' },
+        { name: 'platform-socket.io', fullName: '@nestjs/platform-socket.io', value: '2.0.1' },
+      ];
+
+      const result = infoAction.buildNestVersionsWarningMessage(dependencies);
+      const expected = {
+        '2.1': [{ name: 'platform-fastify', fullName: '@nestjs/platform-fastify', value: '2.1.0' }],
+        '2.0': [
+          { name: 'platform-socket.io', fullName: '@nestjs/platform-socket.io', value: '2.0.1' },
+        ],
+        '1.2': [
+          { name: 'schematics', fullName: '@nestjs/schematics', value: '1.2.3' },
+          { name: 'platform-express', fullName: '@nestjs/platform-express', value: '1.2.4' },
+        ],
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});
+


### PR DESCRIPTION
  More details here: https://github.com/nestjs/nest-cli/issues/1929

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
There is no warnin message if deveopers use different version of the nest-js package in a projet

Issue Number: https://github.com/nestjs/nest-cli/issues/1929


## What is the new behavior?

Developer now gets a warning message folowing the suggestion => https://github.com/nestjs/nest-cli/issues/1929

<img width="668" alt="Capture d’écran, le 2023-11-22 à 09 38 28" src="https://github.com/nestjs/nest-cli/assets/3729979/3afbb8ac-fad7-4ca0-9f1c-8d4a62385786">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
