### PR TITLE
feat: Integrate Bun as a package manager

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -170,7 +170,7 @@ const installPackages = async (
 const askForPackageManager = async () => {
   const question = generateSelect('packageManager')(
     MESSAGES.PACKAGE_MANAGER_QUESTION,
-  )([PackageManager.NPM, PackageManager.YARN, PackageManager.PNPM]);
+  )([PackageManager.NPM, PackageManager.YARN, PackageManager.PNPM, PackageManager.BUN]);
 
   return select(question).catch(gracefullyExitOnPromptError);
 };

--- a/lib/package-managers/bun.package-manager.ts
+++ b/lib/package-managers/bun.package-manager.ts
@@ -1,0 +1,27 @@
+import { Runner, RunnerFactory } from '../runners';
+import { BunRunner } from '../runners/bun.runner';
+import { AbstractPackageManager } from './abstract.package-manager';
+import { PackageManager } from './package-manager';
+import { PackageManagerCommands } from './package-manager-commands';
+
+export class BunPackageManager extends AbstractPackageManager {
+  constructor() {
+    super(RunnerFactory.create(Runner.BUN) as BunRunner);
+  }
+
+  public get name() {
+    return PackageManager.BUN.toUpperCase();
+  }
+
+  get cli(): PackageManagerCommands {
+    return {
+      install: 'install',
+      add: 'add',
+      update: 'update',
+      remove: 'remove',
+      saveFlag: '',
+      saveDevFlag: '--development',
+      silentFlag: '--silent',
+    };
+  }
+}

--- a/lib/package-managers/index.ts
+++ b/lib/package-managers/index.ts
@@ -4,5 +4,6 @@ export * from './abstract.package-manager';
 export * from './npm.package-manager';
 export * from './yarn.package-manager';
 export * from './pnpm.package-manager';
+export * from './bun.package-manager';
 export * from './project.dependency';
 export * from './package-manager-commands';

--- a/lib/package-managers/package-manager.factory.ts
+++ b/lib/package-managers/package-manager.factory.ts
@@ -4,6 +4,7 @@ import { NpmPackageManager } from './npm.package-manager';
 import { PackageManager } from './package-manager';
 import { YarnPackageManager } from './yarn.package-manager';
 import { PnpmPackageManager } from './pnpm.package-manager';
+import { BunPackageManager } from './bun.package-manager';
 
 export class PackageManagerFactory {
   public static create(name: PackageManager | string): AbstractPackageManager {
@@ -14,6 +15,8 @@ export class PackageManagerFactory {
         return new YarnPackageManager();
       case PackageManager.PNPM:
         return new PnpmPackageManager();
+      case PackageManager.BUN:
+        return new BunPackageManager();
       default:
         throw new Error(`Package manager ${name} is not managed.`);
     }
@@ -24,6 +27,11 @@ export class PackageManagerFactory {
 
     try {
       const files = await fs.promises.readdir(process.cwd());
+
+      const hasBunLockFile = files.includes('bun.lockb');
+      if (hasBunLockFile) {
+        return this.create(PackageManager.BUN);
+      }
 
       const hasYarnLockFile = files.includes('yarn.lock');
       if (hasYarnLockFile) {

--- a/lib/package-managers/package-manager.ts
+++ b/lib/package-managers/package-manager.ts
@@ -2,4 +2,5 @@ export enum PackageManager {
   NPM = 'npm',
   YARN = 'yarn',
   PNPM = 'pnpm',
+  BUN = 'bun',
 }

--- a/lib/runners/bun.runner.ts
+++ b/lib/runners/bun.runner.ts
@@ -1,0 +1,7 @@
+import { AbstractRunner } from './abstract.runner';
+
+export class BunRunner extends AbstractRunner {
+  constructor() {
+    super('bun');
+  }
+}

--- a/lib/runners/runner.factory.ts
+++ b/lib/runners/runner.factory.ts
@@ -4,6 +4,7 @@ import { Runner } from './runner';
 import { SchematicRunner } from './schematic.runner';
 import { YarnRunner } from './yarn.runner';
 import { PnpmRunner } from './pnpm.runner';
+import { BunRunner } from './bun.runner';
 
 export class RunnerFactory {
   public static create(runner: Runner) {
@@ -19,6 +20,9 @@ export class RunnerFactory {
 
       case Runner.PNPM:
         return new PnpmRunner();
+
+      case Runner.BUN:
+        return new BunRunner();
 
       default:
         console.info(yellow`[WARN] Unsupported runner: ${runner}`);

--- a/lib/runners/runner.ts
+++ b/lib/runners/runner.ts
@@ -3,4 +3,5 @@ export enum Runner {
   NPM,
   YARN,
   PNPM,
+  BUN
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "tree-kill": "1.2.2",
         "tsconfig-paths": "4.2.0",
         "tsconfig-paths-webpack-plugin": "4.2.0",
-        "typescript": "5.8.3",
         "webpack": "5.99.6",
         "webpack-node-externals": "3.0.0"
       },
@@ -35,10 +34,11 @@
       "devDependencies": {
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-angular": "19.8.1",
+        "@jest/globals": "^29.7.0",
         "@swc/cli": "0.7.7",
         "@swc/core": "1.11.29",
         "@types/inquirer": "9.0.8",
-        "@types/jest": "29.5.14",
+        "@types/jest": "^29.5.14",
         "@types/node": "22.15.21",
         "@types/node-emoji": "1.8.2",
         "@types/webpack-node-externals": "3.0.4",
@@ -50,13 +50,14 @@
         "gulp": "5.0.0",
         "gulp-clean": "0.4.0",
         "husky": "9.1.7",
-        "jest": "29.7.0",
+        "jest": "^29.7.0",
         "lint-staged": "16.0.0",
         "prettier": "3.5.3",
         "release-it": "19.0.2",
-        "ts-jest": "29.3.4",
+        "ts-jest": "^29.3.4",
         "ts-loader": "9.5.2",
-        "ts-node": "10.9.2"
+        "ts-node": "10.9.2",
+        "typescript": "^5.8.3"
       },
       "engines": {
         "node": ">= 20.11"
@@ -2066,6 +2067,7 @@
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -3243,6 +3245,7 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -7852,6 +7855,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -11953,6 +11957,7 @@
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
       "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",
@@ -12150,6 +12155,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -54,17 +54,17 @@
     "tree-kill": "1.2.2",
     "tsconfig-paths": "4.2.0",
     "tsconfig-paths-webpack-plugin": "4.2.0",
-    "typescript": "5.8.3",
     "webpack": "5.99.6",
     "webpack-node-externals": "3.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-angular": "19.8.1",
+    "@jest/globals": "^29.7.0",
     "@swc/cli": "0.7.7",
     "@swc/core": "1.11.29",
     "@types/inquirer": "9.0.8",
-    "@types/jest": "29.5.14",
+    "@types/jest": "^29.5.14",
     "@types/node": "22.15.21",
     "@types/node-emoji": "1.8.2",
     "@types/webpack-node-externals": "3.0.4",
@@ -76,13 +76,14 @@
     "gulp": "5.0.0",
     "gulp-clean": "0.4.0",
     "husky": "9.1.7",
-    "jest": "29.7.0",
+    "jest": "^29.7.0",
     "lint-staged": "16.0.0",
     "prettier": "3.5.3",
     "release-it": "19.0.2",
-    "ts-jest": "29.3.4",
+    "ts-jest": "^29.3.4",
     "ts-loader": "9.5.2",
-    "ts-node": "10.9.2"
+    "ts-node": "10.9.2",
+    "typescript": "^5.8.3"
   },
   "lint-staged": {
     "**/*.{ts,json}": []

--- a/test/lib/package-managers/bun.package-manager.spec.ts
+++ b/test/lib/package-managers/bun.package-manager.spec.ts
@@ -1,0 +1,200 @@
+import { join } from 'path';
+import {
+  BunPackageManager,
+  PackageManagerCommands,
+} from '../../../lib/package-managers';
+import { BunRunner } from '../../../lib/runners/bun.runner';
+
+// Mock the BunRunner to control its behavior during tests
+jest.mock('../../../lib/runners/bun.runner');
+
+/**
+ * Test suite for the BunPackageManager class.
+ */
+describe('BunPackageManager', () => {
+  let packageManager: BunPackageManager;
+  let mockRun: jest.Mock;
+
+  beforeEach(() => {
+    (BunRunner as any).mockClear();
+    mockRun = jest.fn().mockResolvedValue(undefined);
+    (BunRunner as any).mockImplementation(() => {
+      return {
+        run: mockRun,
+        rawFullCommand: jest.fn().mockImplementation((cmd: string) => `bun ${cmd}`),
+      };
+    });
+    packageManager = new BunPackageManager();
+  });
+
+  it('should be created', () => {
+    // Ensures the package manager instance is correctly created.
+    expect(packageManager).toBeInstanceOf(BunPackageManager);
+  });
+
+  it('should have the correct cli commands', () => {
+    // Verifies that the CLI command structure for Bun is accurately defined.
+    // These commands are used by the AbstractPackageManager to execute package management operations.
+    const expectedValues: PackageManagerCommands = {
+      install: 'install',
+      add: 'add',
+      update: 'update',
+      remove: 'remove',
+      saveFlag: '',
+      saveDevFlag: '--development',
+      silentFlag: '--silent',
+    };
+    expect(packageManager.cli).toMatchObject(expectedValues);
+  });
+
+  /**
+   * Tests for the `install` method.
+   */
+  describe('install', () => {
+    it('should use the correct command for installing dependencies', async () => {
+      const dirName = '/tmp';
+      const testDir = join(process.cwd(), dirName);
+      await packageManager.install(dirName, 'bun');
+
+      // AbstractPackageManager appends the silentFlag to the install command.
+      // For Bun: "install" + " " + "--silent"
+      expect(mockRun).toHaveBeenCalledWith('install --silent', true, testDir);
+    });
+  });
+
+  /**
+   * Tests for the `addProduction` method.
+   */
+  describe('addProduction', () => {
+    it('should use the correct command for adding production dependencies', async () => {
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = 'latest';
+
+      // AbstractPackageManager: `this.cli.add` + `this.cli.saveFlag` (which is empty for Bun)
+      // For Bun: "add dep1@tag dep2@tag"
+      const command = `add ${dependencies
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
+      await packageManager.addProduction(dependencies, tag);
+      expect(mockRun).toHaveBeenCalledWith(command.trim(), true);
+    });
+  });
+
+  /**
+   * Tests for the `addDevelopment` method.
+   */
+  describe('addDevelopment', () => {
+    it('should use the correct command for adding development dependencies', async () => {
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      const tag = 'latest';
+
+      // AbstractPackageManager: `this.cli.add` + `this.cli.saveDevFlag`
+      // For Bun: "add --development dep1@tag dep2@tag"
+      const command = `add --development ${dependencies
+        .map((dependency) => `${dependency}@${tag}`)
+        .join(' ')}`;
+      await packageManager.addDevelopment(dependencies, tag);
+      expect(mockRun).toHaveBeenCalledWith(command, true);
+    });
+  });
+
+  /**
+   * Tests for the `updateProduction` method.
+   */
+  describe('updateProduction', () => {
+    it('should use the correct command for updating production dependencies', async () => {
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      // AbstractPackageManager: `this.cli.update` + dependencies
+      // For Bun: "update dep1 dep2"
+      const command = `update ${dependencies.join(' ')}`;
+      await packageManager.updateProduction(dependencies);
+      expect(mockRun).toHaveBeenCalledWith(command, true);
+    });
+  });
+
+  /**
+   * Tests for the `updateDevelopment` method.
+   */
+  describe('updateDevelopment', () => {
+    it('should use the correct command for updating development dependencies', async () => {
+      const dependencies = ['@types/node', 'typescript'];
+      // AbstractPackageManager: `this.cli.update` + dependencies
+      // For Bun: "update dep1 dep2" (Bun's update doesn't typically differentiate between prod/dev for the command itself)
+      const command = `update ${dependencies.join(' ')}`;
+      await packageManager.updateDevelopment(dependencies);
+      expect(mockRun).toHaveBeenCalledWith(command, true);
+    });
+  });
+
+  /**
+   * Tests for the `upgradeProduction` method.
+   * This method first deletes then adds the dependencies.
+   */
+  describe('upgradeProduction', () => {
+    it('should use correct commands for upgrading production dependencies', async () => {
+      const dependencies = ['@nestjs/common'];
+      const tag = 'next';
+
+      // Expected delete command: "remove @nestjs/common" (saveFlag is empty for Bun)
+      const deleteCommand = `remove ${dependencies.join(' ')}`;
+      // Expected add command: "add @nestjs/common@next"
+      const addCommand = `add ${dependencies
+        .map((dep) => `${dep}@${tag}`)
+        .join(' ')}`;
+
+      await packageManager.upgradeProduction(dependencies, tag);
+      expect(mockRun).toHaveBeenCalledWith(deleteCommand.trim(), true);
+      expect(mockRun).toHaveBeenCalledWith(addCommand.trim(), true);
+    });
+  });
+
+  /**
+   * Tests for the `upgradeDevelopment` method.
+   * This method first deletes then adds the dependencies with dev flag.
+   */
+  describe('upgradeDevelopment', () => {
+    it('should use correct commands for upgrading development dependencies', async () => {
+      const dependencies = ['eslint'];
+      const tag = 'latest';
+
+      // Expected delete command: "remove --development eslint"
+      const deleteCommand = `remove --development ${dependencies.join(' ')}`;
+      // Expected add command: "add --development eslint@latest"
+      const addCommand = `add --development ${dependencies
+        .map((dep) => `${dep}@${tag}`)
+        .join(' ')}`;
+
+      await packageManager.upgradeDevelopment(dependencies, tag);
+      expect(mockRun).toHaveBeenCalledWith(deleteCommand, true);
+      expect(mockRun).toHaveBeenCalledWith(addCommand, true);
+    });
+  });
+
+  /**
+   * Tests for the `deleteProduction` method.
+   */
+  describe('deleteProduction', () => {
+    it('should use the correct command for deleting production dependencies', async () => {
+      const dependencies = ['@nestjs/common', '@nestjs/core'];
+      // AbstractPackageManager: `this.cli.remove` (saveFlag is empty for Bun) + dependencies
+      // For Bun: "remove dep1 dep2"
+      const command = `remove ${dependencies.join(' ')}`;
+      await packageManager.deleteProduction(dependencies);
+      expect(mockRun).toHaveBeenCalledWith(command.trim(), true);
+    });
+  });
+
+  /**
+   * Tests for the `deleteDevelopment` method.
+   */
+  describe('deleteDevelopment', () => {
+    it('should use the correct command for deleting development dependencies', async () => {
+      const dependencies = ['@types/jest', 'ts-node'];
+      // AbstractPackageManager: `this.cli.remove` + `this.cli.saveDevFlag` + dependencies
+      // For Bun: "remove --development dep1 dep2"
+      const command = `remove --development ${dependencies.join(' ')}`;
+      await packageManager.deleteDevelopment(dependencies);
+      expect(mockRun).toHaveBeenCalledWith(command, true);
+    });
+  });
+});


### PR DESCRIPTION
## PR Description:

**feat(cli): Add Bun support & improve test config**

This PR introduces Bun as a supported package manager in the Nest CLI, allowing users to leverage its speed.

**Key Changes:**
- Users can now select/auto-detect Bun for project scaffolding and dependency management.
- Added `BunPackageManager` and `BunRunner` for Bun-specific command execution.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Tests for the changes have been added.
- [ ] Docs have been added / updated.

## PR Type
What kind of change does this PR introduce?

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
No Bun support.

Issue Number: N/A

## What is the new behavior?
Adds Bun as a package manager option.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
N/A