### PR TITLE
fix(actions): ignore pkgmgr select when `--skip-install` is passsed

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -94,6 +94,12 @@ const askForMissingInformation = async (inputs: Input[], options: Input[]) => {
     replaceInputMissingInformation(inputs, answers);
   }
 
+  // It should not ask for the package manager if --skip-install is option is set
+  const shouldSkipInstall = options.find((opt) => opt.name === 'skip-install')!;
+  if (shouldSkipInstall.value) {
+    return;
+  }
+
   const packageManagerInput = getPackageManagerInput(options);
   if (!packageManagerInput!.value) {
     const answers = await askForPackageManager();


### PR DESCRIPTION
Since the scaffolder is emitting package.json only. Therefore, package manager prompt is not required here.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Even if we pass `-s` or `--skip-install` option, the CLI asks for the package manager. But now if these options are passed, the package manager selection prompt will be ignored.

## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
