### PR TITLE
feat(@nestjs/cli): add command to remove non-root project in monorepo

### DIFF
--- a/actions/index.ts
+++ b/actions/index.ts
@@ -5,3 +5,4 @@ export * from './info.action';
 export * from './new.action';
 export * from './start.action';
 export * from './add.action';
+export * from './remove.action';

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -20,8 +20,8 @@ import {
   SchematicOption,
 } from '../lib/schematics';
 import { EMOJIS, MESSAGES } from '../lib/ui';
-import { normalizeToKebabOrSnakeCase } from '../lib/utils/formatting';
 import { AbstractAction } from './abstract.action';
+import { getProjectDirectory } from '../lib/utils/project-utils';
 
 export class NewAction extends AbstractAction {
   public async handle(inputs: Input[], options: Input[]) {
@@ -69,16 +69,6 @@ const getApplicationNameInput = (inputs: Input[]) =>
 
 const getPackageManagerInput = (inputs: Input[]) =>
   inputs.find((options) => options.name === 'packageManager');
-
-const getProjectDirectory = (
-  applicationName: Input,
-  directoryOption?: Input,
-): string => {
-  return (
-    (directoryOption && (directoryOption.value as string)) ||
-    normalizeToKebabOrSnakeCase(applicationName.value as string)
-  );
-};
 
 const askForMissingInformation = async (inputs: Input[], options: Input[]) => {
   console.info(MESSAGES.PROJECT_INFORMATION_START);

--- a/actions/remove.action.ts
+++ b/actions/remove.action.ts
@@ -1,0 +1,124 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as chalk from 'chalk';
+import { AbstractAction } from '.';
+import { Input } from '../commands';
+import * as inquirer from 'inquirer';
+import { Question } from 'inquirer';
+import { generateSelect } from '../lib/questions/questions';
+import { CLI_ERRORS, MESSAGES } from '../lib/ui';
+import { getProjectDirectory } from '../lib/utils/project-utils';
+
+export class RemoveAction extends AbstractAction {
+  public async handle(inputs: Input[]) {
+    const projectNameInput = inputs.find((input) => input.name === 'name')!;
+    const projectDirectory = getProjectDirectory(projectNameInput);
+
+    if (!fs.existsSync(path.join(process.cwd(), 'apps', projectDirectory))) {
+      console.error(chalk.red(CLI_ERRORS.PROJECT_NOT_FOUND(projectDirectory)));
+      process.exit(1);
+    }
+
+    const confirmed = await askForConfirmation();
+
+    if (!confirmed) {
+      console.log(chalk.yellow(CLI_ERRORS.ACTION_CANCELLED));
+      process.exit(0);
+    }
+
+    if (check(projectDirectory)) {
+      try {
+        await removeProject(projectDirectory);
+        updateNestCliJson(projectDirectory);
+
+        console.log(
+          chalk.green(
+            `Successfully removed the ${chalk.bgGreenBright.red(
+              projectDirectory,
+            )} application and updated ${chalk.bgGreenBright.red(
+              'nest-cli.json',
+            )}`,
+          ),
+        );
+      } catch (error) {
+        console.error(chalk.red(`Error: ${error.message}`));
+        process.exit(1);
+      }
+    }
+    process.exit(0);
+  }
+}
+
+const removeProject = async (projectDirectory: string) => {
+  const projectPath = path.join(process.cwd(), 'apps', projectDirectory);
+
+  try {
+    fs.rmSync(projectPath, { recursive: true });
+  } catch (error) {
+    throw new Error(CLI_ERRORS.REMOVE_ACTION_FAILED);
+  }
+};
+
+const updateNestCliJson = (removedAppName: string) => {
+  const nestCliJsonPath = path.join(process.cwd(), 'nest-cli.json');
+
+  try {
+    const nestCliJsonContent = JSON.parse(
+      fs.readFileSync(nestCliJsonPath, 'utf-8'),
+    );
+
+    // Create a new object without the specified key
+    const { [removedAppName]: removedApp, ...updatedProjects } =
+      nestCliJsonContent.projects;
+
+    const updatedNestCliJson = {
+      ...nestCliJsonContent,
+      projects: updatedProjects,
+    };
+
+    fs.writeFileSync(
+      nestCliJsonPath,
+      JSON.stringify(updatedNestCliJson, null, 2),
+    );
+  } catch (error) {
+    throw new Error(CLI_ERRORS.REMOVE_ACTION_NEST_CLI_JSON_UPDATE_FAILED);
+  }
+};
+
+const check = (removedAppName: string) => {
+  const nestCliJsonPath = path.join(process.cwd(), 'nest-cli.json');
+
+  try {
+    const nestCliJsonContent = JSON.parse(
+      fs.readFileSync(nestCliJsonPath, 'utf-8'),
+    );
+
+    if (!nestCliJsonContent.monorepo) {
+      console.error(chalk.red(CLI_ERRORS.REMOVE_ACTION_NOT_SUPPORTED));
+      return false;
+    }
+
+    if (nestCliJsonContent.root === `apps/${removedAppName}`) {
+      console.error(
+        chalk.red(CLI_ERRORS.REMOVE_ACTION_FAILURE_FOR_ROOT_APPLICATION),
+      );
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error(chalk.red(CLI_ERRORS.REMOVE_ACTION_NEST_CLI_JSON_NOT_FOUND));
+    return false;
+  }
+};
+
+const askForConfirmation = async (): Promise<boolean> => {
+  const confirmationMessage = `${MESSAGES.PROJECT_REMOVE_CONFIRMATION} (yes/no):`;
+  const questions: Question[] = [
+    generateSelect('confirmation')(confirmationMessage)(['yes', 'no']),
+  ];
+  const prompt = inquirer.createPromptModule();
+  const { confirmation } = await prompt(questions);
+
+  return confirmation.toLowerCase() === 'yes';
+};

--- a/commands/command.loader.ts
+++ b/commands/command.loader.ts
@@ -6,6 +6,7 @@ import {
   GenerateAction,
   InfoAction,
   NewAction,
+  RemoveAction,
   StartAction,
 } from '../actions';
 import { ERROR_PREFIX } from '../lib/ui';
@@ -15,9 +16,11 @@ import { GenerateCommand } from './generate.command';
 import { InfoCommand } from './info.command';
 import { NewCommand } from './new.command';
 import { StartCommand } from './start.command';
+import { RemoveCommand } from './remove.command';
 export class CommandLoader {
   public static async load(program: CommanderStatic): Promise<void> {
     new NewCommand(new NewAction()).load(program);
+    new RemoveCommand(new RemoveAction()).load(program);
     new BuildCommand(new BuildAction()).load(program);
     new StartCommand(new StartAction()).load(program);
     new InfoCommand(new InfoAction()).load(program);

--- a/commands/remove.command.ts
+++ b/commands/remove.command.ts
@@ -1,0 +1,16 @@
+import { Command, CommanderStatic } from 'commander';
+import { AbstractCommand } from './abstract.command';
+import { Input } from './command.input';
+
+export class RemoveCommand extends AbstractCommand {
+  public load(program: CommanderStatic) {
+    program
+      .command('remove [name]')
+      .alias('r')
+      .description('Remove a Nest application in monorepo.')
+      .action(async (name: string) => {
+        const inputs: Input[] = [{ name: 'name', value: name }];
+        await this.action.handle(inputs);
+      });
+  }
+}

--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -101,8 +101,9 @@ export class AssetsManager {
 
           this.watchers.push(watcher);
         } else {
-          const files = sync(item.glob, { ignore: item.exclude })
-            .filter((matched) => statSync(matched).isFile());
+          const files = sync(item.glob, { ignore: item.exclude }).filter(
+            (matched) => statSync(matched).isFile(),
+          );
           for (const path of files) {
             this.actionOnFile({ ...option, path, action: 'change' });
           }

--- a/lib/ui/errors.ts
+++ b/lib/ui/errors.ts
@@ -5,4 +5,14 @@ export const CLI_ERRORS = {
     `Could not find TypeScript configuration file "${path}". Please, ensure that you are running this command in the appropriate directory (inside Nest workspace).`,
   WRONG_PLUGIN: (name: string) =>
     `The "${name}" plugin is not compatible with Nest CLI. Neither "after()" nor "before()" nor "afterDeclarations()" function have been provided.`,
+  PROJECT_NOT_FOUND: (name: string) =>
+    `Error: The project directory '${name}' does not exist.`,
+  ACTION_CANCELLED: 'Action Cancelled',
+  REMOVE_ACTION_NOT_SUPPORTED:
+    'This command line utility is supported in monorepo projects only.',
+  REMOVE_ACTION_FAILURE_FOR_ROOT_APPLICATION:
+    'Cannot remove the root application.',
+  REMOVE_ACTION_FAILED: 'Failed to remove application.',
+  REMOVE_ACTION_NEST_CLI_JSON_UPDATE_FAILED: 'Failed to update nest-cli.json.',
+  REMOVE_ACTION_NEST_CLI_JSON_NOT_FOUND: 'Failed to read nest-cli.json',
 };

--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -30,4 +30,6 @@ export const MESSAGES = {
     `Unable to install library ${name} because package did not install. Please check package name.`,
   LIBRARY_INSTALLATION_FAILED_NO_LIBRARY: 'No library found.',
   LIBRARY_INSTALLATION_STARTS: 'Starting library setup...',
+  PROJECT_REMOVE_CONFIRMATION:
+    'Are you sure you want to permanently delete this project? This action cannot be undone.',
 };

--- a/lib/utils/project-utils.ts
+++ b/lib/utils/project-utils.ts
@@ -4,6 +4,7 @@ import { Input } from '../../commands';
 import { getValueOrDefault } from '../compiler/helpers/get-value-or-default';
 import { Configuration, ProjectConfiguration } from '../configuration';
 import { generateSelect } from '../questions/questions';
+import { normalizeToKebabOrSnakeCase } from './formatting';
 
 export function shouldAskForProject(
   schematic: string,
@@ -150,3 +151,13 @@ export function hasValidOptionFlag(
       option.name === queriedOptionName && option.value === queriedValue,
   );
 }
+
+export const getProjectDirectory = (
+  applicationName: Input,
+  directoryOption?: Input,
+): string => {
+  return (
+    (directoryOption && (directoryOption.value as string)) ||
+    normalizeToKebabOrSnakeCase(applicationName.value as string)
+  );
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?
There is no command to delete a project.

Issue Number: #2436


## What is the new behavior?
A new command is added to delete a non-root project from mono-repo and auto-update nest-cli.json file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
