### PR TITLE
fix(@nestjs/cli): nest start --watch with swc will be initialized twice

### DIFF
--- a/test/lib/compiler/swc/swc-compiler.spec.ts
+++ b/test/lib/compiler/swc/swc-compiler.spec.ts
@@ -226,9 +226,9 @@ describe('SWC Compiler', () => {
       expect(compiler['debounce']).not.toHaveBeenCalled();
     });
 
-    it('should call debounce method with debounceTime and onSuccess method and when extras.watch is true', async () => {
+    it('should call debounce method with debounceTime and a callback function when extras.watch is true', async () => {
       const fixture = {
-        onSuccess: jest.fn(),
+        onSuccess: jest.fn().mockReturnValue({}),
       };
 
       await callRunCompiler({
@@ -238,7 +238,10 @@ describe('SWC Compiler', () => {
         },
       });
 
-      expect(compiler['debounce']).toHaveBeenCalledWith(fixture.onSuccess, 150);
+      expect(compiler['debounce']).toHaveBeenCalledWith(
+        expect.any(Function),
+        150,
+      );
     });
 
     it('should call watchFilesInOutDir method with swcOptions and callback when extras.watch is true', async () => {


### PR DESCRIPTION
ensure swc watcher only triggers initialization once on first run

Closes #3108

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3108 


## What is the new behavior?
The initialization is triggered only once on initial run

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
