### PR TITLE
feat: respect tsconfig excludes when using swc

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -1,7 +1,6 @@
 import { createRequire } from 'module';
 import { red } from 'ansis';
 import { join } from 'path';
-import type * as ts from 'typescript';
 import { BuildCommandContext } from '../commands/index.js';
 import { AssetsManager } from '../lib/compiler/assets-manager.js';
 import { deleteOutDirIfEnabled } from '../lib/compiler/helpers/delete-out-dir.js';
@@ -11,7 +10,10 @@ import { getRspackConfigPath } from '../lib/compiler/helpers/get-rspack-config-p
 import { getTscConfigPath } from '../lib/compiler/helpers/get-tsc-config.path.js';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default.js';
 import { getWebpackConfigPath } from '../lib/compiler/helpers/get-webpack-config-path.js';
-import { TsConfigProvider } from '../lib/compiler/helpers/tsconfig-provider.js';
+import {
+  TsConfigProvider,
+  TsConfigProviderOutput,
+} from '../lib/compiler/helpers/tsconfig-provider.js';
 import { PluginsLoader } from '../lib/compiler/plugins/plugins-loader.js';
 import { TypeScriptBinaryLoader } from '../lib/compiler/typescript-loader.js';
 import {
@@ -214,7 +216,7 @@ export class BuildAction extends AbstractAction {
     pathToTsconfig: string,
     watchMode: boolean,
     options: Record<string, any>,
-    tsOptions: ts.CompilerOptions,
+    tsOptions: TsConfigProviderOutput['options'],
     emitDeclarations: boolean,
     onSuccess: (() => void) | undefined,
   ) {

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -85,8 +85,11 @@ export class BuildAction extends AbstractAction {
 
     const buildApp = async (appName: string | undefined) => {
       const pathToTsconfig = getTscConfigPath(configuration, options, appName);
-      const { options: tsOptions, fileNames: tsFileNames } =
-        this.tsConfigProvider.getByConfigFilename(pathToTsconfig);
+      const {
+        exclude,
+        options: tsOptions,
+        fileNames: tsFileNames,
+      } = this.tsConfigProvider.getByConfigFilename(pathToTsconfig);
       const outDir = tsOptions.outDir || defaultOutDir;
       const tsRootDir = getEffectiveRootDir(tsOptions.rootDir, tsFileNames);
 
@@ -181,6 +184,7 @@ export class BuildAction extends AbstractAction {
             watchMode,
             options,
             tsOptions,
+            exclude,
             emitDeclarations,
             onSuccess,
           );
@@ -217,6 +221,7 @@ export class BuildAction extends AbstractAction {
     watchMode: boolean,
     options: Record<string, any>,
     tsOptions: TsConfigProviderOutput['options'],
+    tsConfigExclude: string[],
     emitDeclarations: boolean,
     onSuccess: (() => void) | undefined,
   ) {
@@ -239,6 +244,7 @@ export class BuildAction extends AbstractAction {
         ),
         emitDeclarations,
         tsOptions,
+        tsConfigExclude,
         assetsManager: this.assetsManager,
         silent: isSilent,
       },

--- a/lib/compiler/defaults/swc-defaults.ts
+++ b/lib/compiler/defaults/swc-defaults.ts
@@ -4,6 +4,7 @@ import { Configuration } from '../../configuration/index.js';
 export const swcDefaultsFactory = (
   tsOptions?: ts.CompilerOptions,
   configuration?: Configuration,
+  tsConfigExclude: string[] = [],
 ) => {
   const builderOptions =
     typeof configuration?.compilerOptions?.builder !== 'string'
@@ -43,6 +44,7 @@ export const swcDefaultsFactory = (
       extensions: ['.js', '.ts'],
       copyFiles: false,
       includeDotfiles: false,
+      ignore: tsConfigExclude.length ? tsConfigExclude : undefined,
       quiet: false,
       watch: false,
       stripLeadingPaths: !tsOptions?.rootDir,

--- a/lib/compiler/helpers/tsconfig-provider.ts
+++ b/lib/compiler/helpers/tsconfig-provider.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { dirname, isAbsolute, join, relative } from 'path';
 import * as ts from 'typescript';
 import { CLI_ERRORS } from '../../ui/index.js';
 import { TypeScriptBinaryLoader } from '../typescript-loader.js';
@@ -7,7 +7,9 @@ import { TypeScriptBinaryLoader } from '../typescript-loader.js';
 export type TsConfigProviderOutput = Pick<
   ts.ParsedCommandLine,
   'options' | 'fileNames' | 'projectReferences'
->;
+> & {
+  exclude: string[];
+};
 
 export class TsConfigProvider {
   constructor(private readonly typescriptLoader: TypeScriptBinaryLoader) {}
@@ -28,7 +30,43 @@ export class TsConfigProvider {
         `Could not parse TypeScript configuration file "${configFilename}". Please, ensure that the file contains valid JSON and compiler options.`,
       );
     }
-    const { options, fileNames, projectReferences } = parsedCmd;
-    return { options, fileNames, projectReferences };
+    const {
+      options,
+      fileNames,
+      projectReferences,
+      raw,
+    } = parsedCmd;
+
+    const exclude = this.normalizeExclude(
+      this.parseExclude(raw?.exclude),
+      configPath,
+    );
+
+    return { options, fileNames, projectReferences, exclude };
+  }
+
+  private parseExclude(exclude: unknown): string[] {
+    const passesTypeValidation =
+      Array.isArray(exclude) &&
+      exclude.every((item) => typeof item === 'string');
+
+    if (!passesTypeValidation) {
+      return [];
+    }
+
+    return exclude;
+  }
+
+  private normalizeExclude(exclude: string[], configPath: string): string[] {
+    const configDir = dirname(configPath);
+    const relativeConfigDir = relative(process.cwd(), configDir);
+
+    return exclude.map((pattern) => {
+      const normalized = isAbsolute(pattern)
+        ? relative(process.cwd(), pattern)
+        : join(relativeConfigDir, pattern);
+
+      return normalized.replace(/\\/g, '/');
+    });
   }
 }

--- a/lib/compiler/helpers/tsconfig-provider.ts
+++ b/lib/compiler/helpers/tsconfig-provider.ts
@@ -4,10 +4,15 @@ import * as ts from 'typescript';
 import { CLI_ERRORS } from '../../ui/index.js';
 import { TypeScriptBinaryLoader } from '../typescript-loader.js';
 
+export type TsConfigProviderOutput = Pick<
+  ts.ParsedCommandLine,
+  'options' | 'fileNames' | 'projectReferences'
+>;
+
 export class TsConfigProvider {
   constructor(private readonly typescriptLoader: TypeScriptBinaryLoader) {}
 
-  public getByConfigFilename(configFilename: string) {
+  public getByConfigFilename(configFilename: string): TsConfigProviderOutput {
     const configPath = join(process.cwd(), configFilename);
     if (!existsSync(configPath)) {
       throw new Error(CLI_ERRORS.MISSING_TYPESCRIPT(configFilename));

--- a/lib/compiler/swc/swc-compiler.ts
+++ b/lib/compiler/swc/swc-compiler.ts
@@ -34,6 +34,7 @@ export type SwcCompilerExtras = {
   emitDeclarations: boolean;
   assetsManager: AssetsManager;
   tsOptions: TsConfigProviderOutput['options'];
+  tsConfigExclude: string[];
   silent?: boolean;
 };
 
@@ -52,7 +53,11 @@ export class SwcCompiler extends BaseCompiler {
     extras: SwcCompilerExtras,
     onSuccess?: () => void,
   ) {
-    const swcOptions = swcDefaultsFactory(extras.tsOptions, configuration);
+    const swcOptions = swcDefaultsFactory(
+      extras.tsOptions,
+      configuration,
+      extras.tsConfigExclude,
+    );
     const swcrcFilePath = getValueOrDefault<string | undefined>(
       configuration,
       'compilerOptions.builder.options.swcrcPath',

--- a/lib/compiler/swc/swc-compiler.ts
+++ b/lib/compiler/swc/swc-compiler.ts
@@ -3,9 +3,10 @@ import { fork, spawnSync } from 'child_process';
 import * as chokidar from 'chokidar';
 import { readFileSync } from 'fs';
 import { stat } from 'fs/promises';
+import { minimatch } from 'minimatch';
 import { createRequire } from 'module';
 import * as path from 'path';
-import { dirname, isAbsolute, join } from 'path';
+import { dirname, isAbsolute, join, posix, relative } from 'path';
 import { fileURLToPath } from 'url';
 import { Configuration } from '../../configuration/index.js';
 import { ERROR_PREFIX } from '../../ui/index.js';
@@ -343,7 +344,37 @@ export class SwcCompiler extends BaseCompiler {
         pollInterval: 10,
       },
     });
-    watcher.on('add', async (file) => onFileAdded(file));
+    watcher.on('add', async (file) => {
+      if (this.isIgnoredBySwc(file, options.cliOptions?.ignore)) {
+        return;
+      }
+
+      await onFileAdded(file);
+    });
+  }
+
+  private isIgnoredBySwc(
+    file: string,
+    ignore: string[] = [],
+    cwd = process.cwd(),
+  ): boolean {
+    if (!ignore.length) {
+      return false;
+    }
+
+    const relativeFile = isAbsolute(file) ? relative(cwd, file) : file;
+    const normalizedFile = this.normalizeSwcIgnorePath(relativeFile);
+    return ignore.some((pattern) => {
+      const normalizedPattern = this.normalizeSwcIgnorePath(pattern);
+
+      return [normalizedPattern, posix.join(normalizedPattern, '**')].some(
+        (pattern) => minimatch(normalizedFile, pattern),
+      );
+    });
+  }
+
+  private normalizeSwcIgnorePath(value: string): string {
+    return posix.normalize(value.replace(/\\/g, '/'));
   }
 
   private watchFilesInOutDir(

--- a/lib/compiler/swc/swc-compiler.ts
+++ b/lib/compiler/swc/swc-compiler.ts
@@ -6,7 +6,6 @@ import { stat } from 'fs/promises';
 import { createRequire } from 'module';
 import * as path from 'path';
 import { dirname, isAbsolute, join } from 'path';
-import * as ts from 'typescript';
 import { fileURLToPath } from 'url';
 import { Configuration } from '../../configuration/index.js';
 import { ERROR_PREFIX } from '../../ui/index.js';
@@ -15,6 +14,7 @@ import { AssetsManager } from '../assets-manager.js';
 import { BaseCompiler } from '../base-compiler.js';
 import { swcDefaultsFactory } from '../defaults/swc-defaults.js';
 import { getValueOrDefault } from '../helpers/get-value-or-default.js';
+import type { TsConfigProviderOutput } from '../helpers/tsconfig-provider.js';
 import { PluginMetadataGenerator } from '../plugins/plugin-metadata-generator.js';
 import { PluginsLoader } from '../plugins/plugins-loader.js';
 import {
@@ -33,7 +33,7 @@ export type SwcCompilerExtras = {
   typeCheck: boolean;
   emitDeclarations: boolean;
   assetsManager: AssetsManager;
-  tsOptions: ts.CompilerOptions;
+  tsOptions: TsConfigProviderOutput['options'];
   silent?: boolean;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "cli-table3": "0.6.5",
         "commander": "14.0.3",
         "glob": "13.0.6",
+        "minimatch": "10.2.5",
         "node-emoji": "2.2.0",
         "ora": "9.3.0",
         "tsconfig-paths": "4.2.0",
@@ -4211,7 +4212,7 @@
       "version": "25.3.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -4851,6 +4852,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
@@ -5095,13 +5109,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5653,8 +5678,9 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.2",
@@ -5977,6 +6003,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/delete-empty/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/delete-empty/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5995,6 +6032,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/delete-empty/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/delete-empty/node_modules/rimraf": {
@@ -6720,6 +6770,17 @@
         "webpack": "^5.11.0"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -6734,6 +6795,19 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/readdirp": {
@@ -7031,6 +7105,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-watcher/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/glob-watcher/node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7041,39 +7128,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-directory": {
@@ -7207,6 +7261,17 @@
         "node": ">=0.9"
       }
     },
+    "node_modules/gulp-clean/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/gulp-clean/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -7225,6 +7290,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gulp-clean/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/gulp-clean/node_modules/rimraf": {
@@ -8743,6 +8821,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -8798,15 +8889,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -9529,12 +9623,13 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -10938,18 +11033,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -11145,7 +11228,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
@@ -11591,19 +11674,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
@@ -11688,19 +11758,6 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/vitest/node_modules/tinyexec": {
       "version": "1.1.1",
@@ -13027,7 +13084,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13077,7 +13135,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13150,7 +13209,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13200,7 +13260,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13264,7 +13325,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13314,7 +13376,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13365,7 +13428,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13432,7 +13496,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13483,7 +13548,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13535,7 +13601,8 @@
         "@inquirer/type": {
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
-          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="
+          "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+          "requires": {}
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -13552,7 +13619,8 @@
     "@inquirer/type": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "requires": {}
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.8",
@@ -13749,7 +13817,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
       "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "17.0.0",
@@ -14501,7 +14570,7 @@
       "version": "25.3.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "undici-types": "~7.18.0"
       }
@@ -14887,7 +14956,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "7.1.3",
@@ -14937,7 +15007,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -15002,6 +15073,14 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+          "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+          "dev": true
+        }
       }
     },
     "arch": {
@@ -15171,13 +15250,18 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+        }
       }
     },
     "braces": {
@@ -15551,7 +15635,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "confbox": {
@@ -15762,6 +15846,16 @@
         "rimraf": "^2.6.2"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "glob": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -15774,6 +15868,15 @@
             "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "rimraf": {
@@ -16173,7 +16276,8 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "file-type": {
       "version": "19.6.0",
@@ -16304,6 +16408,16 @@
         "tapable": "^2.2.1"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "chokidar": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -16311,6 +16425,15 @@
           "dev": true,
           "requires": {
             "readdirp": "^4.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "readdirp": {
@@ -16460,29 +16583,6 @@
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "path-scurry": "^2.0.2"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
-        },
-        "brace-expansion": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-          "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-          "requires": {
-            "balanced-match": "^4.0.2"
-          }
-        },
-        "minimatch": {
-          "version": "10.2.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-          "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-          "requires": {
-            "brace-expansion": "^5.0.2"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -16550,6 +16650,12 @@
           "requires": {
             "is-glob": "^4.0.1"
           }
+        },
+        "picomatch": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+          "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+          "dev": true
         },
         "readdirp": {
           "version": "3.6.0",
@@ -16662,6 +16768,16 @@
         "vinyl": "^2.1.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "glob": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -16674,6 +16790,15 @@
             "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "rimraf": {
@@ -17704,6 +17829,14 @@
       "requires": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+          "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+          "dev": true
+        }
       }
     },
     "mime-db": {
@@ -17739,12 +17872,11 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       }
     },
     "minimist": {
@@ -18242,9 +18374,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true
     },
     "piscina": {
@@ -19250,14 +19382,6 @@
       "requires": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
-      },
-      "dependencies": {
-        "picomatch": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true
-        }
       }
     },
     "tinyrainbow": {
@@ -19400,7 +19524,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true
+      "devOptional": true
     },
     "unicode-emoji-modifier-base": {
       "version": "1.0.0",
@@ -19679,14 +19803,6 @@
         "postcss": "^8.5.3",
         "rollup": "^4.34.9",
         "tinyglobby": "^0.2.13"
-      },
-      "dependencies": {
-        "picomatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-          "dev": true
-        }
       }
     },
     "vitest": {
@@ -19721,12 +19837,6 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
           "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-          "dev": true
-        },
-        "picomatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
           "dev": true
         },
         "tinyexec": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cli-table3": "0.6.5",
     "commander": "14.0.3",
     "glob": "13.0.6",
+    "minimatch": "10.2.5",
     "node-emoji": "2.2.0",
     "ora": "9.3.0",
     "tsconfig-paths": "4.2.0",

--- a/test/lib/compiler/defaults/swc-defaults.spec.ts
+++ b/test/lib/compiler/defaults/swc-defaults.spec.ts
@@ -63,7 +63,93 @@ describe('swcDefaultsFactory', () => {
     expect(result.cliOptions.filenames).toEqual(['src']);
   });
 
+  it('should return default configuration when no options are provided', () => {
+    const result = swcDefaultsFactory();
+
+    expect(result.swcOptions).toEqual({
+      sourceMaps: undefined,
+      module: {
+        type: 'commonjs',
+      },
+      jsc: {
+        target: 'es2021',
+        parser: {
+          syntax: 'typescript',
+          decorators: true,
+          dynamicImport: true,
+        },
+        transform: {
+          legacyDecorator: true,
+          decoratorMetadata: true,
+          useDefineForClassFields: false,
+        },
+        keepClassNames: true,
+        baseUrl: undefined,
+        paths: undefined,
+      },
+      minify: false,
+      swcrc: true,
+    });
+
+    expect(result.cliOptions).toEqual({
+      outDir: 'dist',
+      filenames: ['src'],
+      sync: false,
+      extensions: ['.js', '.ts'],
+      copyFiles: false,
+      includeDotfiles: false,
+      ignore: undefined,
+      quiet: false,
+      watch: false,
+      stripLeadingPaths: true,
+    });
+  });
+
+  describe('swcOptions', () => {
+    it('should set sourceMaps to true if sourceMap is true in tsOptions', () => {
+      const result = swcDefaultsFactory({ sourceMap: true });
+      expect(result.swcOptions.sourceMaps).toBe(true);
+    });
+
+    it('should set sourceMaps to "inline" if inlineSourceMap is true in tsOptions', () => {
+      const result = swcDefaultsFactory({ inlineSourceMap: true });
+      expect(result.swcOptions.sourceMaps).toBe('inline');
+    });
+
+    it('should set baseUrl and paths from tsOptions', () => {
+      const tsOptions = {
+        baseUrl: './',
+        paths: {
+          '@app/*': ['src/*'],
+        },
+      };
+      const result = swcDefaultsFactory(tsOptions);
+      expect(result.swcOptions.jsc.baseUrl).toBe('./');
+      expect(result.swcOptions.jsc.paths).toEqual({
+        '@app/*': ['src/*'],
+      });
+    });
+  });
+
   describe('cliOptions', () => {
+    it('should use sourceRoot from configuration for filenames', () => {
+      const configuration = { sourceRoot: 'custom-src' };
+      const result = swcDefaultsFactory(undefined, configuration);
+      expect(result.cliOptions.filenames).toEqual(['custom-src']);
+    });
+
+    it('should use outDir from tsOptions and convert path', () => {
+      const tsOptions = { outDir: 'build\\dist' };
+      const result = swcDefaultsFactory(tsOptions);
+      expect(result.cliOptions.outDir).toBe('build/dist');
+    });
+
+    it('should handle Windows specific path prefixes in outDir', () => {
+      const tsOptions = { outDir: '\\\\?\\C:\\dist' };
+      const result = swcDefaultsFactory(tsOptions);
+      expect(result.cliOptions.outDir).toBe('C:/dist');
+    });
+
     it('should set ignore if tsconfig exclude is provided', () => {
       const result = swcDefaultsFactory({}, undefined, ['test/**/*.ts']);
       expect(result.cliOptions.ignore).toEqual(['test/**/*.ts']);
@@ -86,6 +172,38 @@ describe('swcDefaultsFactory', () => {
       ]);
 
       expect(result.cliOptions.ignore).toEqual(['custom/**/*.ts']);
+    });
+
+    it('should merge builder options from configuration', () => {
+      const configuration = {
+        compilerOptions: {
+          builder: {
+            type: 'swc' as const,
+            options: {
+              watch: true,
+              sync: true,
+              copyFiles: true,
+            },
+          },
+        },
+      };
+      const result = swcDefaultsFactory(undefined, configuration);
+      expect(result.cliOptions.watch).toBe(true);
+      expect(result.cliOptions.sync).toBe(true);
+      expect(result.cliOptions.copyFiles).toBe(true);
+    });
+
+    it('should not merge builder options if builder is a string', () => {
+      const configuration = {
+        compilerOptions: {
+          builder: 'swc',
+        },
+      };
+
+      const result = swcDefaultsFactory(undefined, configuration as any);
+      expect(result.cliOptions.watch).toBe(false);
+      expect(result.cliOptions.sync).toBe(false);
+      expect(result.cliOptions.copyFiles).toBe(false);
     });
   });
 });

--- a/test/lib/compiler/defaults/swc-defaults.spec.ts
+++ b/test/lib/compiler/defaults/swc-defaults.spec.ts
@@ -62,4 +62,30 @@ describe('swcDefaultsFactory', () => {
     const result = swcDefaultsFactory({}, undefined);
     expect(result.cliOptions.filenames).toEqual(['src']);
   });
+
+  describe('cliOptions', () => {
+    it('should set ignore if tsconfig exclude is provided', () => {
+      const result = swcDefaultsFactory({}, undefined, ['test/**/*.ts']);
+      expect(result.cliOptions.ignore).toEqual(['test/**/*.ts']);
+    });
+
+    it('allows builder options ignore to override tsconfig exclude', () => {
+      const configuration = {
+        compilerOptions: {
+          builder: {
+            type: 'swc' as const,
+            options: {
+              ignore: ['custom/**/*.ts'],
+            },
+          },
+        },
+      };
+
+      const result = swcDefaultsFactory({}, configuration as any, [
+        'tsconfig-excluded/**/*.ts',
+      ]);
+
+      expect(result.cliOptions.ignore).toEqual(['custom/**/*.ts']);
+    });
+  });
 });

--- a/test/lib/compiler/helpers/tsconfig-provider.spec.ts
+++ b/test/lib/compiler/helpers/tsconfig-provider.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync } from 'fs';
+import { join } from 'path';
 import * as ts from 'typescript';
 import { TsConfigProvider } from '../../../../lib/compiler/helpers/tsconfig-provider.js';
 import { TypeScriptBinaryLoader } from '../../../../lib/compiler/typescript-loader.js';
@@ -111,5 +112,150 @@ describe('TsConfigProvider', () => {
       undefined,
       mockTsBinary.sys,
     );
+  });
+
+  it('should handle missing exclude in raw config', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    mockTsBinary.getParsedCommandLineOfConfigFile.mockReturnValue({
+      options: { outDir: 'dist' },
+      fileNames: ['src/main.ts'],
+      projectReferences: [],
+      raw: {},
+    });
+
+    const result = provider.getByConfigFilename('tsconfig.json');
+
+    expect(result.exclude).toEqual([]);
+  });
+
+  it('should normalize exclude paths relative to the config file', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    mockTsBinary.getParsedCommandLineOfConfigFile.mockReturnValue({
+      options: { outDir: 'dist' },
+      fileNames: ['apps/api/src/main.ts'],
+      projectReferences: [],
+      raw: { exclude: ['src/generated/**', 'dist'] },
+    });
+
+    const result = provider.getByConfigFilename('apps/api/tsconfig.app.json');
+
+    expect(result.exclude).toEqual([
+      'apps/api/src/generated/**',
+      'apps/api/dist',
+    ]);
+  });
+
+  it('should handle wrongly typed exclude in raw config', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    const mockParsedCmd = {
+      options: { outDir: 'dist' },
+      fileNames: ['src/main.ts'],
+      projectReferences: [],
+      raw: { exclude: 'not-an-array' as unknown },
+    };
+
+    mockTsBinary.getParsedCommandLineOfConfigFile.mockReturnValue(
+      mockParsedCmd,
+    );
+
+    const result1 = provider.getByConfigFilename('tsconfig.json');
+
+    expect(result1.exclude).toEqual([]);
+
+    mockParsedCmd.raw.exclude = [0, false];
+    mockTsBinary.getParsedCommandLineOfConfigFile.mockReturnValue(
+      mockParsedCmd,
+    );
+
+    const result2 = provider.getByConfigFilename('tsconfig.json');
+
+    expect(result2.exclude).toEqual([]);
+  });
+
+  it('should correctly parse exclude from the real TS binary', () => {
+    const configFilename = 'tsconfig.json';
+    const configPath = join(process.cwd(), configFilename);
+    const tsconfigContent = JSON.stringify({
+      compilerOptions: {
+        outDir: 'dist',
+      },
+      exclude: ['node_modules', 'dist'],
+    });
+    const parseConfigHost: ts.ParseConfigFileHost = {
+      ...ts.sys,
+      onUnRecoverableConfigFileDiagnostic: vi.fn(),
+      fileExists: vi.fn((filename) => filename === configPath),
+      readDirectory: vi.fn(() => []),
+      readFile: vi.fn((filename) => {
+        if (filename === configPath) {
+          return tsconfigContent;
+        }
+        return undefined;
+      }),
+    };
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    const realTypescriptLoader = {
+      load: vi.fn().mockReturnValue({
+        getParsedCommandLineOfConfigFile: ts.getParsedCommandLineOfConfigFile,
+        sys: parseConfigHost,
+      }),
+    } as unknown as TypeScriptBinaryLoader;
+    provider = new TsConfigProvider(realTypescriptLoader);
+
+    const result = provider.getByConfigFilename(configFilename);
+
+    expect(result.exclude).toEqual(['node_modules', 'dist']);
+  });
+
+  it('should preserve exclude inherited through tsconfig extends', () => {
+    const baseConfigFilename = 'tsconfig.base.json';
+    const configFilename = 'apps/api/tsconfig.app.json';
+    const baseConfigPath = join(process.cwd(), baseConfigFilename);
+    const configPath = join(process.cwd(), configFilename);
+    const tsconfigContent = JSON.stringify({
+      extends: '../../tsconfig.base.json',
+      compilerOptions: {
+        outDir: 'dist',
+      },
+    });
+    const baseTsconfigContent = JSON.stringify({
+      exclude: ['generated/**'],
+    });
+    const parseConfigHost: ts.ParseConfigFileHost = {
+      ...ts.sys,
+      onUnRecoverableConfigFileDiagnostic: vi.fn(),
+      fileExists: vi.fn(
+        (filename) => filename === configPath || filename === baseConfigPath,
+      ),
+      readDirectory: vi.fn(() => []),
+      readFile: vi.fn((filename) => {
+        if (filename === configPath) {
+          return tsconfigContent;
+        }
+
+        if (filename === baseConfigPath) {
+          return baseTsconfigContent;
+        }
+
+        return undefined;
+      }),
+    };
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    const realTypescriptLoader = {
+      load: vi.fn().mockReturnValue({
+        getParsedCommandLineOfConfigFile: ts.getParsedCommandLineOfConfigFile,
+        sys: parseConfigHost,
+      }),
+    } as unknown as TypeScriptBinaryLoader;
+    provider = new TsConfigProvider(realTypescriptLoader);
+
+    const result = provider.getByConfigFilename(configFilename);
+
+    expect(result.exclude).toEqual(['generated/**']);
   });
 });

--- a/test/lib/compiler/helpers/tsconfig-provider.spec.ts
+++ b/test/lib/compiler/helpers/tsconfig-provider.spec.ts
@@ -48,6 +48,7 @@ describe('TsConfigProvider', () => {
       options: mockOptions,
       fileNames: mockFileNames,
       projectReferences: mockProjectReferences,
+      raw: { exclude: ['node_modules'] },
     });
 
     const result = provider.getByConfigFilename('tsconfig.json');
@@ -82,10 +83,12 @@ describe('TsConfigProvider', () => {
       options: { strict: true },
       fileNames: ['src/main.ts'],
       projectReferences: undefined,
+      raw: {},
     });
 
     const result = provider.getByConfigFilename('tsconfig.json');
 
+    expect(result.exclude).toEqual([]);
     expect(result.options).toEqual({ strict: true });
     expect(result.fileNames).toEqual(['src/main.ts']);
     expect(result.projectReferences).toBeUndefined();
@@ -98,6 +101,7 @@ describe('TsConfigProvider', () => {
       options: {},
       fileNames: [],
       projectReferences: undefined,
+      raw: {},
     });
 
     provider.getByConfigFilename('custom-tsconfig.json');

--- a/test/lib/compiler/swc/swc-compiler.spec.ts
+++ b/test/lib/compiler/swc/swc-compiler.spec.ts
@@ -1,6 +1,9 @@
 import * as childProcess from 'child_process';
 import * as chokidar from 'chokidar';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { stat } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { swcDefaultsFactory } from '../../../../lib/compiler/defaults/swc-defaults.js';
 import { getValueOrDefault } from '../../../../lib/compiler/helpers/get-value-or-default.js';
@@ -555,6 +558,220 @@ describe('SWC Compiler', () => {
       // Directories should not be ignored
       const dirStats = { isFile: () => false };
       expect(ignoredFn('src/subdir', dirStats)).toBe(false);
+    });
+
+    it('should not call onFileAdded for files matching swc ignore patterns', async () => {
+      const mockWatcher = {
+        on: vi.fn().mockReturnThis(),
+      };
+      vi.mocked(chokidar.watch).mockReturnValue(mockWatcher as any);
+
+      const onFileAdded = vi.fn();
+      const options = {
+        cliOptions: {
+          filenames: ['src'],
+          extensions: ['ts'],
+          ignore: ['src/generated/**'],
+        },
+      };
+
+      await compiler['watchFilesInSrcDir'](options as any, onFileAdded);
+
+      const addHandler = mockWatcher.on.mock.calls.find(
+        ([event]) => event === 'add',
+      )?.[1];
+
+      await addHandler('src/generated/foo.ts');
+
+      expect(onFileAdded).not.toHaveBeenCalled();
+    });
+
+    it('should call onFileAdded for non-ignored files', async () => {
+      const mockWatcher = {
+        on: vi.fn().mockReturnThis(),
+      };
+      vi.mocked(chokidar.watch).mockReturnValue(mockWatcher as any);
+
+      const onFileAdded = vi.fn();
+      const options = {
+        cliOptions: {
+          filenames: ['src'],
+          extensions: ['ts'],
+          ignore: ['src/generated/**'],
+        },
+      };
+
+      await compiler['watchFilesInSrcDir'](options as any, onFileAdded);
+
+      const addHandler = mockWatcher.on.mock.calls.find(
+        ([event]) => event === 'add',
+      )?.[1];
+
+      await addHandler('src/modules/foo.ts');
+
+      expect(onFileAdded).toHaveBeenCalledWith('src/modules/foo.ts');
+    });
+
+    it('should match ignored absolute file paths relative to the current working directory', () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'swc-ignore-'));
+
+      try {
+        mkdirSync(join(cwd, 'src/generated'), { recursive: true });
+        mkdirSync(join(cwd, 'src/modules'), { recursive: true });
+        writeFileSync(join(cwd, 'src/generated/foo.ts'), '');
+        writeFileSync(join(cwd, 'src/modules/foo.ts'), '');
+
+        expect(
+          compiler['isIgnoredBySwc'](
+            join(cwd, 'src/generated/foo.ts'),
+            ['src/generated/**'],
+            cwd,
+          ),
+        ).toBe(true);
+        expect(
+          compiler['isIgnoredBySwc'](
+            join(cwd, 'src/modules/foo.ts'),
+            ['src/generated/**'],
+            cwd,
+          ),
+        ).toBe(false);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it('should match ignored files under plain directory paths', () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'swc-ignore-'));
+
+      try {
+        mkdirSync(join(cwd, 'src/generated'), { recursive: true });
+        mkdirSync(join(cwd, 'src/generated-other'), { recursive: true });
+        writeFileSync(join(cwd, 'src/generated/foo.ts'), '');
+        writeFileSync(join(cwd, 'src/generated-other/foo.ts'), '');
+
+        expect(
+          compiler['isIgnoredBySwc'](
+            join(cwd, 'src/generated/foo.ts'),
+            ['src/generated'],
+            cwd,
+          ),
+        ).toBe(true);
+        expect(
+          compiler['isIgnoredBySwc'](
+            join(cwd, 'src/generated-other/foo.ts'),
+            ['src/generated'],
+            cwd,
+          ),
+        ).toBe(false);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it('should match ignored exact file paths', () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'swc-ignore-'));
+
+      try {
+        mkdirSync(join(cwd, 'src/generated'), { recursive: true });
+        writeFileSync(join(cwd, 'src/generated/foo.ts'), '');
+        writeFileSync(join(cwd, 'src/generated/bar.ts'), '');
+
+        expect(
+          compiler['isIgnoredBySwc'](
+            join(cwd, 'src/generated/foo.ts'),
+            ['src/generated/foo.ts'],
+            cwd,
+          ),
+        ).toBe(true);
+        expect(
+          compiler['isIgnoredBySwc'](
+            join(cwd, 'src/generated/bar.ts'),
+            ['src/generated/foo.ts'],
+            cwd,
+          ),
+        ).toBe(false);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it('should match DOS-style relative file paths against posix ignore patterns', () => {
+      expect(
+        compiler['isIgnoredBySwc']('src\\generated\\foo.ts', [
+          'src/generated/**',
+        ]),
+      ).toBe(true);
+      expect(
+        compiler['isIgnoredBySwc']('src\\modules\\foo.ts', [
+          'src/generated/**',
+        ]),
+      ).toBe(false);
+    });
+
+    it('should match posix file paths against DOS-style ignore patterns', () => {
+      expect(
+        compiler['isIgnoredBySwc']('src/generated/foo.ts', [
+          'src\\generated\\**',
+        ]),
+      ).toBe(true);
+      expect(
+        compiler['isIgnoredBySwc']('src/modules/foo.ts', [
+          'src\\generated\\**',
+        ]),
+      ).toBe(false);
+    });
+
+    it('should ignore trailing slashes and backslashes in ignore patterns', () => {
+      expect(
+        compiler['isIgnoredBySwc']('src/generated/foo.ts', ['src/generated/']),
+      ).toBe(true);
+      expect(
+        compiler['isIgnoredBySwc']('src/generated/foo.ts', ['src\\generated\\']),
+      ).toBe(true);
+      expect(
+        compiler['isIgnoredBySwc']('src/generated-other/foo.ts', [
+          'src/generated/',
+        ]),
+      ).toBe(false);
+    });
+
+    it('should ignore leading dot-slash prefixes in files and ignore patterns', () => {
+      expect(
+        compiler['isIgnoredBySwc']('./src/generated/foo.ts', [
+          'src/generated/**',
+        ]),
+      ).toBe(true);
+      expect(
+        compiler['isIgnoredBySwc']('src/generated/foo.ts', [
+          './src/generated/**',
+        ]),
+      ).toBe(true);
+      expect(
+        compiler['isIgnoredBySwc']('./src/modules/foo.ts', [
+          './src/generated/**',
+        ]),
+      ).toBe(false);
+    });
+
+    it('should treat glob metacharacters in file paths literally', () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'swc-ignore-'));
+
+      try {
+        mkdirSync(join(cwd, 'src/[generated]'), { recursive: true });
+        mkdirSync(join(cwd, 'src/generated'), { recursive: true });
+        writeFileSync(join(cwd, 'src/[generated]/foo.ts'), '');
+        writeFileSync(join(cwd, 'src/generated/foo.ts'), '');
+
+        expect(
+          compiler['isIgnoredBySwc'](
+            join(cwd, 'src/[generated]/foo.ts'),
+            ['src/generated/**'],
+            cwd,
+          ),
+        ).toBe(false);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
     });
 
     it('should skip watching if source directory does not exist', async () => {

--- a/test/lib/compiler/swc/swc-compiler.spec.ts
+++ b/test/lib/compiler/swc/swc-compiler.spec.ts
@@ -84,6 +84,7 @@ describe('SWC Compiler', () => {
       expect(vi.mocked(swcDefaultsFactory)).toHaveBeenCalledWith(
         fixture.extras.tsOptions,
         fixture.configuration,
+        undefined,
       );
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
    - I am unsure where/how to add these. I would be happy to do so after receiving additional guidance.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When switching a fresh [NestJS starter](https://github.com/nestjs/typescript-starter/tree/c4d9330f5513eda0fb5df594f6b34a11fde1a934) over to use SWC (using the official [guide](https://docs.nestjs.com/recipes/swc#swc)), the `exclude` field in `tsconfig.build.json` is no longer considered for build output. This means that a file like `src/app.controller.spec.ts` (included in the starter) ends up in the build as `dist/app.controller.spec.js`, even though `tsconfig.build.json` contains an exclusion glob pattern of `"**/*spec.ts"`.

It is expected that switching the NestJS builder from `tsc` to `swc` does not cause test files to be included in the `nest build` output.

The same concern applies in watch mode for newly added files, because Nest CLI manually watches source additions for SWC and triggers compilation for added files.

Issue Number: #2976


## What is the new behavior?

The SWC builder now uses `exclude` values from the parsed TypeScript config to populate SWC CLI `ignore` defaults.

This includes:

- exposing normalized `exclude` values from `TsConfigProvider`
- supporting inherited `exclude` values from `tsconfig` `extends`
- passing excludes to SWC CLI `ignore`
- respecting those ignore patterns when SWC watch mode manually compiles newly added source files
- preserving user-provided SWC builder option overrides

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

Unfortunately, it is _possible_ that someone has come to rely on the unexpected behaviour of `tsconfig.build.json` excludes not working for SWC compilation. However, I do think it's extremely unlikely. I welcome opposing thoughts.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Caveats

This PR forwards `tsconfig` `exclude` values to SWC CLI `ignore` defaults so SWC's directory traversal does not emit files that are commonly excluded from `tsconfig.build.json`, such as `*.spec.ts` files.

It does not try to provide full TypeScript program parity. TypeScript's `exclude` only affects root file discovery, and excluded files can still be included if imported by included files. The SWC builder already uses a source-directory traversal model, so this change stays within that model instead of trying to reconstruct TypeScript's full file graph.

Explicit SWC builder options continue to override CLI defaults. That means `compilerOptions.builder.options.ignore`, when provided, remains authoritative rather than being force-merged with excludes from `tsconfig`.

## Tests

Added/updated tests for:

- parsing and normalizing `exclude` from TypeScript config
- inherited `exclude` values through `extends`
- SWC defaults mapping `exclude` to `cliOptions.ignore`
- SWC watch-mode handling for newly added ignored files
- absolute path / glob escaping behavior for ignore matching

## Other information

Also, there was already a similar PR, but it used potentially more fragile mechanisms to retrieve the `exclude` value from a `tsconfig.json`:
- https://github.com/nestjs/nest-cli/pull/3048
