### PR TITLE
fix: update default swc config to be compatible with @swc/cli@^0.3.0

### DIFF
--- a/lib/compiler/defaults/swc-defaults.ts
+++ b/lib/compiler/defaults/swc-defaults.ts
@@ -43,6 +43,7 @@ export const swcDefaultsFactory = (
       includeDotfiles: false,
       quiet: false,
       watch: false,
+      stripLeadingPaths: true,
       ...builderOptions,
     },
   };


### PR DESCRIPTION
Reopening https://github.com/nestjs/nest-cli/pull/2481 after branch changes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

As of `@swc/cli@0.3.0`, output paths no longer follow the same behavior as is configured in tsconfig. As of 0.3.5, however, a `stripLeadingPaths` option was introduced to revert back to this functionality.

See https://github.com/nestjs/nest-cli/pull/2467#issuecomment-1915955111 for more context.

Issue Number: N/A


## What is the new behavior?

Default swc configuration now includes the `stripLeadingPaths` option.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I manually tested older versions of `@swc/cli` with this option and they still worked without issue. I also validated that setting this with `@swc/cli@0.3.5` resolves the issue, outputting to the expected destination.