### PR TITLE
fix(start): wait for async shutdown hooks before exiting

### DIFF
--- a/actions/start.action.ts
+++ b/actions/start.action.ts
@@ -131,6 +131,16 @@ export class StartAction extends BuildAction {
       () => childProcessRef && killProcessSync(childProcessRef.pid),
     );
 
+    const signalHandler = (signal: NodeJS.Signals) => {
+      if (childProcessRef) {
+        childProcessRef.kill(signal);
+      } else {
+        process.exit();
+      }
+    };
+    process.on('SIGINT', signalHandler);
+    process.on('SIGTERM', signalHandler);
+
     return () => {
       if (childProcessRef) {
         childProcessRef.removeAllListeners('exit');

--- a/test/actions/start.action.spec.ts
+++ b/test/actions/start.action.spec.ts
@@ -1,0 +1,174 @@
+import { EventEmitter } from 'events';
+
+// Mock all heavy dependencies before importing StartAction
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+  execSync: jest.fn(),
+  spawnSync: jest.fn(() => ({ stdout: '', error: null })),
+}));
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => true),
+  readFileSync: jest.fn(),
+}));
+
+jest.mock('glob', () => ({
+  glob: jest.fn(),
+  globSync: jest.fn(() => []),
+}));
+
+jest.mock('../../lib/compiler/assets-manager', () => ({
+  AssetsManager: jest.fn().mockImplementation(() => ({
+    closeWatchers: jest.fn(),
+  })),
+}));
+
+jest.mock('../../lib/utils/tree-kill', () => ({
+  treeKillSync: jest.fn(),
+}));
+
+import { StartAction } from '../../actions/start.action';
+
+describe('StartAction', () => {
+  let startAction: StartAction;
+  let processOnSpy: jest.SpyInstance;
+  let originalArgv: string[];
+  const registeredHandlers: Record<string, Function[]> = {};
+
+  beforeEach(() => {
+    startAction = new StartAction();
+    (startAction as any).tsConfigProvider = {
+      getByConfigFilename: jest.fn(() => ({ options: { outDir: 'dist' } })),
+    };
+    (startAction as any).loader = {
+      load: jest.fn(() => ({})),
+    };
+
+    for (const key of Object.keys(registeredHandlers)) {
+      delete registeredHandlers[key];
+    }
+
+    processOnSpy = jest
+      .spyOn(process, 'on')
+      .mockImplementation((event: string | symbol, handler: Function) => {
+        const key = String(event);
+        registeredHandlers[key] = registeredHandlers[key] || [];
+        registeredHandlers[key].push(handler);
+        return process;
+      });
+
+    originalArgv = process.argv;
+    process.argv = ['node', 'nest', 'start'];
+  });
+
+  afterEach(() => {
+    processOnSpy.mockRestore();
+    process.argv = originalArgv;
+    jest.restoreAllMocks();
+  });
+
+  describe('createOnSuccessHook - signal handling', () => {
+    it('should register SIGINT and SIGTERM handlers', () => {
+      startAction.createOnSuccessHook(
+        'main',
+        'src',
+        false,
+        'dist',
+        'node',
+        { shell: false },
+      );
+
+      expect(registeredHandlers['SIGINT']).toBeDefined();
+      expect(registeredHandlers['SIGINT'].length).toBeGreaterThanOrEqual(1);
+      expect(registeredHandlers['SIGTERM']).toBeDefined();
+      expect(registeredHandlers['SIGTERM'].length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should forward SIGINT to the child process instead of killing it immediately', () => {
+      const { spawn } = require('child_process');
+      const mockChild = new EventEmitter();
+      (mockChild as any).pid = 12345;
+      (mockChild as any).stdin = null;
+      (mockChild as any).kill = jest.fn();
+      spawn.mockReturnValue(mockChild);
+
+      const onSuccess = startAction.createOnSuccessHook(
+        'main',
+        'src',
+        false,
+        'dist',
+        'node',
+        { shell: false },
+      );
+
+      // Invoke the hook to spawn the child process
+      onSuccess();
+
+      // Simulate receiving SIGINT
+      const sigintHandler =
+        registeredHandlers['SIGINT'][
+          registeredHandlers['SIGINT'].length - 1
+        ];
+      sigintHandler('SIGINT');
+
+      // The signal should be forwarded to the child via kill(), not via treeKillSync
+      expect((mockChild as any).kill).toHaveBeenCalledWith('SIGINT');
+    });
+
+    it('should forward SIGTERM to the child process instead of killing it immediately', () => {
+      const { spawn } = require('child_process');
+      const mockChild = new EventEmitter();
+      (mockChild as any).pid = 12345;
+      (mockChild as any).stdin = null;
+      (mockChild as any).kill = jest.fn();
+      spawn.mockReturnValue(mockChild);
+
+      const onSuccess = startAction.createOnSuccessHook(
+        'main',
+        'src',
+        false,
+        'dist',
+        'node',
+        { shell: false },
+      );
+
+      // Invoke the hook to spawn the child process
+      onSuccess();
+
+      // Simulate receiving SIGTERM
+      const sigtermHandler =
+        registeredHandlers['SIGTERM'][
+          registeredHandlers['SIGTERM'].length - 1
+        ];
+      sigtermHandler('SIGTERM');
+
+      // The signal should be forwarded to the child via kill()
+      expect((mockChild as any).kill).toHaveBeenCalledWith('SIGTERM');
+    });
+
+    it('should call process.exit when no child process is running on signal', () => {
+      const exitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {}) as any);
+
+      startAction.createOnSuccessHook(
+        'main',
+        'src',
+        false,
+        'dist',
+        'node',
+        { shell: false },
+      );
+
+      // Do NOT invoke onSuccess, so no child process exists
+      const sigintHandler =
+        registeredHandlers['SIGINT'][
+          registeredHandlers['SIGINT'].length - 1
+        ];
+      sigintHandler('SIGINT');
+
+      expect(exitSpy).toHaveBeenCalled();
+      exitSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When running `nest start`, pressing Ctrl+C (SIGINT) causes the parent CLI process to immediately kill the child NestJS application via `treeKillSync`, without giving it time to execute async shutdown hooks (`onModuleDestroy`, `onApplicationShutdown`). This means graceful shutdown logic (closing DB connections, flushing logs, etc.) never runs.

Issue Number: #3158


## What is the new behavior?

The parent process now installs `SIGINT` and `SIGTERM` handlers that forward the signal to the child process via `childProcessRef.kill(signal)` instead of killing it immediately. The parent stays alive until the child exits naturally, giving the NestJS application time to run its async shutdown lifecycle hooks before the process terminates.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

**Files changed:**
- `actions/start.action.ts` — Added signal forwarding handlers that send `SIGINT`/`SIGTERM` to the child process instead of killing it immediately
- `test/actions/start.action.spec.ts` — Added 4 regression tests verifying signal forwarding behavior