### PR TITLE
fix: allow resolving copy paths for files in project root folder

### DIFF
--- a/lib/compiler/helpers/copy-path-resolve.ts
+++ b/lib/compiler/helpers/copy-path-resolve.ts
@@ -15,8 +15,8 @@ function dealWith(inPath: string, up: number) {
     return inPath;
   }
 
-  if (depth(inPath) < up) {
-    throw new Error('cant go up that far');
+  if (depth(inPath) < up - 1) {
+    throw new Error('Path outside of project folder is not allowed');
   }
 
   return path.join(...path.normalize(inPath).split(path.sep).slice(up));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The nestjs build fails when addeing a single file asset item to copy a config file from the nestjs root directory.
https://github.com/nestjs/nest-cli/issues/2677

Issue Number: 2677


## What is the new behavior?
The build allows copying files the project root directory.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
