### PR TITLE
style: adjust spacing after heart emoji in package_manager_question

### DIFF
--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -10,7 +10,7 @@ export const MESSAGES = {
   PROJECT_INFORMATION_START: `${EMOJIS.SPARKLES}  We will scaffold your app in a few seconds..`,
   RUNNER_EXECUTION_ERROR: (command: string) =>
     `\nFailed to execute command: ${command}`,
-  PACKAGE_MANAGER_QUESTION: `Which package manager would you ${EMOJIS.HEART} to use?`,
+  PACKAGE_MANAGER_QUESTION: `Which package manager would you ${EMOJIS.HEART}  to use?`,
   PACKAGE_MANAGER_INSTALLATION_IN_PROGRESS: `Installation in progress... ${EMOJIS.COFFEE}`,
   PACKAGE_MANAGER_UPDATE_IN_PROGRESS: `Installation in progress... ${EMOJIS.COFFEE}`,
   PACKAGE_MANAGER_UPGRADE_IN_PROGRESS: `Installation in progress... ${EMOJIS.COFFEE}`,


### PR DESCRIPTION
When using `nest new <projectname>` a message shows up like this:
`Which package manager would you ❤️to use?`

Adding a space makes it more consistent with the other messages in the file, where a double space after the emoji is already present.