### PR TITLE
fix(runners): buffer all stdout chunks and fix error message

### DIFF
--- a/lib/runners/abstract.runner.ts
+++ b/lib/runners/abstract.runner.ts
@@ -1,6 +1,5 @@
 import { red } from 'ansis';
 import { ChildProcess, spawn, SpawnOptions } from 'child_process';
-import { platform } from 'os';
 import { MESSAGES } from '../ui/index.js';
 
 export class AbstractRunner {
@@ -15,30 +14,39 @@ export class AbstractRunner {
     cwd: string = process.cwd(),
   ): Promise<null | string> {
     const args: string[] = [command];
-    const _isWindows = platform() === 'win32';
     const options: SpawnOptions = {
       cwd,
       stdio: collect ? 'pipe' : 'inherit',
       shell: true,
     };
     return new Promise<null | string>((resolve, reject) => {
-      const command = [this.binary, ...this.args, ...args].join(' ');
-      const child: ChildProcess = spawn(command, options);
+      const fullCommand = [this.binary, ...this.args, ...args].join(' ');
+      const child: ChildProcess = spawn(fullCommand, options);
       if (collect) {
-        child.stdout!.on('data', (data) =>
-          resolve(data.toString().replace(/\r\n|\n/, '')),
-        );
+        const chunks: Buffer[] = [];
+        child.stdout!.on('data', (data) => chunks.push(data));
+        child.on('close', (code) => {
+          if (code === 0) {
+            resolve(
+              Buffer.concat(chunks)
+                .toString()
+                .replace(/\r\n|\n/g, ''),
+            );
+          } else {
+            console.error(red(MESSAGES.RUNNER_EXECUTION_ERROR(fullCommand)));
+            reject();
+          }
+        });
+      } else {
+        child.on('close', (code) => {
+          if (code === 0) {
+            resolve(null);
+          } else {
+            console.error(red(MESSAGES.RUNNER_EXECUTION_ERROR(fullCommand)));
+            reject();
+          }
+        });
       }
-      child.on('close', (code) => {
-        if (code === 0) {
-          resolve(null);
-        } else {
-          console.error(
-            red(MESSAGES.RUNNER_EXECUTION_ERROR(`${this.binary} ${command}`)),
-          );
-          reject();
-        }
-      });
     });
   }
 

--- a/test/lib/runners/abstract.runner.spec.ts
+++ b/test/lib/runners/abstract.runner.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ChildProcess, SpawnOptions } from 'child_process';
+import { EventEmitter } from 'events';
+import { Readable } from 'stream';
+
+const spawnMock = vi.fn();
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => spawnMock(...args),
+  };
+});
+
+import { AbstractRunner } from '../../../lib/runners/abstract.runner.js';
+
+class TestRunner extends AbstractRunner {
+  constructor(binary = 'test-bin', args: string[] = []) {
+    super(binary, args);
+  }
+}
+
+function createMockChildProcess(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  child.stdout = new Readable({ read() {} }) as Readable;
+  child.stderr = new Readable({ read() {} }) as Readable;
+  child.stdin = null;
+  child.pid = 1234;
+  child.killed = false;
+  child.connected = false;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = vi.fn();
+  child.send = vi.fn();
+  child.disconnect = vi.fn();
+  child.unref = vi.fn();
+  child.ref = vi.fn();
+  return child;
+}
+
+describe('AbstractRunner', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('run', () => {
+    it('should spawn the full command with shell option', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('npm');
+      const promise = runner.run('install', false);
+
+      child.emit('close', 0);
+      await promise;
+
+      expect(spawnMock).toHaveBeenCalledWith('npm install', {
+        cwd: process.cwd(),
+        stdio: 'inherit',
+        shell: true,
+      });
+    });
+
+    it('should include constructor args in the spawned command', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('node', ['--experimental-modules']);
+      const promise = runner.run('script.js', false);
+
+      child.emit('close', 0);
+      await promise;
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'node --experimental-modules script.js',
+        expect.any(Object),
+      );
+    });
+
+    it('should resolve with null when collect is false and exit code is 0', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('npm');
+      const promise = runner.run('install', false);
+
+      child.emit('close', 0);
+      const result = await promise;
+
+      expect(result).toBeNull();
+    });
+
+    it('should reject when exit code is non-zero and collect is false', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('npm');
+      const promise = runner.run('install', false);
+
+      child.emit('close', 1);
+
+      await expect(promise).rejects.toBeUndefined();
+    });
+
+    it('should use pipe stdio when collect is true', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('npm');
+      const promise = runner.run('--version', true);
+
+      child.stdout!.emit('data', Buffer.from('10.0.0\n'));
+      child.emit('close', 0);
+
+      await promise;
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'npm --version',
+        expect.objectContaining({ stdio: 'pipe' }),
+      );
+    });
+
+    it('should collect all stdout chunks when collect is true', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('npm');
+      const promise = runner.run('--version', true);
+
+      // Simulate multiple data chunks
+      child.stdout!.emit('data', Buffer.from('10.'));
+      child.stdout!.emit('data', Buffer.from('0.'));
+      child.stdout!.emit('data', Buffer.from('0\n'));
+      child.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toBe('10.0.0');
+    });
+
+    it('should strip all newlines from collected output', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('npm');
+      const promise = runner.run('--version', true);
+
+      child.stdout!.emit('data', Buffer.from('10.0.0\r\n'));
+      child.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toBe('10.0.0');
+    });
+
+    it('should strip multiple newlines from collected output', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('some-tool');
+      const promise = runner.run('info', true);
+
+      child.stdout!.emit('data', Buffer.from('line1\nline2\nline3\n'));
+      child.emit('close', 0);
+
+      const result = await promise;
+      expect(result).toBe('line1line2line3');
+    });
+
+    it('should reject when collect is true and exit code is non-zero', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('npm');
+      const promise = runner.run('install bad-pkg', true);
+
+      child.stdout!.emit('data', Buffer.from('error output'));
+      child.emit('close', 1);
+
+      await expect(promise).rejects.toBeUndefined();
+    });
+
+    it('should use the provided cwd option', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('npm');
+      const customCwd = '/custom/path';
+      const promise = runner.run('install', false, customCwd);
+
+      child.emit('close', 0);
+      await promise;
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'npm install',
+        expect.objectContaining({ cwd: customCwd }),
+      );
+    });
+
+    it('should not duplicate binary name in error message', async () => {
+      const child = createMockChildProcess();
+      spawnMock.mockReturnValue(child);
+
+      const runner = new TestRunner('npm');
+      const promise = runner.run('--version', false);
+
+      child.emit('close', 1);
+
+      await expect(promise).rejects.toBeUndefined();
+
+      const errorArg = consoleErrorSpy.mock.calls[0]?.[0] as string;
+      // The error message should contain "npm --version" exactly once,
+      // not "npm npm --version" (which was the old shadowing bug)
+      expect(errorArg).toContain('npm --version');
+      expect(errorArg).not.toContain('npm npm --version');
+    });
+  });
+
+  describe('rawFullCommand', () => {
+    it('should return the full command string', () => {
+      const runner = new TestRunner('npm');
+      const result = runner.rawFullCommand('install');
+      expect(result).toBe('npm install');
+    });
+
+    it('should include constructor args in the full command', () => {
+      const runner = new TestRunner('node', ['--experimental-modules']);
+      const result = runner.rawFullCommand('script.js');
+      expect(result).toBe('node --experimental-modules script.js');
+    });
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `AbstractRunner.run()` method has two bugs:

1. **Stdout data truncation**: When `collect=true`, the `stdout` `data` event handler calls `resolve()` on the very first chunk of data received. If the child process emits output in multiple chunks, all subsequent chunks are silently discarded. This means commands like `--version` could return truncated output depending on how the OS buffers the process output.

2. **Duplicated binary name in error messages**: The local variable `const command` (line 25) shadows the `command` parameter (line 13). The error message on line 37 uses `${this.binary} ${command}` where `command` already contains `this.binary` (since it was reassigned to the full command string). This produces doubled error messages like `"Failed to execute command: npm npm --version"` instead of `"Failed to execute command: npm --version"`.

Additionally:
- The newline replacement regex `/\r\n|\n/` lacks the `g` flag, so only the first newline is stripped
- The `platform` import from `os` is unused (the `_isWindows` variable it was assigned to was never used)

## What is the new behavior?

1. **All stdout chunks are now buffered** into an array and concatenated on the `close` event, ensuring complete output is captured regardless of how the OS chunks the data.

2. **The shadowed variable is renamed** to `fullCommand` to eliminate the shadowing bug, and the error message now correctly uses `fullCommand` directly (which already includes the binary name).

3. **The `g` flag is added** to the newline regex so all newline occurrences are stripped.

4. **The unused `platform` import** is removed.

## Additional context

- Added comprehensive vitest tests for `AbstractRunner` covering: command spawning, stdout chunk collection, error code handling, error message correctness (verifying no binary name duplication), and `rawFullCommand()`.
- All 46 tests in `test/lib/runners/` and `test/lib/package-managers/` pass.
- TypeScript type-checking passes with no errors.
- Prettier formatting verified.