### PR TITLE
chore: remove deprecated tslint comments

### DIFF
--- a/lib/compiler/watch-compiler.ts
+++ b/lib/compiler/watch-compiler.ts
@@ -107,7 +107,6 @@ export class WatchCompiler extends BaseCompiler<TypescriptWatchCompilerExtras> {
     (host as any).createProgram = (
       rootNames: ReadonlyArray<string>,
       options: ts.CompilerOptions | undefined,
-      // tslint:disable-next-line:no-shadowed-variable
       host: ts.CompilerHost,
       oldProgram: ts.EmitAndSemanticDiagnosticsBuilderProgram,
     ) => {

--- a/lib/ui/errors.ts
+++ b/lib/ui/errors.ts
@@ -1,5 +1,3 @@
-// tslint:disable:max-line-length
-
 export const CLI_ERRORS = {
   MISSING_TYPESCRIPT: (path: string) =>
     `Could not find TypeScript configuration file "${path}". Please, ensure that you are running this command in the appropriate directory (inside Nest workspace).`,

--- a/lib/ui/messages.ts
+++ b/lib/ui/messages.ts
@@ -25,7 +25,6 @@ export const MESSAGES = {
   START_COMMAND: (name: string) => `$ ${name} run start`,
   PACKAGE_MANAGER_INSTALLATION_FAILED: (commandToRunManually: string) =>
     `${EMOJIS.SCREAM}  Packages installation failed!\nIn case you don't see any errors above, consider manually running the failed command ${commandToRunManually} to see more details on why it errored out.`,
-  // tslint:disable-next-line:max-line-length
   NEST_INFORMATION_PACKAGE_MANAGER_FAILED: `${EMOJIS.SMIRK}  cannot read your project package.json file, are you inside your project directory?`,
   NEST_INFORMATION_PACKAGE_WARNING_FAILED: (nestDependencies: string[]) =>
     `${


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The codebase contains `tslint:disable` comments from when the project used tslint. These comments don't seem to be functional since the migration to eslint (ca6f3b1a)

## What is the new behavior?

I removed 3 dead tslint comments:
- `lib/ui/errors.ts` - `tslint:disable:max-line-length`
- `lib/ui/messages.ts` - `tslint:disable-next-line:max-line-length`
- `lib/compiler/watch-compiler.ts` - `tslint:disable-next-line:no-shadowed-variable`



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```