### PR TITLE
feat(swc): add reload application when compiling to mjs

### DIFF
--- a/lib/compiler/swc/swc-compiler.ts
+++ b/lib/compiler/swc/swc-compiler.ts
@@ -254,7 +254,8 @@ export class SwcCompiler extends BaseCompiler {
       : join(process.cwd(), options.cliOptions.outDir!);
     const watcher = chokidar.watch(dir, {
       ignored: (file, stats) =>
-        (stats?.isFile() && !file.endsWith('.js')) as boolean,
+        (stats?.isFile() &&
+          !(file.endsWith('.js') || file.endsWith('.mjs'))) as boolean,
       ignoreInitial: true,
       awaitWriteFinish: {
         stabilityThreshold: 50,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using SWC to compile to `.mjs` files for ESM javascript hotreloading when using `nest start --watch` does function correctly because it only checks for `.js` files

Issue Number: N/A


## What is the new behavior?

Now it will also reload when compiling to `.mjs`


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
