### PR TITLE
fix: unification copy behavior between watched and not watched assets

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -103,9 +103,10 @@ export class AssetsManager {
 
           this.watchers.push(watcher);
         } else {
-          const files = sync(item.glob, { ignore: item.exclude }).filter(
-            (matched) => statSync(matched).isFile(),
-          );
+          const files = sync(item.glob, {
+            ignore: item.exclude,
+            dot: true,
+          }).filter((matched) => statSync(matched).isFile());
           for (const path of files) {
             this.actionOnFile({ ...option, path, action: 'change' });
           }


### PR DESCRIPTION
`chokidar.watch` listen also for hidden files but `glob` do not. This means hidden files are copied in watch mode but they are not when watch mode is turned off

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Hidden files are not coppied when watch mode is turned off

Issue Number: #2653


## What is the new behavior?

Hidden files will be copied regardless watch mode

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
