### PR TITLE
fix(@nestjs/cli): disable shell execution on unix to prevent command injection

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -2,6 +2,7 @@ import { red } from 'ansis';
 import { spawn } from 'child_process';
 import * as fs from 'fs';
 import { join } from 'path';
+import { platform } from 'os';
 import * as killProcess from 'tree-kill';
 import { Input } from '../commands';
 import { getTscConfigPath } from '../lib/compiler/helpers/get-tsc-config.path';
@@ -79,7 +80,8 @@ export class StartAction extends BuildAction {
       const shellOption = commandOptions.find(
         (option) => option.name === 'shell',
       );
-      const useShell = !!shellOption?.value;
+      const isWindows = platform() === 'win32';
+      const useShell = shellOption?.value !== false && isWindows;
 
       const envFileOption = commandOptions.find(
         (option) => option.name === 'envFile',

--- a/lib/runners/abstract.runner.ts
+++ b/lib/runners/abstract.runner.ts
@@ -1,5 +1,6 @@
 import { red } from 'ansis';
 import { ChildProcess, spawn, SpawnOptions } from 'child_process';
+import { platform } from 'os';
 import { MESSAGES } from '../ui';
 
 export class AbstractRunner {
@@ -14,14 +15,15 @@ export class AbstractRunner {
     cwd: string = process.cwd(),
   ): Promise<null | string> {
     const args: string[] = [command];
+    const isWindows = platform() === 'win32';
     const options: SpawnOptions = {
       cwd,
       stdio: collect ? 'pipe' : 'inherit',
-      shell: true,
+      shell: isWindows,
     };
     return new Promise<null | string>((resolve, reject) => {
       const child: ChildProcess = spawn(
-        `${this.binary}`,
+        this.binary,
         [...this.args, ...args],
         options,
       );

--- a/test/lib/runners/abstract.runner.security.spec.ts
+++ b/test/lib/runners/abstract.runner.security.spec.ts
@@ -1,0 +1,95 @@
+import { spawn } from 'child_process';
+import { platform } from 'os';
+import { AbstractRunner } from '../../../lib/runners/abstract.runner';
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+jest.mock('os', () => ({
+  platform: jest.fn(),
+}));
+
+describe('AbstractRunner Security Tests', () => {
+  let mockSpawn: jest.MockedFunction<typeof spawn>;
+  let mockPlatform: jest.MockedFunction<typeof platform>;
+
+  beforeEach(() => {
+    mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+    mockPlatform = platform as jest.MockedFunction<typeof platform>;
+
+    const mockChild = {
+      on: jest.fn((event: string, callback: (code: number) => void) => {
+        if (event === 'close') {
+          setTimeout(() => callback(0), 0);
+        }
+      }),
+    } as any;
+
+    mockSpawn.mockReturnValue(mockChild);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('Shell injection protection', () => {
+    it('should not use shell on macOS/Linux to prevent command injection', async () => {
+      mockPlatform.mockReturnValue('darwin');
+
+      const runner = new AbstractRunner('node');
+      await runner.run('$(malicious-command)');
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'node',
+        ['$(malicious-command)'],
+        expect.objectContaining({
+          shell: false,
+        }),
+      );
+    });
+
+    it('should not use shell on Linux to prevent variable expansion', async () => {
+      mockPlatform.mockReturnValue('linux');
+
+      const runner = new AbstractRunner('node');
+      await runner.run('$USER');
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'node',
+        ['$USER'],
+        expect.objectContaining({
+          shell: false,
+        }),
+      );
+    });
+
+    it('should use shell only on Windows for compatibility', async () => {
+      mockPlatform.mockReturnValue('win32');
+
+      const runner = new AbstractRunner('node');
+      await runner.run('test-command');
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'node',
+        ['test-command'],
+        expect.objectContaining({
+          shell: true,
+        }),
+      );
+    });
+
+    it('should pass commands as separate arguments, not concatenated strings', async () => {
+      mockPlatform.mockReturnValue('darwin');
+
+      const runner = new AbstractRunner('node', ['--enable-source-maps']);
+      await runner.run('dist/main.js');
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'node',
+        ['--enable-source-maps', 'dist/main.js'],
+        expect.any(Object),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The CLI currently enables shell execution (`shell: true`) on all platforms when spawning child processes. This creates a command injection vulnerability on Unix-like systems (macOS/Linux) where shell metacharacters can be exploited to execute malicious commands.

Commands containing `$()`, `${}`, or other shell expansions can potentially execute arbitrary code on the system.

Issue Number: #3064 


## What is the new behavior?

Shell execution is now disabled on Unix-like systems (macOS/Linux) while remaining enabled on Windows for compatibility. This prevents command injection attacks on Unix systems while maintaining cross-platform functionality.

**Changes:**
- Unix systems: `shell: false` - prevents shell metacharacter exploitation
- Windows: `shell: true` - maintains compatibility
- Commands are safely passed as separate arguments to prevent injection

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
