### PR TITLE
feat: add flag to disable shell mode for `nest start --watch`

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -72,12 +72,15 @@ export class StartAction extends BuildAction {
         commandOptions,
         defaultConfiguration.sourceRoot,
       );
+      const noShellOption = commandOptions.find((option) => option.name === 'noShell')
+      const useShell = noShellOption ? !noShellOption.value : true;
       const onSuccess = this.createOnSuccessHook(
         entryFile,
         sourceRoot,
         debugFlag,
         outDir,
         binaryToRun,
+        useShell,
       );
 
       await this.runBuild(
@@ -103,6 +106,7 @@ export class StartAction extends BuildAction {
     debugFlag: boolean | string | undefined,
     outDirName: string,
     binaryToRun: string,
+    useShell: boolean,
   ) {
     let childProcessRef: any;
     process.on(
@@ -120,6 +124,7 @@ export class StartAction extends BuildAction {
             debugFlag,
             outDirName,
             binaryToRun,
+            useShell,
           );
           childProcessRef.on('exit', () => (childProcessRef = undefined));
         });
@@ -133,6 +138,7 @@ export class StartAction extends BuildAction {
           debugFlag,
           outDirName,
           binaryToRun,
+          useShell,
         );
         childProcessRef.on('exit', (code: number) => {
           process.exitCode = code;
@@ -148,6 +154,7 @@ export class StartAction extends BuildAction {
     debug: boolean | string | undefined,
     outDirName: string,
     binaryToRun: string,
+    useShell: boolean,
   ) {
     let outputFilePath = join(outDirName, sourceRoot, entryFile);
     if (!fs.existsSync(outputFilePath + '.js')) {
@@ -179,7 +186,7 @@ export class StartAction extends BuildAction {
 
     return spawn(binaryToRun, processArgs, {
       stdio: 'inherit',
-      shell: true,
+      shell: useShell,
     });
   }
 }

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -38,6 +38,7 @@ export class StartCommand extends AbstractCommand {
         '--preserveWatchOutput',
         'Use "preserveWatchOutput" option when using tsc watch mode.',
       )
+      .option('--noShell', 'Spawn child processes without shell (see node\'s child_process.spawn() method docs)')
       .description('Run Nest application.')
       .action(async (app: string, command: Command) => {
         const options: Input[] = [];
@@ -79,6 +80,10 @@ export class StartCommand extends AbstractCommand {
             !!command.watch &&
             !isWebpackEnabled,
         });
+        options.push({
+          name: 'noShell',
+          value: !!command.noShell,
+        })
 
         const availableBuilders = ['tsc', 'webpack', 'swc'];
         if (command.builder && !availableBuilders.includes(command.builder)) {


### PR DESCRIPTION
When running on Linux/WSL, `nest start --watch` does not wait the app to shutdown on restart. That leads to two instances of application running simultaneously, especially if it has async shutdown hooks. That commit fixes that adding an option to disable shell mode when spawning child processes so then app will completely shutdown first and only then started again. Thanks @jleverenz for the investigation and solution idea in [#1641](https://github.com/nestjs/nest-cli/issues/1614#issuecomment-1463838659)

fixes nestjs/nest-cli/1614

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Nest does not wait for app to stop when doing hot reload (on files change)

Issue Number: #1614 


## What is the new behavior?

Now running `nest start --watch --noShell` hot reload will first wait for app to gracefully stop

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
