### PR TITLE
fix: update default swc config to be compatible with @swc/cli@^0.3.0

### DIFF
--- a/lib/compiler/defaults/swc-defaults.ts
+++ b/lib/compiler/defaults/swc-defaults.ts
@@ -43,6 +43,7 @@ export const swcDefaultsFactory = (
       includeDotfiles: false,
       quiet: false,
       watch: false,
+      stripLeadingPaths: true,
       ...builderOptions,
     },
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,8 @@
       "devDependencies": {
         "@commitlint/cli": "18.6.0",
         "@commitlint/config-angular": "18.6.0",
-        "@swc/cli": "0.1.65",
-        "@swc/core": "1.3.105",
+        "@swc/cli": "0.3.5",
+        "@swc/core": "1.3.107",
         "@types/inquirer": "9.0.3",
         "@types/jest": "29.5.11",
         "@types/node": "20.11.8",
@@ -65,7 +65,7 @@
         "node": ">= 16.14"
       },
       "peerDependencies": {
-        "@swc/cli": "^0.1.62",
+        "@swc/cli": "^0.1.62 || ^0.3.0",
         "@swc/core": "^1.3.62"
       },
       "peerDependenciesMeta": {
@@ -2746,15 +2746,16 @@
       }
     },
     "node_modules/@swc/cli": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.1.65.tgz",
-      "integrity": "sha512-4NcgsvJVHhA7trDnMmkGLLvWMHu2kSy+qHx6QwRhhJhdiYdNUrhdp+ERxen73sYtaeEOYeLJcWrQ60nzKi6rpg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.3.5.tgz",
+      "integrity": "sha512-YWt6J7KrbGxvtuktFzsXibr0Npi/VhTdtA+rVkRty0A1KfQD18o2Tt9JMRlKTpH40ZMFygJf/Up6FxCFdFjV5g==",
       "dev": true,
       "dependencies": {
         "@mole-inc/bin-wrapper": "^8.0.1",
         "commander": "^7.1.0",
         "fast-glob": "^3.2.5",
         "minimatch": "^9.0.3",
+        "piscina": "^4.3.0",
         "semver": "^7.3.8",
         "slash": "3.0.0",
         "source-map": "^0.7.3"
@@ -2765,7 +2766,7 @@
         "swcx": "bin/swcx.js"
       },
       "engines": {
-        "node": ">= 12.13"
+        "node": ">= 16.14.0"
       },
       "peerDependencies": {
         "@swc/core": "^1.2.66",
@@ -2835,9 +2836,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.105.tgz",
-      "integrity": "sha512-me2VZyr3OjqRpFrYQJJYy7x/zbFSl9nt+MAGnIcBtjDsN00iTVqEaKxBjPBFQV9BDAgPz2SRWes/DhhVm5SmMw==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.107.tgz",
+      "integrity": "sha512-zKhqDyFcTsyLIYK1iEmavljZnf4CCor5pF52UzLAz4B6Nu/4GLU+2LQVAf+oRHjusG39PTPjd2AlRT3f3QWfsQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2852,16 +2853,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.105",
-        "@swc/core-darwin-x64": "1.3.105",
-        "@swc/core-linux-arm-gnueabihf": "1.3.105",
-        "@swc/core-linux-arm64-gnu": "1.3.105",
-        "@swc/core-linux-arm64-musl": "1.3.105",
-        "@swc/core-linux-x64-gnu": "1.3.105",
-        "@swc/core-linux-x64-musl": "1.3.105",
-        "@swc/core-win32-arm64-msvc": "1.3.105",
-        "@swc/core-win32-ia32-msvc": "1.3.105",
-        "@swc/core-win32-x64-msvc": "1.3.105"
+        "@swc/core-darwin-arm64": "1.3.107",
+        "@swc/core-darwin-x64": "1.3.107",
+        "@swc/core-linux-arm-gnueabihf": "1.3.107",
+        "@swc/core-linux-arm64-gnu": "1.3.107",
+        "@swc/core-linux-arm64-musl": "1.3.107",
+        "@swc/core-linux-x64-gnu": "1.3.107",
+        "@swc/core-linux-x64-musl": "1.3.107",
+        "@swc/core-win32-arm64-msvc": "1.3.107",
+        "@swc/core-win32-ia32-msvc": "1.3.107",
+        "@swc/core-win32-x64-msvc": "1.3.107"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -2873,9 +2874,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.105.tgz",
-      "integrity": "sha512-buWeweLVDXXmcnfIemH4PGnpjwsDTUGitnPchdftb0u1FU8zSSP/lw/pUCBDG/XvWAp7c/aFxgN4CyG0j7eayA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.107.tgz",
+      "integrity": "sha512-47tD/5vSXWxPd0j/ZllyQUg4bqalbQTsmqSw0J4dDdS82MWqCAwUErUrAZPRjBkjNQ6Kmrf5rpCWaGTtPw+ngw==",
       "cpu": [
         "arm64"
       ],
@@ -2889,9 +2890,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.105.tgz",
-      "integrity": "sha512-hFmXPApqjA/8sy/9NpljHVaKi1OvL9QkJ2MbbTCCbJERuHMpMUeMBUWipHRfepGHFhU+9B9zkEup/qJaJR4XIg==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.107.tgz",
+      "integrity": "sha512-hwiLJ2ulNkBGAh1m1eTfeY1417OAYbRGcb/iGsJ+LuVLvKAhU/itzsl535CvcwAlt2LayeCFfcI8gdeOLeZa9A==",
       "cpu": [
         "x64"
       ],
@@ -2905,9 +2906,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.105.tgz",
-      "integrity": "sha512-mwXyMC41oMKkKrPpL8uJpOxw7fyfQoVtIw3Y5p0Blabk+espNYqix0E8VymHdRKuLmM//z5wVmMsuHdGBHvZeg==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.107.tgz",
+      "integrity": "sha512-I2wzcC0KXqh0OwymCmYwNRgZ9nxX7DWnOOStJXV3pS0uB83TXAkmqd7wvMBuIl9qu4Hfomi9aDM7IlEEn9tumQ==",
       "cpu": [
         "arm"
       ],
@@ -2921,9 +2922,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.105.tgz",
-      "integrity": "sha512-H7yEIVydnUtqBSUxwmO6vpIQn7j+Rr0DF6ZOORPyd/SFzQJK9cJRtmJQ3ZMzlJ1Bb+1gr3MvjgLEnmyCYEm2Hg==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.107.tgz",
+      "integrity": "sha512-HWgnn7JORYlOYnGsdunpSF8A+BCZKPLzLtEUA27/M/ZuANcMZabKL9Zurt7XQXq888uJFAt98Gy+59PU90aHKg==",
       "cpu": [
         "arm64"
       ],
@@ -2937,9 +2938,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.105.tgz",
-      "integrity": "sha512-Jg7RTFT3pGFdGt5elPV6oDkinRy7q9cXpenjXnJnM2uvx3jOwnsAhexPyCDHom8SHL0j+9kaLLC66T3Gz1E4UA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.107.tgz",
+      "integrity": "sha512-vfPF74cWfAm8hyhS8yvYI94ucMHIo8xIYU+oFOW9uvDlGQRgnUf/6DEVbLyt/3yfX5723Ln57U8uiMALbX5Pyw==",
       "cpu": [
         "arm64"
       ],
@@ -2953,9 +2954,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.105.tgz",
-      "integrity": "sha512-DJghplpyusAmp1X5pW/y93MmS/u83Sx5GrpJxI6KLPa82+NItTgMcl8KBQmW5GYAJpVKZyaIvBanS5TdR8aN2w==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.107.tgz",
+      "integrity": "sha512-uBVNhIg0ip8rH9OnOsCARUFZ3Mq3tbPHxtmWk9uAa5u8jQwGWeBx5+nTHpDOVd3YxKb6+5xDEI/edeeLpha/9g==",
       "cpu": [
         "x64"
       ],
@@ -2969,9 +2970,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.105.tgz",
-      "integrity": "sha512-wD5jL2dZH/5nPNssBo6jhOvkI0lmWnVR4vnOXWjuXgjq1S0AJpO5jdre/6pYLmf26hft3M42bteDnjR4AAZ38w==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.107.tgz",
+      "integrity": "sha512-mvACkUvzSIB12q1H5JtabWATbk3AG+pQgXEN95AmEX2ZA5gbP9+B+mijsg7Sd/3tboHr7ZHLz/q3SHTvdFJrEw==",
       "cpu": [
         "x64"
       ],
@@ -2985,9 +2986,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.105.tgz",
-      "integrity": "sha512-UqJtwILUHRw2+3UTPnRkZrzM/bGdQtbR4UFdp79mZQYfryeOUVNg7aJj/bWUTkKtLiZ3o+FBNrM/x2X1mJX5bA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.107.tgz",
+      "integrity": "sha512-J3P14Ngy/1qtapzbguEH41kY109t6DFxfbK4Ntz9dOWNuVY3o9/RTB841ctnJk0ZHEG+BjfCJjsD2n8H5HcaOA==",
       "cpu": [
         "arm64"
       ],
@@ -3001,9 +3002,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.105.tgz",
-      "integrity": "sha512-Z95C6vZgBEJ1snidYyjVKnVWiy/ZpPiIFIXGWkDr4ZyBgL3eZX12M6LzZ+NApHKffrbO4enbFyFomueBQgS2oA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.107.tgz",
+      "integrity": "sha512-ZBUtgyjTHlz8TPJh7kfwwwFma+ktr6OccB1oXC8fMSopD0AxVnQasgun3l3099wIsAB9eEsJDQ/3lDkOLs1gBA==",
       "cpu": [
         "ia32"
       ],
@@ -3017,9 +3018,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.105.tgz",
-      "integrity": "sha512-3J8fkyDPFsS3mszuYUY4Wfk7/B2oio9qXUwF3DzOs2MK+XgdyMLIptIxL7gdfitXJBH8k39uVjrIw1JGJDjyFA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.107.tgz",
+      "integrity": "sha512-Eyzo2XRqWOxqhE1gk9h7LWmUf4Bp4Xn2Ttb0ayAXFp6YSTxQIThXcT9kipXZqcpxcmDwoq8iWbbf2P8XL743EA==",
       "cpu": [
         "x64"
       ],
@@ -13121,10 +13122,32 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "node_modules/nice-napi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
+      "integrity": "sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "!win32"
+      ],
+      "dependencies": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.2"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+    },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -13169,6 +13192,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -13942,6 +13977,15 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/piscina": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.3.0.tgz",
+      "integrity": "sha512-vTQszGZj78p0BHFNO/cSvpzPUYa4tLXRe30aIYyQjqRS3fK/kPqdxvkTfGXQlEpWOI+mOOkda0iEY6NaanLWJA==",
+      "dev": true,
+      "optionalDependencies": {
+        "nice-napi": "^1.0.2"
       }
     },
     "node_modules/pkg-dir": {
@@ -20369,15 +20413,16 @@
       }
     },
     "@swc/cli": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.1.65.tgz",
-      "integrity": "sha512-4NcgsvJVHhA7trDnMmkGLLvWMHu2kSy+qHx6QwRhhJhdiYdNUrhdp+ERxen73sYtaeEOYeLJcWrQ60nzKi6rpg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.3.5.tgz",
+      "integrity": "sha512-YWt6J7KrbGxvtuktFzsXibr0Npi/VhTdtA+rVkRty0A1KfQD18o2Tt9JMRlKTpH40ZMFygJf/Up6FxCFdFjV5g==",
       "dev": true,
       "requires": {
         "@mole-inc/bin-wrapper": "^8.0.1",
         "commander": "^7.1.0",
         "fast-glob": "^3.2.5",
         "minimatch": "^9.0.3",
+        "piscina": "^4.3.0",
         "semver": "^7.3.8",
         "slash": "3.0.0",
         "source-map": "^0.7.3"
@@ -20425,92 +20470,92 @@
       }
     },
     "@swc/core": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.105.tgz",
-      "integrity": "sha512-me2VZyr3OjqRpFrYQJJYy7x/zbFSl9nt+MAGnIcBtjDsN00iTVqEaKxBjPBFQV9BDAgPz2SRWes/DhhVm5SmMw==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.107.tgz",
+      "integrity": "sha512-zKhqDyFcTsyLIYK1iEmavljZnf4CCor5pF52UzLAz4B6Nu/4GLU+2LQVAf+oRHjusG39PTPjd2AlRT3f3QWfsQ==",
       "dev": true,
       "requires": {
-        "@swc/core-darwin-arm64": "1.3.105",
-        "@swc/core-darwin-x64": "1.3.105",
-        "@swc/core-linux-arm-gnueabihf": "1.3.105",
-        "@swc/core-linux-arm64-gnu": "1.3.105",
-        "@swc/core-linux-arm64-musl": "1.3.105",
-        "@swc/core-linux-x64-gnu": "1.3.105",
-        "@swc/core-linux-x64-musl": "1.3.105",
-        "@swc/core-win32-arm64-msvc": "1.3.105",
-        "@swc/core-win32-ia32-msvc": "1.3.105",
-        "@swc/core-win32-x64-msvc": "1.3.105",
+        "@swc/core-darwin-arm64": "1.3.107",
+        "@swc/core-darwin-x64": "1.3.107",
+        "@swc/core-linux-arm-gnueabihf": "1.3.107",
+        "@swc/core-linux-arm64-gnu": "1.3.107",
+        "@swc/core-linux-arm64-musl": "1.3.107",
+        "@swc/core-linux-x64-gnu": "1.3.107",
+        "@swc/core-linux-x64-musl": "1.3.107",
+        "@swc/core-win32-arm64-msvc": "1.3.107",
+        "@swc/core-win32-ia32-msvc": "1.3.107",
+        "@swc/core-win32-x64-msvc": "1.3.107",
         "@swc/counter": "^0.1.1",
         "@swc/types": "^0.1.5"
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.105.tgz",
-      "integrity": "sha512-buWeweLVDXXmcnfIemH4PGnpjwsDTUGitnPchdftb0u1FU8zSSP/lw/pUCBDG/XvWAp7c/aFxgN4CyG0j7eayA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.107.tgz",
+      "integrity": "sha512-47tD/5vSXWxPd0j/ZllyQUg4bqalbQTsmqSw0J4dDdS82MWqCAwUErUrAZPRjBkjNQ6Kmrf5rpCWaGTtPw+ngw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.105.tgz",
-      "integrity": "sha512-hFmXPApqjA/8sy/9NpljHVaKi1OvL9QkJ2MbbTCCbJERuHMpMUeMBUWipHRfepGHFhU+9B9zkEup/qJaJR4XIg==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.107.tgz",
+      "integrity": "sha512-hwiLJ2ulNkBGAh1m1eTfeY1417OAYbRGcb/iGsJ+LuVLvKAhU/itzsl535CvcwAlt2LayeCFfcI8gdeOLeZa9A==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.105.tgz",
-      "integrity": "sha512-mwXyMC41oMKkKrPpL8uJpOxw7fyfQoVtIw3Y5p0Blabk+espNYqix0E8VymHdRKuLmM//z5wVmMsuHdGBHvZeg==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.107.tgz",
+      "integrity": "sha512-I2wzcC0KXqh0OwymCmYwNRgZ9nxX7DWnOOStJXV3pS0uB83TXAkmqd7wvMBuIl9qu4Hfomi9aDM7IlEEn9tumQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.105.tgz",
-      "integrity": "sha512-H7yEIVydnUtqBSUxwmO6vpIQn7j+Rr0DF6ZOORPyd/SFzQJK9cJRtmJQ3ZMzlJ1Bb+1gr3MvjgLEnmyCYEm2Hg==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.107.tgz",
+      "integrity": "sha512-HWgnn7JORYlOYnGsdunpSF8A+BCZKPLzLtEUA27/M/ZuANcMZabKL9Zurt7XQXq888uJFAt98Gy+59PU90aHKg==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.105.tgz",
-      "integrity": "sha512-Jg7RTFT3pGFdGt5elPV6oDkinRy7q9cXpenjXnJnM2uvx3jOwnsAhexPyCDHom8SHL0j+9kaLLC66T3Gz1E4UA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.107.tgz",
+      "integrity": "sha512-vfPF74cWfAm8hyhS8yvYI94ucMHIo8xIYU+oFOW9uvDlGQRgnUf/6DEVbLyt/3yfX5723Ln57U8uiMALbX5Pyw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.105.tgz",
-      "integrity": "sha512-DJghplpyusAmp1X5pW/y93MmS/u83Sx5GrpJxI6KLPa82+NItTgMcl8KBQmW5GYAJpVKZyaIvBanS5TdR8aN2w==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.107.tgz",
+      "integrity": "sha512-uBVNhIg0ip8rH9OnOsCARUFZ3Mq3tbPHxtmWk9uAa5u8jQwGWeBx5+nTHpDOVd3YxKb6+5xDEI/edeeLpha/9g==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.105.tgz",
-      "integrity": "sha512-wD5jL2dZH/5nPNssBo6jhOvkI0lmWnVR4vnOXWjuXgjq1S0AJpO5jdre/6pYLmf26hft3M42bteDnjR4AAZ38w==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.107.tgz",
+      "integrity": "sha512-mvACkUvzSIB12q1H5JtabWATbk3AG+pQgXEN95AmEX2ZA5gbP9+B+mijsg7Sd/3tboHr7ZHLz/q3SHTvdFJrEw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.105.tgz",
-      "integrity": "sha512-UqJtwILUHRw2+3UTPnRkZrzM/bGdQtbR4UFdp79mZQYfryeOUVNg7aJj/bWUTkKtLiZ3o+FBNrM/x2X1mJX5bA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.107.tgz",
+      "integrity": "sha512-J3P14Ngy/1qtapzbguEH41kY109t6DFxfbK4Ntz9dOWNuVY3o9/RTB841ctnJk0ZHEG+BjfCJjsD2n8H5HcaOA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.105.tgz",
-      "integrity": "sha512-Z95C6vZgBEJ1snidYyjVKnVWiy/ZpPiIFIXGWkDr4ZyBgL3eZX12M6LzZ+NApHKffrbO4enbFyFomueBQgS2oA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.107.tgz",
+      "integrity": "sha512-ZBUtgyjTHlz8TPJh7kfwwwFma+ktr6OccB1oXC8fMSopD0AxVnQasgun3l3099wIsAB9eEsJDQ/3lDkOLs1gBA==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.3.105",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.105.tgz",
-      "integrity": "sha512-3J8fkyDPFsS3mszuYUY4Wfk7/B2oio9qXUwF3DzOs2MK+XgdyMLIptIxL7gdfitXJBH8k39uVjrIw1JGJDjyFA==",
+      "version": "1.3.107",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.107.tgz",
+      "integrity": "sha512-Eyzo2XRqWOxqhE1gk9h7LWmUf4Bp4Xn2Ttb0ayAXFp6YSTxQIThXcT9kipXZqcpxcmDwoq8iWbbf2P8XL743EA==",
       "dev": true,
       "optional": true
     },
@@ -28025,10 +28070,28 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "nice-napi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
+      "integrity": "sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.2"
+      }
+    },
     "node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+    },
+    "node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true,
+      "optional": true
     },
     "node-domexception": {
       "version": "1.0.0",
@@ -28054,6 +28117,13 @@
         "fetch-blob": "^3.1.4",
         "formdata-polyfill": "^4.0.10"
       }
+    },
+    "node-gyp-build": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "dev": true,
+      "optional": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -28619,6 +28689,15 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "dev": true
+    },
+    "piscina": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.3.0.tgz",
+      "integrity": "sha512-vTQszGZj78p0BHFNO/cSvpzPUYa4tLXRe30aIYyQjqRS3fK/kPqdxvkTfGXQlEpWOI+mOOkda0iEY6NaanLWJA==",
+      "dev": true,
+      "requires": {
+        "nice-napi": "^1.0.2"
+      }
     },
     "pkg-dir": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   "devDependencies": {
     "@commitlint/cli": "18.6.0",
     "@commitlint/config-angular": "18.6.0",
-    "@swc/cli": "0.1.65",
-    "@swc/core": "1.3.105",
+    "@swc/cli": "0.3.5",
+    "@swc/core": "1.3.107",
     "@types/inquirer": "9.0.3",
     "@types/jest": "29.5.11",
     "@types/node": "20.11.8",
@@ -91,7 +91,7 @@
     "**/*.{ts,json}": []
   },
   "peerDependencies": {
-    "@swc/cli": "^0.1.62",
+    "@swc/cli": "^0.1.62 || ^0.3.0",
     "@swc/core": "^1.3.62"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

As of `@swc/cli@0.3.0`, output paths no longer follow the same behavior as is configured in tsconfig. As of 0.3.5, however, a `stripLeadingPaths` option was introduced to revert back to this functionality.

See https://github.com/nestjs/nest-cli/pull/2467#issuecomment-1915955111 for more context.

Issue Number: N/A


## What is the new behavior?

Default swc configuration now includes the `stripLeadingPaths` option.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I manually tested older versions of `@swc/cli` with this option and they still worked without issue. I also validated that setting this with `@swc/cli@0.3.5` resolves the issue, outputting to the expected destination.