### PR TITLE
feat: Add type and CRUD options in generate command

### DIFF
--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -48,6 +48,8 @@ export class GenerateCommand extends AbstractCommand {
         '-c, --collection [collectionName]',
         'Schematics collection to use.',
       )
+      .option('--type <type>', 'Transport layer type (rest, graphql, microservice)')
+      .option('--crud', 'Generate CRUD entry points')
       .action(
         async (
           schematic: string,
@@ -91,6 +93,16 @@ export class GenerateCommand extends AbstractCommand {
           options.push({
             name: 'skipImport',
             value: command.skipImport,
+          });
+
+          options.push({
+            name: 'type',
+            value: command.type,
+          });
+
+          options.push({
+            name: 'crud',
+            value: !!command.crud,
           });
 
           const inputs: Input[] = [];

--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -49,7 +49,7 @@ export class GenerateCommand extends AbstractCommand {
         'Schematics collection to use.',
       )
       .option('--type <type>', 'Transport layer type (rest, graphql, microservice)')
-      .option('--crud', 'Generate CRUD entry points')
+      .option('--crud [value]', 'Generate CRUD entry points')
       .action(
         async (
           schematic: string,
@@ -100,10 +100,12 @@ export class GenerateCommand extends AbstractCommand {
             value: command.type,
           });
 
-          options.push({
-            name: 'crud',
-            value: !!command.crud,
-          });
+          if (command.crud !== undefined) {
+            options.push({
+              name: 'crud',
+              value: command.crud === true || command.crud === 'true',
+            });
+          }
 
           const inputs: Input[] = [];
           inputs.push({ name: 'schematic', value: schematic });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```bash
nest g resource users --type rest --crud
```
throws:

```bash
Unknown option: --type
Unknown option: --crud
```
Even though --type and --crud are defined in the resource/schema.json schematic.

Issue Number: #3229


## What is the new behavior?

- --type and --crud options are now forwarded correctly to the resource schematic.
- CLI recognizes these options and generates a REST CRUD resource automatically.
- Example:
```bash
nest g resource users --type rest --crud
 ```
Generates:
```bash
src/users/users.module.ts
src/users/users.controller.ts
src/users/users.service.ts
src/users/dto/create-user.dto.ts
src/users/entities/user.entity.ts
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
- No automated tests were added because there are no existing e2e tests for generate resource.
- Manual testing confirms the fix works.