### PR TITLE
fix(assets): use ready event for watcher closing

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -14,27 +14,17 @@ import { getValueOrDefault } from './helpers/get-value-or-default';
 export class AssetsManager {
   private watchAssetsKeyValue: { [key: string]: boolean } = {};
   private watchers: chokidar.FSWatcher[] = [];
-  private actionInProgress = false;
+  private watcherReadyPromises: Promise<void>[] = [];
 
   /**
-   * Using on `nest build` to close file watch or the build process will not end
-   * Interval like process
-   * If no action has been taken recently close watchers
-   * If action has been taken recently flag and try again
+   * Using on `nest build` to close file watch or the build process will not end.
+   * Waits for all watchers to complete their initial scan before closing them,
+   * ensuring all assets are copied regardless of system speed.
    */
   public closeWatchers() {
-    // Consider adjusting this for larger files
-    const timeoutMs = 500;
-    const closeFn = () => {
-      if (this.actionInProgress) {
-        this.actionInProgress = false;
-        setTimeout(closeFn, timeoutMs);
-      } else {
-        this.watchers.forEach((watcher) => watcher.close());
-      }
-    };
-
-    setTimeout(closeFn, timeoutMs);
+    Promise.all(this.watcherReadyPromises).then(() => {
+      this.watchers.forEach((watcher) => watcher.close());
+    });
   }
 
   public copyAssets(
@@ -105,6 +95,9 @@ export class AssetsManager {
             .on('unlink', (path: string) => this.actionOnFile({ ...option, path, action: 'unlink' }));
 
           this.watchers.push(watcher);
+          this.watcherReadyPromises.push(
+            new Promise<void>((resolve) => watcher.on('ready', resolve)),
+          );
         } else {
           const matchedPaths = sync(item.glob, {
             ignore: item.exclude,
@@ -144,8 +137,6 @@ export class AssetsManager {
     }
     // Set path value to true for watching the first time
     this.watchAssetsKeyValue[assetCheckKey] = true;
-    // Set action to true to avoid watches getting cutoff
-    this.actionInProgress = true;
 
     const dest = copyPathResolve(
       path,

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -1,0 +1,202 @@
+import { EventEmitter } from 'events';
+import { AssetsManager } from '../../../lib/compiler/assets-manager';
+
+// Mock all dependencies
+jest.mock('chokidar', () => ({
+  watch: jest.fn(),
+}));
+jest.mock('glob', () => ({
+  sync: jest.fn(),
+}));
+jest.mock('fs', () => ({
+  copyFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  rmSync: jest.fn(),
+  statSync: jest.fn(),
+}));
+jest.mock('../../../lib/compiler/helpers/copy-path-resolve', () => ({
+  copyPathResolve: jest.fn().mockReturnValue('/dest/file.txt'),
+}));
+jest.mock('../../../lib/compiler/helpers/get-value-or-default', () => ({
+  getValueOrDefault: jest.fn(),
+}));
+
+import * as chokidar from 'chokidar';
+import { sync as globSync } from 'glob';
+import { copyFileSync, mkdirSync } from 'fs';
+import { getValueOrDefault } from '../../../lib/compiler/helpers/get-value-or-default';
+
+describe('AssetsManager', () => {
+  let assetsManager: AssetsManager;
+
+  beforeEach(() => {
+    assetsManager = new AssetsManager();
+    jest.clearAllMocks();
+  });
+
+  describe('closeWatchers', () => {
+    it('should wait for all watchers to be ready before closing them', async () => {
+      // Simulate a watcher that takes time to become ready
+      const mockWatcher = new EventEmitter() as any;
+      mockWatcher.close = jest.fn();
+
+      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
+      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
+      (getValueOrDefault as jest.Mock)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }]) // assets
+        .mockReturnValueOnce('src') // sourceRoot
+        .mockReturnValueOnce(false); // compilerOptions.watchAssets
+
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+      );
+
+      // Call closeWatchers before watcher is ready
+      assetsManager.closeWatchers();
+
+      // Watcher should NOT have been closed yet
+      expect(mockWatcher.close).not.toHaveBeenCalled();
+
+      // Now emit ready event (simulating chokidar finishing initial scan)
+      mockWatcher.emit('ready');
+
+      // Allow promise microtask to resolve
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Now the watcher should be closed
+      expect(mockWatcher.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('should close watchers immediately if they are already ready', async () => {
+      const mockWatcher = new EventEmitter() as any;
+      mockWatcher.close = jest.fn();
+
+      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
+      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
+      (getValueOrDefault as jest.Mock)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+      );
+
+      // Emit ready before calling closeWatchers
+      mockWatcher.emit('ready');
+      await new Promise((resolve) => setImmediate(resolve));
+
+      assetsManager.closeWatchers();
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockWatcher.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('should wait for multiple watchers to all be ready', async () => {
+      const mockWatcher1 = new EventEmitter() as any;
+      mockWatcher1.close = jest.fn();
+      const mockWatcher2 = new EventEmitter() as any;
+      mockWatcher2.close = jest.fn();
+
+      (chokidar.watch as jest.Mock)
+        .mockReturnValueOnce(mockWatcher1)
+        .mockReturnValueOnce(mockWatcher2);
+      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
+      (getValueOrDefault as jest.Mock)
+        .mockReturnValueOnce([
+          { include: '**/*.hbs', watchAssets: true },
+          { include: '**/*.html', watchAssets: true },
+        ])
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+      );
+
+      assetsManager.closeWatchers();
+
+      // Only first watcher is ready
+      mockWatcher1.emit('ready');
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Neither should be closed yet since watcher2 is not ready
+      expect(mockWatcher1.close).not.toHaveBeenCalled();
+      expect(mockWatcher2.close).not.toHaveBeenCalled();
+
+      // Now second watcher is ready
+      mockWatcher2.emit('ready');
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Both should now be closed
+      expect(mockWatcher1.close).toHaveBeenCalledTimes(1);
+      expect(mockWatcher2.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle no watchers gracefully', async () => {
+      // closeWatchers with no watchers should not throw
+      assetsManager.closeWatchers();
+      await new Promise((resolve) => setImmediate(resolve));
+      // No error thrown = success
+    });
+
+    it('should ensure all add events fire before watcher is closed', async () => {
+      const addedFiles: string[] = [];
+      const mockWatcher = new EventEmitter() as any;
+      mockWatcher.close = jest.fn();
+
+      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
+      (globSync as unknown as jest.Mock).mockReturnValue([
+        '/src/a.hbs',
+        '/src/b.hbs',
+        '/src/c.hbs',
+      ]);
+      (getValueOrDefault as jest.Mock)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      // Track calls to copyFileSync to verify files are copied
+      (copyFileSync as jest.Mock).mockImplementation(() => {
+        addedFiles.push('copied');
+      });
+
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+      );
+
+      // Request close before any add events
+      assetsManager.closeWatchers();
+
+      // Simulate chokidar emitting add events for each file
+      mockWatcher.emit('add', '/src/a.hbs');
+      mockWatcher.emit('add', '/src/b.hbs');
+      mockWatcher.emit('add', '/src/c.hbs');
+
+      // Watcher should still be open
+      expect(mockWatcher.close).not.toHaveBeenCalled();
+
+      // All files should have been copied
+      expect(addedFiles).toHaveLength(3);
+
+      // Now emit ready (chokidar does this after initial scan)
+      mockWatcher.emit('ready');
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Now close should have been called
+      expect(mockWatcher.close).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`AssetsManager.closeWatchers()` uses an arbitrary 500ms timeout with an `actionInProgress` flag to decide when to close chokidar file watchers. On slower machines or in CI environments, the chokidar `add` events may not have finished firing within that window, causing assets to be missed or copied nondeterministically.

Issue Number: #2018


## What is the new behavior?

Each chokidar watcher now tracks a `ready` promise that resolves when chokidar emits its `ready` event (indicating the initial scan is complete). `closeWatchers()` awaits all watcher ready promises via `Promise.all()` before closing any watchers. This guarantees all assets from the initial scan are fully copied regardless of system speed, eliminating the race condition.

Changes:
- `lib/compiler/assets-manager.ts`: Replaced the timeout/polling mechanism (`actionInProgress` flag + `setTimeout`) with a `watcherReadyPromises` array. Each watcher registers a promise that resolves on its `ready` event, and `closeWatchers()` awaits all promises before closing.
- `test/lib/compiler/assets-manager.spec.ts`: Added 5 new regression tests covering watcher ready behavior, delayed ready events, multiple watchers, and verifying watchers are not closed prematurely.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

The `ready` event is a built-in chokidar event that fires after the initial scan of all matched files is complete, making it the correct signal to use instead of an arbitrary timeout.