### PR TITLE
fix(cli): resolve malformed paths in schematic runner

### DIFF
--- a/lib/runners/abstract.runner.ts
+++ b/lib/runners/abstract.runner.ts
@@ -14,7 +14,7 @@ export class AbstractRunner {
     collect = false,
     cwd: string = process.cwd(),
   ): Promise<null | string> {
-    const args: string[] = [command];
+    const commandArgs = command.split(' ');
     const isWindows = platform() === 'win32';
     const options: SpawnOptions = {
       cwd,
@@ -24,7 +24,7 @@ export class AbstractRunner {
     return new Promise<null | string>((resolve, reject) => {
       const child: ChildProcess = spawn(
         this.binary,
-        [...this.args, ...args],
+        [...this.args, ...commandArgs],
         options,
       );
       if (collect) {

--- a/lib/runners/schematic.runner.ts
+++ b/lib/runners/schematic.runner.ts
@@ -2,7 +2,7 @@ import { AbstractRunner } from './abstract.runner';
 
 export class SchematicRunner extends AbstractRunner {
   constructor() {
-    super(`node`, [`"${SchematicRunner.findClosestSchematicsBinary()}"`]);
+    super(`node`, [SchematicRunner.findClosestSchematicsBinary()]);
   }
 
   public static getModulePaths() {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3191 

- The schematic runner was wrapping the binary path in extra quotes, which caused malformed paths when spawning the process. Also, commands with spaces weren't being split properly into separate arguments.

- as we can see here
<img width="1920" height="630" alt="image" src="https://github.com/user-attachments/assets/710d3a07-d271-4d2d-8c40-a1e6865c2752" />

- already tried using multiple nodejs versions, 20, 22 and 24 (LTS latest) and using other node version manager (fnm, nvm, mise) and still resulting the same error.

## What is the new behavior?

- Removed unnecessary quotes around the schematics binary path in `SchematicRunner`
- Fixed command argument handling by properly splitting command strings into individual args before passing to `spawn()`

This ensures paths are resolved correctly and commands execute as expected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Just a small fix. The extra quotes were causing issues when node tried to execute the schematics binary.
