### PR TITLE
Use node watch mode when watch is enabled to restart the application when dependencies change

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -78,6 +78,7 @@ export class StartAction extends BuildAction {
         debugFlag,
         outDir,
         binaryToRun,
+        isWatchEnabled,
       );
 
       await this.runBuild(
@@ -103,6 +104,7 @@ export class StartAction extends BuildAction {
     debugFlag: boolean | string | undefined,
     outDirName: string,
     binaryToRun: string,
+    isWatchEnabled: boolean,
   ) {
     let childProcessRef: any;
     process.on(
@@ -120,6 +122,7 @@ export class StartAction extends BuildAction {
             debugFlag,
             outDirName,
             binaryToRun,
+            isWatchEnabled,
           );
           childProcessRef.on('exit', () => (childProcessRef = undefined));
         });
@@ -133,6 +136,7 @@ export class StartAction extends BuildAction {
           debugFlag,
           outDirName,
           binaryToRun,
+          isWatchEnabled,
         );
         childProcessRef.on('exit', (code: number) => {
           process.exitCode = code;
@@ -148,6 +152,7 @@ export class StartAction extends BuildAction {
     debug: boolean | string | undefined,
     outDirName: string,
     binaryToRun: string,
+    isWatchEnabled: boolean,
   ) {
     let outputFilePath = join(outDirName, sourceRoot, entryFile);
     if (!fs.existsSync(outputFilePath + '.js')) {
@@ -174,6 +179,9 @@ export class StartAction extends BuildAction {
       const inspectFlag =
         typeof debug === 'string' ? `--inspect=${debug}` : '--inspect';
       processArgs.unshift(inspectFlag);
+    }
+    if (isWatchEnabled) {
+      processArgs.unshift('--watch');
     }
     processArgs.unshift('--enable-source-maps');
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
> Couldn't find any existing tests for the start action.
- [ ] Docs have been added / updated (for bug fixes / features)
> Couldn't find any existing tests for the start action.

## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

This is in-between a bugfix and a new feature: I was expecting the watch mode of Nest.js to behave like nodemon or Node.js' watch mode and watch all imported files, and not like TypeScript's build watch that only watches files to build.

## What is the current behavior?

Currently, the start command's watch mode only watches for files to build. But once the application has started, changes to dependencies don't trigger a restart. It's a build watch, not a run watch.

## What is the new behavior?

This change appends the `--watch` option to the node command run when the build succeeds to also add this run watch behaviour.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
