### PR TITLE
refactor(dependency): Remove tree-kill dependency

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -2,7 +2,6 @@ import { red } from 'ansis';
 import { spawn } from 'child_process';
 import * as fs from 'fs';
 import { join } from 'path';
-import * as killProcess from 'tree-kill';
 import { Input } from '../commands';
 import { getTscConfigPath } from '../lib/compiler/helpers/get-tsc-config.path';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
@@ -151,7 +150,7 @@ export class StartAction extends BuildAction {
         });
 
         childProcessRef.stdin && childProcessRef.stdin.pause();
-        killProcess(childProcessRef.pid);
+        killProcessSync(childProcessRef.pid);
       } else {
         childProcessRef = this.spawnChildProcess(
           entryFile,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "glob": "11.0.3",
     "node-emoji": "1.11.0",
     "ora": "5.4.1",
-    "tree-kill": "1.2.2",
     "tsconfig-paths": "4.2.0",
     "tsconfig-paths-webpack-plugin": "4.2.0",
     "typescript": "5.8.3",


### PR DESCRIPTION
Remove external tree-kill dependency and use only local tree-kill code

Closes #3156

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
`start` action uses the abandoned `tree-kill` library while swc compiler code uses local tree-kill code.

Issue Number: 3156

## What is the new behavior?
`tree-kill` dependency is removed. `start` action uses the local tree-kill code.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
`tree-kill` NPM package has some file descriptor related issues for some on MacOS due to issues with use of `spawn` command to create the shell process to build the process tree. Forks of this library, and the local tree-kill code, use `execSync` instead, which helps with this issue.