### PR TITLE
ci: switch npm ignore to allow list

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,11 +1,16 @@
+# ignore everything by default
 *
 
 # definitions
 !**/*.d.ts
 !*.d.ts
+
+# source
 !actions/**/*.js
 !bin/**/*.js
 !commands/**/*.js
 !lib/**/*.js
+
+# documents
 !README.md
 !LICENSE


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3202 

.npmignore allows non essential files to be included in package tarball.

## What is the new behavior?

.npmignore switches to an allow list format by ignoring everything `*`

And then negating for files that should be publishes



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Depending on the situation that led to #3202, some may consider this only part of the solution. IE ideally the release operations occur from a CI environment where the source tree would not be in a dirty state and provenance on the environment is attached/provided when publish to NPM IE: https://docs.npmjs.com/trusted-publishers
