### PR TITLE
fix: show type check warning only when builder is not swc 

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import * as ts from 'typescript';
 import { Input } from '../commands';
 import { AssetsManager } from '../lib/compiler/assets-manager';
+import { deleteOutDirIfEnabled } from '../lib/compiler/helpers/delete-out-dir';
 import { getBuilder } from '../lib/compiler/helpers/get-builder';
 import { getTscConfigPath } from '../lib/compiler/helpers/get-tsc-config.path';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
@@ -10,7 +11,6 @@ import { getWebpackConfigPath } from '../lib/compiler/helpers/get-webpack-config
 import { TsConfigProvider } from '../lib/compiler/helpers/tsconfig-provider';
 import { PluginsLoader } from '../lib/compiler/plugins/plugins-loader';
 import { TypeScriptBinaryLoader } from '../lib/compiler/typescript-loader';
-import { deleteOutDirIfEnabled } from '../lib/compiler/helpers/delete-out-dir';
 import {
   Configuration,
   ConfigurationLoader,
@@ -21,7 +21,7 @@ import {
   defaultWebpackConfigFilename,
 } from '../lib/configuration/defaults';
 import { FileSystemReader } from '../lib/readers';
-import { ERROR_PREFIX } from '../lib/ui';
+import { ERROR_PREFIX, INFO_PREFIX } from '../lib/ui';
 import { isModuleAvailable } from '../lib/utils/is-module-available';
 import { AbstractAction } from './abstract.action';
 import webpack = require('webpack');
@@ -108,6 +108,20 @@ export class BuildAction extends AbstractAction {
       outDir,
       watchAssetsMode,
     );
+
+    const typeCheck = getValueOrDefault<boolean>(
+      configuration,
+      'compilerOptions.typeCheck',
+      appName,
+      'typeCheck',
+      commandOptions,
+    );
+    if (typeCheck && builder.type !== 'swc') {
+      console.warn(
+        INFO_PREFIX +
+          ` "typeCheck" will not have any effect when "builder" is not "swc".`,
+      );
+    }
 
     switch (builder.type) {
       case 'tsc':

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -1,5 +1,5 @@
 import { Command, CommanderStatic } from 'commander';
-import { ERROR_PREFIX, INFO_PREFIX } from '../lib/ui';
+import { ERROR_PREFIX } from '../lib/ui';
 import { AbstractCommand } from './abstract.command';
 import { Input } from './command.input';
 
@@ -60,12 +60,6 @@ export class BuildCommand extends AbstractCommand {
           value: command.builder,
         });
 
-        if (command.typeCheck && command.builder !== 'swc') {
-          console.warn(
-            INFO_PREFIX +
-              ` "typeCheck" will not have any effect when "builder" is not "swc".`,
-          );
-        }
         options.push({
           name: 'typeCheck',
           value: command.typeCheck,

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -1,5 +1,5 @@
 import { Command, CommanderStatic } from 'commander';
-import { ERROR_PREFIX, INFO_PREFIX } from '../lib/ui';
+import { ERROR_PREFIX } from '../lib/ui';
 import { getRemainingFlags } from '../lib/utils/remaining-flags';
 import { AbstractCommand } from './abstract.command';
 import { Input } from './command.input';
@@ -95,12 +95,6 @@ export class StartCommand extends AbstractCommand {
           value: command.builder,
         });
 
-        if (command.typeCheck && command.builder !== 'swc') {
-          console.warn(
-            INFO_PREFIX +
-              ` "typeCheck" will not have any effect when "builder" is not "swc".`,
-          );
-        }
         options.push({
           name: 'typeCheck',
           value: command.typeCheck,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2791


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
