### PR TITLE
feat: support multiple `--env-file` arguments

### DIFF
--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -20,6 +20,12 @@ import {
 } from '../lib/utils/project-utils';
 import { AbstractAction } from './abstract.action';
 
+function assertNonArray<T>(value: T): asserts value is Exclude<T, any[]> {
+  if (Array.isArray(value)) {
+    throw new TypeError('Expected a non-array value');
+  }
+}
+
 export class GenerateAction extends AbstractAction {
   public async handle(inputs: Input[], options: Input[]) {
     await generateFiles(inputs.concat(options));
@@ -153,6 +159,7 @@ const mapSchematicOptions = (inputs: Input[]): SchematicOption[] => {
   const options: SchematicOption[] = [];
   inputs.forEach((input) => {
     if (!excludedInputNames.includes(input.name) && input.value !== undefined) {
+      assertNonArray(input.value);
       options.push(new SchematicOption(input.name, input.value));
     }
   });

--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -19,12 +19,7 @@ import {
   shouldGenerateSpec,
 } from '../lib/utils/project-utils';
 import { AbstractAction } from './abstract.action';
-
-function assertNonArray<T>(value: T): asserts value is Exclude<T, any[]> {
-  if (Array.isArray(value)) {
-    throw new TypeError('Expected a non-array value');
-  }
-}
+import { assertNonArray } from '../lib/utils/type-assertions';
 
 export class GenerateAction extends AbstractAction {
   public async handle(inputs: Input[], options: Input[]) {

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -23,6 +23,7 @@ import { EMOJIS, MESSAGES } from '../lib/ui';
 import { normalizeToKebabOrSnakeCase } from '../lib/utils/formatting';
 import { gracefullyExitOnPromptError } from '../lib/utils/gracefully-exit-on-prompt-error';
 import { AbstractAction } from './abstract.action';
+import { assertNonArray } from '../lib/utils/type-assertions';
 
 export class NewAction extends AbstractAction {
   public async handle(inputs: Input[], options: Input[]) {
@@ -62,12 +63,6 @@ export class NewAction extends AbstractAction {
       printCollective();
     }
     process.exit(0);
-  }
-}
-
-function assertNonArray<T>(value: T): asserts value is Exclude<T, any[]> {
-  if (Array.isArray(value)) {
-    throw new TypeError('Expected a non-array value');
   }
 }
 

--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -65,6 +65,12 @@ export class NewAction extends AbstractAction {
   }
 }
 
+function assertNonArray<T>(value: T): asserts value is Exclude<T, any[]> {
+  if (Array.isArray(value)) {
+    throw new TypeError('Expected a non-array value');
+  }
+}
+
 const getApplicationNameInput = (inputs: Input[]) =>
   inputs.find((input) => input.name === 'name');
 
@@ -133,6 +139,7 @@ const mapSchematicOptions = (options: Input[]): SchematicOption[] => {
   return options.reduce(
     (schematicOptions: SchematicOption[], option: Input) => {
       if (option.name !== 'skip-install') {
+        assertNonArray(option.value);
         schematicOptions.push(new SchematicOption(option.name, option.value));
       }
       return schematicOptions;

--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -14,6 +14,12 @@ import { ERROR_PREFIX } from '../lib/ui';
 import { treeKillSync as killProcessSync } from '../lib/utils/tree-kill';
 import { BuildAction } from './build.action';
 
+function assertNonArray<T>(value: T): asserts value is Exclude<T, any[]> {
+  if (Array.isArray(value)) {
+    throw new TypeError('Expected a non-array value');
+  }
+}
+
 export class StartAction extends BuildAction {
   public async handle(commandInputs: Input[], commandOptions: Input[]) {
     try {
@@ -44,6 +50,8 @@ export class StartAction extends BuildAction {
         watchAssetsModeOption && watchAssetsModeOption.value
       );
       const debugFlag = debugModeOption && debugModeOption.value;
+      assertNonArray(debugFlag);
+
       const binaryToRun = getValueOrDefault(
         configuration,
         'exec',
@@ -81,7 +89,7 @@ export class StartAction extends BuildAction {
       const envFileOption = commandOptions.find(
         (option) => option.name === 'envFile',
       );
-      const envFile = envFileOption?.value as string;
+      const envFile = (envFileOption?.value ?? []) as string[];
 
       const onSuccess = this.createOnSuccessHook(
         entryFile,
@@ -120,7 +128,7 @@ export class StartAction extends BuildAction {
     binaryToRun: string,
     options: {
       shell: boolean;
-      envFile?: string;
+      envFile?: string[];
     },
   ) {
     let childProcessRef: any;
@@ -177,7 +185,7 @@ export class StartAction extends BuildAction {
     binaryToRun: string,
     options: {
       shell: boolean;
-      envFile?: string;
+      envFile?: string[];
     },
   ) {
     let outputFilePath = join(outDirName, sourceRoot, entryFile);
@@ -206,9 +214,14 @@ export class StartAction extends BuildAction {
         typeof debug === 'string' ? `--inspect=${debug}` : '--inspect';
       processArgs.unshift(inspectFlag);
     }
-    if (options.envFile) {
-      processArgs.unshift(`--env-file=${options.envFile}`);
+
+    if (options.envFile && options.envFile.length > 0) {
+      const envFileNodeArgs = options.envFile.map(
+        (envFilePath) => `--env-file=${envFilePath}`,
+      );
+      processArgs.unshift(envFileNodeArgs.join(' '));
     }
+
     processArgs.unshift('--enable-source-maps');
 
     return spawn(binaryToRun, processArgs, {

--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -13,12 +13,7 @@ import {
 import { ERROR_PREFIX } from '../lib/ui';
 import { treeKillSync as killProcessSync } from '../lib/utils/tree-kill';
 import { BuildAction } from './build.action';
-
-function assertNonArray<T>(value: T): asserts value is Exclude<T, any[]> {
-  if (Array.isArray(value)) {
-    throw new TypeError('Expected a non-array value');
-  }
-}
+import { assertNonArray } from '../lib/utils/type-assertions';
 
 export class StartAction extends BuildAction {
   public async handle(commandInputs: Input[], commandOptions: Input[]) {

--- a/commands/command.input.ts
+++ b/commands/command.input.ts
@@ -1,5 +1,5 @@
 export interface Input {
   name: string;
-  value: boolean | string;
+  value: boolean | string | string[];
   options?: any;
 }

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -6,6 +6,10 @@ import { Input } from './command.input';
 
 export class StartCommand extends AbstractCommand {
   public load(program: CommanderStatic): void {
+    const collect = (value: any, previous: any) => {
+      return previous.concat([value]);
+    };
+
     program
       .command('start [app]')
       .allowUnknownOption()
@@ -47,6 +51,8 @@ export class StartCommand extends AbstractCommand {
       .option(
         '--env-file [path]',
         'Path to an env file (.env) to be loaded into the environment.',
+        collect,
+        [],
       )
       .description('Run Nest application.')
       .action(async (app: string, command: Command) => {

--- a/lib/utils/type-assertions.ts
+++ b/lib/utils/type-assertions.ts
@@ -1,0 +1,7 @@
+export function assertNonArray<T>(
+  value: T,
+): asserts value is Exclude<T, any[]> {
+  if (Array.isArray(value)) {
+    throw new TypeError('Expected a non-array value');
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #2981


## What is the new behavior?

just like nodejs's `--env-file` feature, Nest CLI will support supplying multiple `--env-file` arguments  

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
