### PR TITLE
fix: propagate errors raised when loading the webpack configuration file

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -22,6 +22,7 @@ import {
 } from '../lib/configuration/defaults';
 import { FileSystemReader } from '../lib/readers';
 import { ERROR_PREFIX } from '../lib/ui';
+import { isModuleAvailable } from '../lib/utils/is-module-available';
 import { AbstractAction } from './abstract.action';
 import webpack = require('webpack');
 
@@ -261,13 +262,15 @@ export class BuildAction extends AbstractAction {
     webpackRef: typeof webpack,
   ) => webpack.Configuration {
     const pathToWebpackFile = join(process.cwd(), webpackPath);
+    const isWebpackFileAvailable = isModuleAvailable(pathToWebpackFile);
+    if (!isWebpackFileAvailable && webpackPath === defaultPath) {
+      return ({}) => ({});
+    }
+
     try {
       return require(pathToWebpackFile);
     } catch (err) {
-      if (webpackPath !== defaultPath) {
-        throw err;
-      }
-      return ({}) => ({});
+      throw err;
     }
   }
 }

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -266,11 +266,6 @@ export class BuildAction extends AbstractAction {
     if (!isWebpackFileAvailable && webpackPath === defaultPath) {
       return ({}) => ({});
     }
-
-    try {
-      return require(pathToWebpackFile);
-    } catch (err) {
-      throw err;
-    }
+    return require(pathToWebpackFile);
   }
 }

--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -60,10 +60,13 @@ export class AssetsManager {
 
       const filesToCopy = assets.map<AssetEntry>((item) => {
         let includePath = typeof item === 'string' ? item : item.include!;
-        let excludePath = typeof item !== 'string' && item.exclude ? item.exclude : undefined;
+        let excludePath =
+          typeof item !== 'string' && item.exclude ? item.exclude : undefined;
 
         includePath = join(sourceRoot, includePath).replace(/\\/g, '/');
-        excludePath = excludePath ? join(sourceRoot, excludePath).replace(/\\/g, '/') : undefined;
+        excludePath = excludePath
+          ? join(sourceRoot, excludePath).replace(/\\/g, '/')
+          : undefined;
 
         return {
           outDir: typeof item !== 'string' ? item.outDir || outDir : outDir,

--- a/lib/utils/is-module-available.ts
+++ b/lib/utils/is-module-available.ts
@@ -1,0 +1,8 @@
+export function isModuleAvailable(path: string): boolean {
+  try {
+    require.resolve(path);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #2421

## What is the new behavior?

propagate any errors raised when loading the webpack configuration file. For example:


<details>
<summary>1. when webpack config path is not supplied but the file do exists</summary>

in this case I didn't installed `run-script-webpack-plugin` and the config file is using it

![image](https://github.com/nestjs/nest-cli/assets/13461315/b9555cc0-aec3-47b6-b449-938097b6ff41)

</details>


<details>
<summary>2. when the supplied webpack config path is not found</summary>

![image](https://github.com/nestjs/nest-cli/assets/13461315/1e07866b-0cc9-4f76-9d2b-5b9d3a9f5b4a)

</details>


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No(?)
```

