### PR TITLE
fix: Node v24 DEP0190 warning by removing args for shell: true

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -1,5 +1,5 @@
 import { red } from 'ansis';
-import { spawn } from 'child_process';
+import { spawn, SpawnOptions } from 'child_process';
 import * as fs from 'fs';
 import { join } from 'path';
 import { Input } from '../commands';
@@ -218,9 +218,16 @@ export class StartAction extends BuildAction {
 
     processArgs.unshift('--enable-source-maps');
 
-    return spawn(binaryToRun, processArgs, {
+    const spawnOptions: SpawnOptions = {
       stdio: 'inherit',
       shell: options.shell,
-    });
+    };
+
+    if (options.shell) {
+      const command = [binaryToRun, ...processArgs].join(' ');
+      return spawn(command, spawnOptions);
+    }
+
+    return spawn(binaryToRun, processArgs, spawnOptions);
   }
 }

--- a/lib/runners/abstract.runner.ts
+++ b/lib/runners/abstract.runner.ts
@@ -22,11 +22,8 @@ export class AbstractRunner {
       shell: true,
     };
     return new Promise<null | string>((resolve, reject) => {
-      const child: ChildProcess = spawn(
-        `${this.binary}`,
-        [...this.args, ...args],
-        options,
-      );
+      const command = [this.binary, ...this.args, ...args].join(' ');
+      const child: ChildProcess = spawn(command, options);
       if (collect) {
         child.stdout!.on('data', (data) =>
           resolve(data.toString().replace(/\r\n|\n/, '')),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Passing an args array together with `shell: true` triggers Node.js deprecation warning `DEP0190`

Issue Number: https://github.com/nestjs/nest/issues/15943


## What is the new behavior?

When shell is enabled, the CLI now passes a single command string to spawn instead of using the args array

This matches the pattern recommended by a Node.js member in
https://github.com/nodejs/help/issues/5063#issuecomment-3132899776


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

This change follows Node.js API guidance, rather than introducing a new escaping strategy.

Node.js deprecated the `args + shell: true` combination because the API shape gives a false impression that arguments are safely escaped, while they are in fact just concatenated into a single shell command string (see the DEP0190 change in [`normalizeSpawnArguments`](https://github.com/nodejs/node/pull/57199/files)).

This PR:

- Aligns the CLI with the recommended usage by passing a single command string when `shell: true`, and keeping `command + args` only when `shell` is `false` ([ the same pattern Node.js itself uses internally](https://github.com/nodejs/node/blob/934d90735ae36bc1bd362bf28f901d7b68c1176e/lib/child_process.js#L652) ).
- Avoids implying any “magic escaping” from the CLI side — we simply stop using the misleading `args + shell: true` combination.

Proper shell escaping / input hardening is intentionally **out of scope** for this PR and should be handled separately in a follow-up change, closer to where potentially untrusted input enters the system.