### PR TITLE
refactor(cli): simplify and clean up new command option mapping

### DIFF
--- a/commands/new.command.ts
+++ b/commands/new.command.ts
@@ -17,10 +17,7 @@ export class NewCommand extends AbstractCommand {
       )
       .option('-g, --skip-git', 'Skip git repository initialization.', false)
       .option('-s, --skip-install', 'Skip package installation.', false)
-      .option(
-        '-p, --package-manager [packageManager]',
-        'Specify package manager.',
-      )
+      .option('-p, --package-manager [packageManager]', 'Specify package manager.')
       .option(
         '-l, --language [language]',
         'Programming language to be used (TypeScript or JavaScript)',
@@ -33,46 +30,41 @@ export class NewCommand extends AbstractCommand {
       )
       .option('--strict', 'Enables strict mode in TypeScript.', false)
       .action(async (name: string, command: Command) => {
-        const options: Input[] = [];
-        const availableLanguages = ['js', 'ts', 'javascript', 'typescript'];
-        options.push({ name: 'directory', value: command.directory });
-        options.push({ name: 'dry-run', value: command.dryRun });
-        options.push({ name: 'skip-git', value: command.skipGit });
-        options.push({ name: 'skip-install', value: command.skipInstall });
-        options.push({ name: 'strict', value: command.strict });
-        options.push({
-          name: 'packageManager',
-          value: command.packageManager,
-        });
-        options.push({ name: 'collection', value: command.collection });
+        const langInput = command.language?.toLowerCase();
+        const langMap: Record<string, string> = {
+          javascript: 'js',
+          typescript: 'ts',
+        };
 
-        if (!!command.language) {
-          const lowercasedLanguage = command.language.toLowerCase();
-          const langMatch = availableLanguages.includes(lowercasedLanguage);
-          if (!langMatch) {
-            throw new Error(
-              `Invalid language "${command.language}" selected. Available languages are "typescript" or "javascript"`,
-            );
-          }
-          switch (lowercasedLanguage) {
-            case 'javascript':
-              command.language = 'js';
-              break;
-            case 'typescript':
-              command.language = 'ts';
-              break;
-            default:
-              command.language = lowercasedLanguage;
-              break;
-          }
+        if (langInput && !['js', 'ts', 'javascript', 'typescript'].includes(langInput)) {
+          throw new Error(
+            `Invalid language "${command.language}" selected. Available languages are "typescript" or "javascript".`,
+          );
         }
-        options.push({
-          name: 'language',
-          value: command.language,
-        });
 
-        const inputs: Input[] = [];
-        inputs.push({ name: 'name', value: name });
+        command.language = langMap[langInput] || langInput;
+
+        const cliKeys: Record<string, string> = {
+          dryRun: 'dry-run',
+          skipGit: 'skip-git',
+          skipInstall: 'skip-install',
+        };
+
+        const options: Input[] = [
+          'directory',
+          'dryRun',
+          'skipGit',
+          'skipInstall',
+          'strict',
+          'packageManager',
+          'collection',
+          'language',
+        ].map((key) => ({
+          name: cliKeys[key] ?? key,
+          value: command[key],
+        }));
+
+        const inputs: Input[] = [{ name: 'name', value: name }];
 
         await this.action.handle(inputs, options);
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `new` command contains repetitive logic for parsing and mapping CLI options.
Language validation and CLI option transformation are done manually and imperatively.

Issue Number: N/A


## What is the new behavior?
- Introduces a centralized language normalization map (`typescript` -> `ts`, etc.)
- Dynamically maps CLI flags into internal `Input[]` format
- Reduces repetitive `.push()` calls
- Improves readability and future extensibility

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This change does not affect CLI output or logic, only simplifies internal structure of the `new` command handler.