### PR TITLE
fix(swc): fail build on type errors with type check

### DIFF
--- a/lib/compiler/swc/type-checker-host.ts
+++ b/lib/compiler/swc/type-checker-host.ts
@@ -45,8 +45,13 @@ export class TypeCheckerHost {
       return;
     }
     spinner.start();
-    this.runOnce(tsconfigPath, tsBinary, options);
-    spinner.succeed();
+    try {
+      this.runOnce(tsconfigPath, tsBinary, options);
+      spinner.succeed();
+    } catch (err) {
+      spinner.fail();
+      throw err;
+    }
   }
 
   private runInWatchMode(
@@ -121,14 +126,17 @@ export class TypeCheckerHost {
         getNewLine: () => tsBinary.sys.newLine,
       };
 
-      console.log();
-      console.log(
+      const formattedDiagnostics =
         tsBinary.formatDiagnosticsWithColorAndContext(
           diagnostics,
           formatDiagnosticsHost,
-        ),
+        );
+
+      console.log();
+      console.log(formattedDiagnostics);
+      throw new Error(
+        `Found ${diagnostics.length} type error(s) during compilation.`,
       );
-      process.exit(1);
     }
     options.onTypeCheck?.(programRef);
   }

--- a/test/lib/compiler/swc/type-checker-host.spec.ts
+++ b/test/lib/compiler/swc/type-checker-host.spec.ts
@@ -1,13 +1,14 @@
 import * as ts from 'typescript';
-import { TypeCheckerHost } from '../../../../lib/compiler/swc/type-checker-host';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TypeCheckerHost } from '../../../../lib/compiler/swc/type-checker-host.js';
 
-jest.mock('ora', () => {
+vi.mock('ora', () => {
   const spinner = {
-    start: jest.fn().mockReturnThis(),
-    succeed: jest.fn().mockReturnThis(),
-    fail: jest.fn().mockReturnThis(),
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
   };
-  return jest.fn(() => spinner);
+  return { default: vi.fn(() => spinner) };
 });
 
 describe('TypeCheckerHost', () => {
@@ -15,22 +16,22 @@ describe('TypeCheckerHost', () => {
 
   beforeEach(() => {
     typeCheckerHost = new TypeCheckerHost();
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('runOnce (via run)', () => {
     function setupMocks(diagnostics: ts.Diagnostic[]) {
       const mockProgram = {
-        getSourceFiles: jest.fn().mockReturnValue([]),
-        getCompilerOptions: jest.fn().mockReturnValue({}),
+        getSourceFiles: vi.fn().mockReturnValue([]),
+        getCompilerOptions: vi.fn().mockReturnValue({}),
       } as unknown as ts.Program;
 
       const mockBuilderProgram = {
-        getProgram: jest.fn().mockReturnValue(mockProgram),
+        getProgram: vi.fn().mockReturnValue(mockProgram),
       };
 
       const mockTsConfigProvider = {
-        getByConfigFilename: jest.fn().mockReturnValue({
+        getByConfigFilename: vi.fn().mockReturnValue({
           options: {},
           fileNames: [],
           projectReferences: undefined,
@@ -39,18 +40,18 @@ describe('TypeCheckerHost', () => {
 
       const mockTsBinary = {
         ...ts,
-        createIncrementalProgram: jest
+        createIncrementalProgram: vi
           .fn()
           .mockReturnValue(mockBuilderProgram),
-        getPreEmitDiagnostics: jest.fn().mockReturnValue(diagnostics),
-        formatDiagnosticsWithColorAndContext: jest
+        getPreEmitDiagnostics: vi.fn().mockReturnValue(diagnostics),
+        formatDiagnosticsWithColorAndContext: vi
           .fn()
           .mockReturnValue('mock formatted diagnostics'),
         sys: ts.sys,
       };
 
       const mockTypescriptLoader = {
-        load: jest.fn().mockReturnValue(mockTsBinary),
+        load: vi.fn().mockReturnValue(mockTsBinary),
       };
 
       Object.defineProperty(typeCheckerHost, 'tsConfigProvider', {
@@ -77,7 +78,7 @@ describe('TypeCheckerHost', () => {
 
       setupMocks([mockDiagnostic]);
 
-      const onTypeCheck = jest.fn();
+      const onTypeCheck = vi.fn();
 
       expect(() => {
         typeCheckerHost.run('tsconfig.json', {
@@ -93,7 +94,7 @@ describe('TypeCheckerHost', () => {
     it('should call onTypeCheck when there are no type errors', () => {
       const { mockProgram } = setupMocks([]);
 
-      const onTypeCheck = jest.fn();
+      const onTypeCheck = vi.fn();
 
       expect(() => {
         typeCheckerHost.run('tsconfig.json', {
@@ -107,7 +108,7 @@ describe('TypeCheckerHost', () => {
     });
 
     it('should not call process.exit when type errors are found', () => {
-      const processExitSpy = jest
+      const processExitSpy = vi
         .spyOn(process, 'exit')
         .mockImplementation(() => undefined as never);
 
@@ -125,7 +126,7 @@ describe('TypeCheckerHost', () => {
       try {
         typeCheckerHost.run('tsconfig.json', {
           watch: false,
-          onTypeCheck: jest.fn(),
+          onTypeCheck: vi.fn(),
         });
       } catch {
         // Expected to throw
@@ -168,7 +169,7 @@ describe('TypeCheckerHost', () => {
       expect(() => {
         typeCheckerHost.run('tsconfig.json', {
           watch: false,
-          onTypeCheck: jest.fn(),
+          onTypeCheck: vi.fn(),
         });
       }).toThrow('Found 3 type error(s) during compilation.');
     });

--- a/test/lib/compiler/swc/type-checker-host.spec.ts
+++ b/test/lib/compiler/swc/type-checker-host.spec.ts
@@ -1,0 +1,176 @@
+import * as ts from 'typescript';
+import { TypeCheckerHost } from '../../../../lib/compiler/swc/type-checker-host';
+
+jest.mock('ora', () => {
+  const spinner = {
+    start: jest.fn().mockReturnThis(),
+    succeed: jest.fn().mockReturnThis(),
+    fail: jest.fn().mockReturnThis(),
+  };
+  return jest.fn(() => spinner);
+});
+
+describe('TypeCheckerHost', () => {
+  let typeCheckerHost: TypeCheckerHost;
+
+  beforeEach(() => {
+    typeCheckerHost = new TypeCheckerHost();
+    jest.clearAllMocks();
+  });
+
+  describe('runOnce (via run)', () => {
+    function setupMocks(diagnostics: ts.Diagnostic[]) {
+      const mockProgram = {
+        getSourceFiles: jest.fn().mockReturnValue([]),
+        getCompilerOptions: jest.fn().mockReturnValue({}),
+      } as unknown as ts.Program;
+
+      const mockBuilderProgram = {
+        getProgram: jest.fn().mockReturnValue(mockProgram),
+      };
+
+      const mockTsConfigProvider = {
+        getByConfigFilename: jest.fn().mockReturnValue({
+          options: {},
+          fileNames: [],
+          projectReferences: undefined,
+        }),
+      };
+
+      const mockTsBinary = {
+        ...ts,
+        createIncrementalProgram: jest
+          .fn()
+          .mockReturnValue(mockBuilderProgram),
+        getPreEmitDiagnostics: jest.fn().mockReturnValue(diagnostics),
+        formatDiagnosticsWithColorAndContext: jest
+          .fn()
+          .mockReturnValue('mock formatted diagnostics'),
+        sys: ts.sys,
+      };
+
+      const mockTypescriptLoader = {
+        load: jest.fn().mockReturnValue(mockTsBinary),
+      };
+
+      Object.defineProperty(typeCheckerHost, 'tsConfigProvider', {
+        value: mockTsConfigProvider,
+        writable: true,
+      });
+      Object.defineProperty(typeCheckerHost, 'typescriptLoader', {
+        value: mockTypescriptLoader,
+        writable: true,
+      });
+
+      return { mockProgram, mockTsBinary };
+    }
+
+    it('should throw an error when type errors are found', () => {
+      const mockDiagnostic: ts.Diagnostic = {
+        file: undefined,
+        start: undefined,
+        length: undefined,
+        messageText: 'Type error mock',
+        category: ts.DiagnosticCategory.Error,
+        code: 2322,
+      };
+
+      setupMocks([mockDiagnostic]);
+
+      const onTypeCheck = jest.fn();
+
+      expect(() => {
+        typeCheckerHost.run('tsconfig.json', {
+          watch: false,
+          onTypeCheck,
+        });
+      }).toThrow('Found 1 type error(s) during compilation.');
+
+      // onTypeCheck should NOT be called when there are errors
+      expect(onTypeCheck).not.toHaveBeenCalled();
+    });
+
+    it('should call onTypeCheck when there are no type errors', () => {
+      const { mockProgram } = setupMocks([]);
+
+      const onTypeCheck = jest.fn();
+
+      expect(() => {
+        typeCheckerHost.run('tsconfig.json', {
+          watch: false,
+          onTypeCheck,
+        });
+      }).not.toThrow();
+
+      expect(onTypeCheck).toHaveBeenCalledTimes(1);
+      expect(onTypeCheck).toHaveBeenCalledWith(mockProgram);
+    });
+
+    it('should not call process.exit when type errors are found', () => {
+      const processExitSpy = jest
+        .spyOn(process, 'exit')
+        .mockImplementation(() => undefined as never);
+
+      const mockDiagnostic: ts.Diagnostic = {
+        file: undefined,
+        start: undefined,
+        length: undefined,
+        messageText: 'Type error mock',
+        category: ts.DiagnosticCategory.Error,
+        code: 2322,
+      };
+
+      setupMocks([mockDiagnostic]);
+
+      try {
+        typeCheckerHost.run('tsconfig.json', {
+          watch: false,
+          onTypeCheck: jest.fn(),
+        });
+      } catch {
+        // Expected to throw
+      }
+
+      expect(processExitSpy).not.toHaveBeenCalled();
+      processExitSpy.mockRestore();
+    });
+
+    it('should include the number of errors in the thrown error message', () => {
+      const diagnostics: ts.Diagnostic[] = [
+        {
+          file: undefined,
+          start: undefined,
+          length: undefined,
+          messageText: 'Error 1',
+          category: ts.DiagnosticCategory.Error,
+          code: 2322,
+        },
+        {
+          file: undefined,
+          start: undefined,
+          length: undefined,
+          messageText: 'Error 2',
+          category: ts.DiagnosticCategory.Error,
+          code: 2345,
+        },
+        {
+          file: undefined,
+          start: undefined,
+          length: undefined,
+          messageText: 'Error 3',
+          category: ts.DiagnosticCategory.Error,
+          code: 2741,
+        },
+      ];
+
+      setupMocks(diagnostics);
+
+      expect(() => {
+        typeCheckerHost.run('tsconfig.json', {
+          watch: false,
+          onTypeCheck: jest.fn(),
+        });
+      }).toThrow('Found 3 type error(s) during compilation.');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When running `nest build -b swc --type-check`, type errors are detected and printed to the console, but the build process still exits with code 0 (success). This happens because `process.exit(1)` is called inside `runOnce`, which terminates the process before the error can propagate back to the caller. The spinner always shows success, and `SwcCompiler.run` proceeds with compilation despite type errors.

Issue Number: #2646


## What is the new behavior?

Type errors now cause the build to fail properly with exit code 1. The `process.exit(1)` call in `runOnce` has been replaced with a thrown `Error`, which propagates naturally: `runOnce` throws, `run` catches the error and fails the spinner, the promise rejects, `SwcCompiler.run` skips compilation, and `BuildAction.handle` catches the rejection and exits with code 1.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

- `lib/compiler/swc/type-checker-host.ts`: Replaced `process.exit(1)` with `throw new Error(...)` and added try/catch around `runOnce` to fail the spinner on error before re-throwing.
- `test/lib/compiler/swc/type-checker-host.spec.ts`: Added 4 regression tests covering both success and failure paths for `run` and `runOnce`.