### PR TITLE
refactor: replace chalk with smaller and faster ansis

### DIFF
--- a/actions/add.action.ts
+++ b/actions/add.action.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { red } from 'ansis';
 import { Input } from '../commands';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
 import {
@@ -40,7 +40,7 @@ export class AddAction extends AbstractAction {
       await this.addLibrary(collectionName, options, extraFlags);
     } else {
       console.error(
-        chalk.red(
+        red(
           MESSAGES.LIBRARY_INSTALLATION_FAILED_BAD_PACKAGE(libraryName),
         ),
       );
@@ -109,7 +109,7 @@ export class AddAction extends AbstractAction {
       installResult = await manager.addProduction([collectionName], tagName);
     } catch (error) {
       if (error && error.message) {
-        console.error(chalk.red(error.message));
+        console.error(red(error.message));
       }
     }
     return installResult;
@@ -140,7 +140,7 @@ export class AddAction extends AbstractAction {
       );
     } catch (error) {
       if (error && error.message) {
-        console.error(chalk.red(error.message));
+        console.error(red(error.message));
         return Promise.reject();
       }
     }

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { red } from 'ansis';
 import { join } from 'path';
 import * as ts from 'typescript';
 import { Input } from '../commands';
@@ -60,7 +60,7 @@ export class BuildAction extends AbstractAction {
       if (err instanceof Error) {
         console.log(`\n${ERROR_PREFIX} ${err.message}\n`);
       } else {
-        console.error(`\n${chalk.red(err)}\n`);
+        console.error(`\n${red(err)}\n`);
       }
       process.exit(1);
     }

--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { red } from 'ansis';
 import * as path from 'path';
 import { Input } from '../commands';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
@@ -143,7 +143,7 @@ const generateFiles = async (inputs: Input[]) => {
     await collection.execute(schematicInput.value as string, schematicOptions);
   } catch (error) {
     if (error && error.message) {
-      console.error(chalk.red(error.message));
+      console.error(red(error.message));
     }
   }
 };

--- a/actions/info.action.ts
+++ b/actions/info.action.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { blue, bold, green, red, yellow } from 'ansis';
 import { readFileSync } from 'fs';
 import { platform, release } from 'os';
 import { join } from 'path';
@@ -50,16 +50,16 @@ export class InfoAction extends AbstractAction {
   }
 
   private displayBanner() {
-    console.info(chalk.red(BANNER));
+    console.info(red(BANNER));
   }
 
   private async displaySystemInformation(): Promise<void> {
-    console.info(chalk.green('[System Information]'));
+    console.info(green`[System Information]`);
     console.info(
       'OS Version     :',
-      chalk.blue(osName(platform(), release()), release()),
+      blue(osName(platform(), release()) + release()),
     );
-    console.info('NodeJS Version :', chalk.blue(process.version));
+    console.info('NodeJS Version :', blue(process.version));
     await this.displayPackageManagerVersion();
   }
 
@@ -68,13 +68,13 @@ export class InfoAction extends AbstractAction {
       const version: string = await this.manager.version();
       console.info(
         `${this.manager.name} Version    :`,
-        chalk.blue(version),
+        blue(version),
         '\n',
       );
     } catch {
       console.error(
         `${this.manager.name} Version    :`,
-        chalk.red('Unknown'),
+        red`Unknown`,
         '\n',
       );
     }
@@ -82,7 +82,7 @@ export class InfoAction extends AbstractAction {
 
   async displayNestInformation(): Promise<void> {
     this.displayCliVersion();
-    console.info(chalk.green('[Nest Platform Information]'));
+    console.info(green`[Nest Platform Information`);
     await this.displayNestInformationFromPackage();
   }
 
@@ -93,16 +93,16 @@ export class InfoAction extends AbstractAction {
       this.displayNestVersions(dependencies);
     } catch (err) {
       console.error(
-        chalk.red(MESSAGES.NEST_INFORMATION_PACKAGE_MANAGER_FAILED),
+        red(MESSAGES.NEST_INFORMATION_PACKAGE_MANAGER_FAILED),
       );
     }
   }
 
   displayCliVersion(): void {
-    console.info(chalk.green('[Nest CLI]'));
+    console.info(green`[Nest CLI]`);
     console.info(
       'Nest CLI Version :',
-      chalk.blue(
+      blue(
         JSON.parse(readFileSync(join(__dirname, '../package.json')).toString())
           .version,
       ),
@@ -125,7 +125,7 @@ export class InfoAction extends AbstractAction {
   displayNestVersions(dependencies: PackageJsonDependencies) {
     const nestDependencies = this.buildNestVersionsMessage(dependencies);
     nestDependencies.forEach((dependency) =>
-      console.info(dependency.name, chalk.blue(dependency.value)),
+      console.info(dependency.name, blue(dependency.value)),
     );
 
     this.displayWarningMessage(nestDependencies);
@@ -137,13 +137,13 @@ export class InfoAction extends AbstractAction {
       const majorVersions = Object.keys(warnings);
       if (majorVersions.length > 0) {
         console.info('\r');
-        console.info(chalk.yellow('[Warnings]'));
+        console.info(yellow`[Warnings]`);
         console.info(
           'The following packages are not in the same major version',
         );
         console.info('This could lead to runtime errors');
         majorVersions.forEach((version) => {
-          console.info(chalk.bold(`* Under version ${version}`));
+          console.info(bold`* Under version ${version}`);
           warnings[version].forEach(({ packageName, value }) => {
             console.info(`- ${packageName} ${value}`);
           });
@@ -152,7 +152,7 @@ export class InfoAction extends AbstractAction {
     } catch {
       console.info('\t');
       console.error(
-        chalk.red(
+        red(
           MESSAGES.NEST_INFORMATION_PACKAGE_WARNING_FAILED(
             this.warningMessageDependenciesWhiteList,
           ),

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -1,5 +1,5 @@
 import { input, select } from '@inquirer/prompts';
-import * as chalk from 'chalk';
+import * as ansis from 'ansis';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import { Answers } from 'inquirer';
@@ -151,7 +151,7 @@ const installPackages = async (
   let packageManager: AbstractPackageManager;
   if (dryRunMode) {
     console.info();
-    console.info(chalk.green(MESSAGES.DRY_RUN_MODE));
+    console.info(ansis.green(MESSAGES.DRY_RUN_MODE));
     console.info();
     return;
   }
@@ -160,7 +160,7 @@ const installPackages = async (
     await packageManager.install(installDirectory, inputPackageManager);
   } catch (error) {
     if (error && error.message) {
-      console.error(chalk.red(error.message));
+      console.error(ansis.red(error.message));
     }
   }
 };
@@ -176,7 +176,7 @@ const askForPackageManager = async () => {
 const initializeGitRepository = async (dir: string) => {
   const runner = new GitRunner();
   await runner.run('init', true, join(process.cwd(), dir)).catch(() => {
-    console.error(chalk.red(MESSAGES.GIT_INITIALIZATION_ERROR));
+    console.error(ansis.red(MESSAGES.GIT_INITIALIZATION_ERROR));
   });
 };
 
@@ -212,7 +212,7 @@ const printCollective = () => {
   emptyLine();
   emptyLine();
   print()(
-    `${chalk.bold(`${EMOJIS.WINE}  Donate:`)} ${chalk.underline(
+    `${ansis.bold`${EMOJIS.WINE}  Donate:`} ${ansis.underline(
       'https://opencollective.com/nest',
     )}`,
   );
@@ -227,7 +227,7 @@ const print =
     const leftPaddingLength = Math.floor((terminalCols - strLength) / 2);
     const leftPadding = ' '.repeat(Math.max(leftPaddingLength, 0));
     if (color) {
-      str = (chalk as any)[color](str);
+      str = (ansis as any)[color](str);
     }
     console.log(leftPadding, str);
   };

--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { red } from 'ansis';
 import { spawn } from 'child_process';
 import * as fs from 'fs';
 import { join } from 'path';
@@ -107,7 +107,7 @@ export class StartAction extends BuildAction {
       if (err instanceof Error) {
         console.log(`\n${ERROR_PREFIX} ${err.message}\n`);
       } else {
-        console.error(`\n${chalk.red(err)}\n`);
+        console.error(`\n${red(err)}\n`);
       }
     }
   }

--- a/commands/command.loader.ts
+++ b/commands/command.loader.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { red } from 'ansis';
 import { CommanderStatic } from 'commander';
 import {
   AddAction,
@@ -30,11 +30,11 @@ export class CommandLoader {
   private static handleInvalidCommand(program: CommanderStatic) {
     program.on('command:*', () => {
       console.error(
-        `\n${ERROR_PREFIX} Invalid command: ${chalk.red('%s')}`,
+        `\n${ERROR_PREFIX} Invalid command: ${red`%s`}`,
         program.args.join(' '),
       );
       console.log(
-        `See ${chalk.red('--help')} for a list of available commands.\n`,
+        `See ${red`--help`} for a list of available commands.\n`,
       );
       process.exit(1);
     });

--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { bold, cyan, green } from 'ansis';
 import * as Table from 'cli-table3';
 import { Command, CommanderStatic } from 'commander';
 import { AbstractCollection, CollectionFactory } from '../lib/schematics';
@@ -107,7 +107,7 @@ export class GenerateCommand extends AbstractCommand {
     const collection = await this.getCollection();
     return (
       'Generate a Nest element.\n' +
-      `  Schematics available on ${chalk.bold(collection)} collection:\n` +
+      `  Schematics available on ${bold(collection)} collection:\n` +
       this.buildSchematicsListAsTable(await this.getSchematics(collection))
     );
   }
@@ -129,8 +129,8 @@ export class GenerateCommand extends AbstractCommand {
     const table: any = new Table(tableConfig);
     for (const schematic of schematics) {
       table.push([
-        chalk.green(schematic.name),
-        chalk.cyan(schematic.alias),
+        green(schematic.name),
+        cyan(schematic.alias),
         schematic.description,
       ]);
     }

--- a/lib/compiler/helpers/manual-restart.ts
+++ b/lib/compiler/helpers/manual-restart.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { gray } from 'ansis';
 
 export function listenForManualRestart(callback: () => void) {
   const stdinListener = (data: Buffer) => {
@@ -11,5 +11,5 @@ export function listenForManualRestart(callback: () => void) {
 }
 
 export function displayManualRestartTip(): void {
-  console.log(`To restart at any time, enter ${chalk.gray('rs')}.\n`);
+  console.log(`To restart at any time, enter ${gray`rs`}.\n`);
 }

--- a/lib/compiler/swc/constants.ts
+++ b/lib/compiler/swc/constants.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { bgCyan, bgGreen, bgRed, cyan, green, red } from 'ansis';
 
 export const TSC_NO_ERRORS_MESSAGE =
   'Found 0 errors. Watching for file changes.';
@@ -6,19 +6,17 @@ export const TSC_NO_ERRORS_MESSAGE =
 export const TSC_COMPILATION_STARTED_MESSAGE =
   'Starting compilation in watch mode...';
 
-export const SWC_LOG_PREFIX = chalk.cyan('> ') + chalk.bgCyan.bold(' SWC ');
+export const SWC_LOG_PREFIX = cyan('> ') + bgCyan.bold(' SWC ');
 
-export const TSC_LOG_PREFIX = chalk.cyan('> ') + chalk.bgCyan.bold(' TSC ');
-export const TSC_LOG_ERROR_PREFIX = chalk.red('> ') + chalk.bgRed.bold(' TSC ');
-export const TSC_LOG_SUCCESS_PREFIX =
-  chalk.green('> ') + chalk.bgGreen.bold(' TSC ');
+export const TSC_LOG_PREFIX = cyan('> ') + bgCyan.bold(' TSC ');
+export const TSC_LOG_ERROR_PREFIX = red('> ') + bgRed.bold(' TSC ');
+export const TSC_LOG_SUCCESS_PREFIX = green('> ') + bgGreen.bold(' TSC ');
 
 export const INITIALIZING_TYPE_CHECKER =
-  chalk.bgCyan.bold(' TSC ') + chalk.cyan(' Initializing type checker...');
+  bgCyan.bold(' TSC ') + cyan(' Initializing type checker...');
 
 export const FOUND_NO_ISSUES_METADATA_GENERATION_SKIPPED =
-  TSC_LOG_SUCCESS_PREFIX + chalk.green(' Found 0 issues.');
+  TSC_LOG_SUCCESS_PREFIX + green(' Found 0 issues.');
 
 export const FOUND_NO_ISSUES_GENERATING_METADATA =
-  TSC_LOG_SUCCESS_PREFIX +
-  chalk.green(' Found 0 issues. Generating metadata...');
+  TSC_LOG_SUCCESS_PREFIX + green(' Found 0 issues. Generating metadata...');

--- a/lib/compiler/swc/swc-compiler.ts
+++ b/lib/compiler/swc/swc-compiler.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { cyan } from 'ansis';
 import { fork } from 'child_process';
 import * as chokidar from 'chokidar';
 import { readFileSync } from 'fs';
@@ -156,7 +156,7 @@ export class SwcCompiler extends BaseCompiler {
     swcrcFilePath?: string,
   ) {
     process.nextTick(() =>
-      console.log(SWC_LOG_PREFIX, chalk.cyan('Running...')),
+      console.log(SWC_LOG_PREFIX, cyan('Running...')),
     );
 
     const swcCli = this.loadSwcCliBinary();

--- a/lib/compiler/swc/type-checker-host.ts
+++ b/lib/compiler/swc/type-checker-host.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { red } from 'ansis';
 import * as ora from 'ora';
 import * as ts from 'typescript';
 import { TsConfigProvider } from '../helpers/tsconfig-provider';
@@ -63,7 +63,7 @@ export class TypeCheckerHost {
     const reportWatchStatusCallback = (diagnostic: ts.Diagnostic) => {
       if (diagnostic.messageText !== TSC_NO_ERRORS_MESSAGE) {
         if ((diagnostic.messageText as string)?.includes('Found')) {
-          console.log(TSC_LOG_ERROR_PREFIX, chalk.red(diagnostic.messageText));
+          console.log(TSC_LOG_ERROR_PREFIX, red(diagnostic.messageText.toString()));
         }
         return;
       }

--- a/lib/package-managers/abstract.package-manager.ts
+++ b/lib/package-managers/abstract.package-manager.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { bold, gray, red } from 'ansis';
 import { readFile } from 'fs';
 import * as ora from 'ora';
 import { join } from 'path';
@@ -34,17 +34,17 @@ export abstract class AbstractPackageManager {
       console.info(MESSAGES.PACKAGE_MANAGER_INSTALLATION_SUCCEED(directory));
       console.info(MESSAGES.GET_STARTED_INFORMATION);
       console.info();
-      console.info(chalk.gray(MESSAGES.CHANGE_DIR_COMMAND(directory)));
-      console.info(chalk.gray(MESSAGES.START_COMMAND(packageManager)));
+      console.info(gray(MESSAGES.CHANGE_DIR_COMMAND(directory)));
+      console.info(gray(MESSAGES.START_COMMAND(packageManager)));
       console.info();
     } catch {
       spinner.fail();
       const commandArgs = this.cli.install;
       const commandToRun = this.runner.rawFullCommand(commandArgs);
       console.error(
-        chalk.red(
+        red(
           MESSAGES.PACKAGE_MANAGER_INSTALLATION_FAILED(
-            chalk.bold(commandToRun),
+            bold(commandToRun),
           ),
         ),
       );

--- a/lib/runners/abstract.runner.ts
+++ b/lib/runners/abstract.runner.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { red } from 'ansis';
 import { ChildProcess, spawn, SpawnOptions } from 'child_process';
 import { MESSAGES } from '../ui';
 
@@ -35,7 +35,7 @@ export class AbstractRunner {
           resolve(null);
         } else {
           console.error(
-            chalk.red(
+            red(
               MESSAGES.RUNNER_EXECUTION_ERROR(`${this.binary} ${command}`),
             ),
           );

--- a/lib/runners/runner.factory.ts
+++ b/lib/runners/runner.factory.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { yellow } from 'ansis';
 import { NpmRunner } from './npm.runner';
 import { Runner } from './runner';
 import { SchematicRunner } from './schematic.runner';
@@ -21,7 +21,7 @@ export class RunnerFactory {
         return new PnpmRunner();
 
       default:
-        console.info(chalk.yellow(`[WARN] Unsupported runner: ${runner}`));
+        console.info(yellow`[WARN] Unsupported runner: ${runner}`);
     }
   }
 }

--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import { green } from 'ansis';
 import { EMOJIS } from './emojis';
 
 export const MESSAGES = {
@@ -18,7 +18,7 @@ export const MESSAGES = {
   GIT_INITIALIZATION_ERROR: 'Git repository has not been initialized',
   PACKAGE_MANAGER_INSTALLATION_SUCCEED: (name: string) =>
     name !== '.'
-      ? `${EMOJIS.ROCKET}  Successfully created project ${chalk.green(name)}`
+      ? `${EMOJIS.ROCKET}  Successfully created project ${green(name)}`
       : `${EMOJIS.ROCKET}  Successfully created a new project`,
   GET_STARTED_INFORMATION: `${EMOJIS.POINT_RIGHT}  Get started with the following commands:`,
   CHANGE_DIR_COMMAND: (name: string) => `$ cd ${name}`,

--- a/lib/ui/prefixes.ts
+++ b/lib/ui/prefixes.ts
@@ -1,8 +1,8 @@
-import * as chalk from 'chalk';
+import { bgRgb } from 'ansis';
 
-export const ERROR_PREFIX = chalk.bgRgb(210, 0, 75).bold.rgb(0, 0, 0)(
+export const ERROR_PREFIX = bgRgb(210, 0, 75).bold.rgb(0, 0, 0)(
   ' Error ',
 );
-export const INFO_PREFIX = chalk.bgRgb(60, 190, 100).bold.rgb(0, 0, 0)(
+export const INFO_PREFIX = bgRgb(60, 190, 100).bold.rgb(0, 0, 0)(
   ' Info ',
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@nestjs/cli",
-  "version": "10.4.8",
+  "version": "11.0.0-next.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nestjs/cli",
-      "version": "10.4.8",
+      "version": "11.0.0-next.4",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": "19.0.1",
         "@angular-devkit/schematics": "19.0.1",
         "@angular-devkit/schematics-cli": "19.0.1",
         "@inquirer/prompts": "5.3.8",
-        "@nestjs/schematics": "^10.0.1",
-        "chalk": "4.1.2",
+        "@nestjs/schematics": "next",
+        "ansis": "3.4.0",
         "chokidar": "4.0.1",
         "cli-table3": "0.6.5",
         "commander": "4.1.1",
@@ -59,7 +59,7 @@
         "ts-node": "10.9.2"
       },
       "engines": {
-        "node": ">= 16.14"
+        "node": ">= 20.11"
       },
       "peerDependencies": {
         "@swc/cli": "^0.1.62 || ^0.3.0 || ^0.4.0 || ^0.5.0",
@@ -4153,6 +4153,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.4.0.tgz",
+      "integrity": "sha512-zVESKSQhWaPhGaWiKj1k+UqvpC7vPBBgG3hjQEeIx2YGzylWt8qA3ziAzRuUtm0OnaGsZKjIvfl8D/sJTt/I0w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/anymatch": {
@@ -16695,6 +16704,11 @@
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
+    },
+    "ansis": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.4.0.tgz",
+      "integrity": "sha512-zVESKSQhWaPhGaWiKj1k+UqvpC7vPBBgG3hjQEeIx2YGzylWt8qA3ziAzRuUtm0OnaGsZKjIvfl8D/sJTt/I0w=="
     },
     "anymatch": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@angular-devkit/schematics-cli": "19.0.1",
     "@inquirer/prompts": "5.3.8",
     "@nestjs/schematics": "next",
-    "chalk": "4.1.2",
+    "ansis": "3.4.0",
     "chokidar": "4.0.1",
     "cli-table3": "0.6.5",
     "commander": "4.1.1",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR replaces the outdated [chalk@4](https://www.npmjs.com/package/chalk/v/4.1.2) (`64 kB` install size, 2 dependencies) package with smaller and faster [ansis](https://github.com/webdiscus/ansis).

### Benefits of `ansis`

- ansis is compatible with chalk API, plus supports [named import](https://github.com/webdiscus/ansis#named-import):  `import { red,  bold, bgRgb } from 'ansis'`
- Installed package size only `10KB` (no dependencies), see [Compare the size of most popular packages](https://github.com/webdiscus/ansis#compare-size)
- faster than `chalk`, see [Benchmarks](https://github.com/webdiscus/ansis#benchmark)
- using [named import](https://github.com/webdiscus/ansis#named-import) your code will be clean and more readable:
  ```diff
  - `See ${chalk.red('--help')} for a list of available commands.\n`,
  + `See ${red`--help`} for a list of available commands.\n`, // <= shorter and more readable
  ```

### Packages that already use `ansis`

- [nestjs/nest](https://github.com/nestjs/nest), [PR](https://github.com/nestjs/nest/pull/14155)
- [sequelize/core](https://github.com/sequelize/sequelize/blob/main/packages/core/package.json)
- [facebook/stylex](https://github.com/facebook/stylex/blob/main/packages/cli/package.json)
- [salesforcecli/cli](https://github.com/salesforcecli/cli/blob/main/package.json)
- [grafana/faro-javascript-bundler-plugins](https://github.com/grafana/faro-javascript-bundler-plugins/blob/main/packages/faro-bundlers-shared/package.json)
- and [thousands others](https://github.com/webdiscus/ansis/network/dependents)


### Alternatives

Today are actual two fastest and smallest libraries:: `picocolors` and `ansis`.
Both are [recommended](https://github.com/es-tooling/ecosystem-cleanup/issues/132#issuecomment-2532027854) by the [ES Tooling](https://github.com/es-tooling) community .

`picocolors` vs `ansis`, see the [Compare features](https://github.com/webdiscus/ansis?tab=readme-ov-file#compare)

- install size
  - `picocolors` -  `6.3 kB`
  - `ansis`      - `10.3 kB`
- [performance](https://github.com/webdiscus/ansis?tab=readme-ov-file#benchmark)
  - using singe color, `picocolors` is fastest
  - using 2 and more color/styles, `ansis` is fastest
- truecolor
  - `picocolors` doesn't supports the truecolor
  - `ansis` has rgb() and hex() functions, e.g. `bgRgb(60, 190, 100).bold.rgb(0, 0, 0)(' Info ');`
     ansis supports [fallback](https://github.com/webdiscus/ansis#fallback-1) to supported color space:
    `TrueColor —> 256 colors —> 16 colors —> no colors (black & white)`
- chained syntax
  - `picocolors` doesn't supports chained syntax: `picocolors.bgCyan(picocolors.bold(' SWC '))`
  - `ansis` supports chained syntax: `bgCyan.bold(' SWC ')` <= more readable and shorter

## Test

This PR does not require unit/integration tests.

But you can do the `manual test`.

### Install the fork

```
git clone https://github.com/webdiscus/ansis-nest-cli.git
cd ansis-nest-cli
git checkout switch-to-ansis
npm i
npm run build
```

### Test changed files
- commands/generate.command.ts

Cmd:
```
npm start
```

In console output will be displayed color text:
![Generate a Graphol resolver declaration](https://github.com/user-attachments/assets/a9229afe-6ba0-4b4a-8597-d9d93d851ad6)


### Test changed files
- commands/command.loader.ts
- lib/ui/prefixes.ts (RGB prefix)

Cmd:
```
npm start hello
```

In console output will be displayed color text:
![Invalid command](https://github.com/user-attachments/assets/c927133a-7c27-4a6d-9ecd-17682320585d)


### Test changed files
- actions/info.action.ts

Cmd:
```
npm start i
```

In console output will be displayed color text:
![~DevelProjectsGitHubForksansis-nest-cli (master x)• D npm start i](https://github.com/user-attachments/assets/e527ec47-2c04-4aa8-84cc-4506b6e77514)


### Test changed files
- actions/new.action.ts
- lib/ui/messages.ts

Cmd:
```
npm start new
```

In console output will be displayed color text:
![CREATE apptsconfig build json (97 bytes)](https://github.com/user-attachments/assets/0bad5987-4518-4bc9-ba58-e44a639a0700)

