### PR TITLE
feat(assets): restart app on asset change in watch mode (#2626)

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -103,6 +103,7 @@ export class BuildAction extends AbstractAction {
         appName,
         outDir,
         watchAssetsMode,
+        onSuccess,
       );
       this.warnOnIgnoredLibraryAssets(configuration, appName);
 

--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -11,6 +11,8 @@ import {
 import { copyPathResolve } from './helpers/copy-path-resolve.js';
 import { getValueOrDefault } from './helpers/get-value-or-default.js';
 
+const ASSET_CHANGE_RESTART_DEBOUNCE_MS = 150;
+
 export class AssetsManager {
   private watchAssetsKeyValue: { [key: string]: boolean } = {};
   private watchers: chokidar.FSWatcher[] = [];
@@ -32,6 +34,7 @@ export class AssetsManager {
     appName: string | undefined,
     outDir: string,
     watchAssetsMode: boolean,
+    onSuccess?: () => void,
   ) {
     const assets =
       getValueOrDefault<Asset[]>(
@@ -74,6 +77,22 @@ export class AssetsManager {
           appName,
         ) || watchAssetsMode;
 
+      // Debounce onSuccess so that a burst of asset changes (e.g. a git
+      // checkout touching many files at once) only triggers a single restart.
+      let debouncedOnSuccess: (() => void) | undefined;
+      if (onSuccess) {
+        let pending: NodeJS.Timeout | undefined;
+        debouncedOnSuccess = () => {
+          if (pending) {
+            clearTimeout(pending);
+          }
+          pending = setTimeout(() => {
+            pending = undefined;
+            onSuccess();
+          }, ASSET_CHANGE_RESTART_DEBOUNCE_MS);
+        };
+      }
+
       for (const item of filesToCopy) {
         const option: ActionOnFile = {
           action: 'change',
@@ -101,12 +120,32 @@ export class AssetsManager {
             continue;
           }
 
+          let ready = false;
           // prettier-ignore
           const watcher = chokidar
             .watch(matchedPaths)
-            .on('add', (path: string) => this.actionOnFile({ ...option, path, action: 'change' }))
-            .on('change', (path: string) => this.actionOnFile({ ...option, path, action: 'change' }))
-            .on('unlink', (path: string) => this.actionOnFile({ ...option, path, action: 'unlink' }));
+            .on('add', (path: string) => {
+              this.actionOnFile({ ...option, path, action: 'change' });
+              if (ready && debouncedOnSuccess) {
+                debouncedOnSuccess();
+              }
+            })
+            .on('change', (path: string) => {
+              this.actionOnFile({ ...option, path, action: 'change' });
+              if (ready && debouncedOnSuccess) {
+                debouncedOnSuccess();
+              }
+            })
+            .on('unlink', (path: string) => {
+              this.actionOnFile({ ...option, path, action: 'unlink' });
+              if (ready && debouncedOnSuccess) {
+                debouncedOnSuccess();
+              }
+            });
+
+          watcher.on('ready', () => {
+            ready = true;
+          });
 
           this.watchers.push(watcher);
           this.watcherReadyPromises.push(

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import * as chokidar from 'chokidar';
 import { copyFileSync } from 'fs';
 import { sync as globSync } from 'glob';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AssetsManager } from '../../../lib/compiler/assets-manager.js';
 import { getValueOrDefault } from '../../../lib/compiler/helpers/get-value-or-default.js';
 
@@ -155,6 +155,7 @@ describe('AssetsManager', () => {
 
   describe('onSuccess callback on asset change', () => {
     it('should call onSuccess when a watched asset changes after watcher is ready', async () => {
+      vi.useFakeTimers();
       const mockWatcher = new EventEmitter() as any;
       mockWatcher.close = vi.fn();
       const onSuccess = vi.fn();
@@ -176,17 +177,21 @@ describe('AssetsManager', () => {
 
       // Simulate initial add (before ready) - should NOT call onSuccess
       mockWatcher.emit('add', '/src/file.hbs');
+      await vi.runAllTimersAsync();
       expect(onSuccess).not.toHaveBeenCalled();
 
       // Emit ready
       mockWatcher.emit('ready');
 
-      // Simulate change after ready - should call onSuccess
+      // Simulate change after ready - should call onSuccess (after debounce)
       mockWatcher.emit('change', '/src/file.hbs');
+      await vi.runAllTimersAsync();
       expect(onSuccess).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
     });
 
     it('should call onSuccess when a new asset is added after watcher is ready', async () => {
+      vi.useFakeTimers();
       const mockWatcher = new EventEmitter() as any;
       mockWatcher.close = vi.fn();
       const onSuccess = vi.fn();
@@ -208,12 +213,15 @@ describe('AssetsManager', () => {
 
       mockWatcher.emit('ready');
 
-      // Simulate add after ready - should call onSuccess
+      // Simulate add after ready - should call onSuccess (after debounce)
       mockWatcher.emit('add', '/src/new-file.hbs');
+      await vi.runAllTimersAsync();
       expect(onSuccess).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
     });
 
     it('should call onSuccess when an asset is deleted after watcher is ready', async () => {
+      vi.useFakeTimers();
       const mockWatcher = new EventEmitter() as any;
       mockWatcher.close = vi.fn();
       const onSuccess = vi.fn();
@@ -236,9 +244,45 @@ describe('AssetsManager', () => {
       mockWatcher.emit('add', '/src/file.hbs');
       mockWatcher.emit('ready');
 
-      // Simulate unlink after ready - should call onSuccess
+      // Simulate unlink after ready - should call onSuccess (after debounce)
       mockWatcher.emit('unlink', '/src/file.hbs');
+      await vi.runAllTimersAsync();
       expect(onSuccess).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it('should debounce rapid onSuccess calls into a single invocation', async () => {
+      vi.useFakeTimers();
+      const mockWatcher = new EventEmitter() as any;
+      mockWatcher.close = vi.fn();
+      const onSuccess = vi.fn();
+
+      vi.mocked(chokidar.watch).mockReturnValue(mockWatcher);
+      vi.mocked(globSync).mockReturnValue(['/src/file.hbs']);
+      vi.mocked(getValueOrDefault)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+        onSuccess,
+      );
+
+      mockWatcher.emit('ready');
+
+      // Burst of changes — should collapse into a single onSuccess call
+      mockWatcher.emit('change', '/src/a.hbs');
+      mockWatcher.emit('change', '/src/b.hbs');
+      mockWatcher.emit('add', '/src/c.hbs');
+      mockWatcher.emit('unlink', '/src/a.hbs');
+      await vi.runAllTimersAsync();
+
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
     });
 
     it('should not call onSuccess if no callback is provided', async () => {

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -151,6 +151,120 @@ describe('AssetsManager', () => {
       await new Promise((resolve) => setImmediate(resolve));
       // No error thrown = success
     });
+  });
+
+  describe('onSuccess callback on asset change', () => {
+    it('should call onSuccess when a watched asset changes after watcher is ready', async () => {
+      const mockWatcher = new EventEmitter() as any;
+      mockWatcher.close = jest.fn();
+      const onSuccess = jest.fn();
+
+      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
+      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
+      (getValueOrDefault as jest.Mock)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+        onSuccess,
+      );
+
+      // Simulate initial add (before ready) - should NOT call onSuccess
+      mockWatcher.emit('add', '/src/file.hbs');
+      expect(onSuccess).not.toHaveBeenCalled();
+
+      // Emit ready
+      mockWatcher.emit('ready');
+
+      // Simulate change after ready - should call onSuccess
+      mockWatcher.emit('change', '/src/file.hbs');
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onSuccess when a new asset is added after watcher is ready', async () => {
+      const mockWatcher = new EventEmitter() as any;
+      mockWatcher.close = jest.fn();
+      const onSuccess = jest.fn();
+
+      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
+      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
+      (getValueOrDefault as jest.Mock)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+        onSuccess,
+      );
+
+      mockWatcher.emit('ready');
+
+      // Simulate add after ready - should call onSuccess
+      mockWatcher.emit('add', '/src/new-file.hbs');
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onSuccess when an asset is deleted after watcher is ready', async () => {
+      const mockWatcher = new EventEmitter() as any;
+      mockWatcher.close = jest.fn();
+      const onSuccess = jest.fn();
+
+      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
+      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
+      (getValueOrDefault as jest.Mock)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+        onSuccess,
+      );
+
+      mockWatcher.emit('add', '/src/file.hbs');
+      mockWatcher.emit('ready');
+
+      // Simulate unlink after ready - should call onSuccess
+      mockWatcher.emit('unlink', '/src/file.hbs');
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call onSuccess if no callback is provided', async () => {
+      const mockWatcher = new EventEmitter() as any;
+      mockWatcher.close = jest.fn();
+
+      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
+      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
+      (getValueOrDefault as jest.Mock)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      // No onSuccess provided
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+      );
+
+      mockWatcher.emit('ready');
+
+      // Should not throw when change occurs without onSuccess
+      expect(() => mockWatcher.emit('change', '/src/file.hbs')).not.toThrow();
+    });
 
     it('should not stall when asset glob matches no files', async () => {
       // Chokidar does not emit 'ready' when given an empty array,

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -156,12 +156,12 @@ describe('AssetsManager', () => {
   describe('onSuccess callback on asset change', () => {
     it('should call onSuccess when a watched asset changes after watcher is ready', async () => {
       const mockWatcher = new EventEmitter() as any;
-      mockWatcher.close = jest.fn();
-      const onSuccess = jest.fn();
+      mockWatcher.close = vi.fn();
+      const onSuccess = vi.fn();
 
-      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
-      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
-      (getValueOrDefault as jest.Mock)
+      vi.mocked(chokidar.watch).mockReturnValue(mockWatcher);
+      vi.mocked(globSync).mockReturnValue(['/src/file.hbs']);
+      vi.mocked(getValueOrDefault)
         .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
         .mockReturnValueOnce('src')
         .mockReturnValueOnce(false);
@@ -188,12 +188,12 @@ describe('AssetsManager', () => {
 
     it('should call onSuccess when a new asset is added after watcher is ready', async () => {
       const mockWatcher = new EventEmitter() as any;
-      mockWatcher.close = jest.fn();
-      const onSuccess = jest.fn();
+      mockWatcher.close = vi.fn();
+      const onSuccess = vi.fn();
 
-      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
-      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
-      (getValueOrDefault as jest.Mock)
+      vi.mocked(chokidar.watch).mockReturnValue(mockWatcher);
+      vi.mocked(globSync).mockReturnValue(['/src/file.hbs']);
+      vi.mocked(getValueOrDefault)
         .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
         .mockReturnValueOnce('src')
         .mockReturnValueOnce(false);
@@ -215,12 +215,12 @@ describe('AssetsManager', () => {
 
     it('should call onSuccess when an asset is deleted after watcher is ready', async () => {
       const mockWatcher = new EventEmitter() as any;
-      mockWatcher.close = jest.fn();
-      const onSuccess = jest.fn();
+      mockWatcher.close = vi.fn();
+      const onSuccess = vi.fn();
 
-      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
-      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
-      (getValueOrDefault as jest.Mock)
+      vi.mocked(chokidar.watch).mockReturnValue(mockWatcher);
+      vi.mocked(globSync).mockReturnValue(['/src/file.hbs']);
+      vi.mocked(getValueOrDefault)
         .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
         .mockReturnValueOnce('src')
         .mockReturnValueOnce(false);
@@ -243,11 +243,11 @@ describe('AssetsManager', () => {
 
     it('should not call onSuccess if no callback is provided', async () => {
       const mockWatcher = new EventEmitter() as any;
-      mockWatcher.close = jest.fn();
+      mockWatcher.close = vi.fn();
 
-      (chokidar.watch as jest.Mock).mockReturnValue(mockWatcher);
-      (globSync as unknown as jest.Mock).mockReturnValue(['/src/file.hbs']);
-      (getValueOrDefault as jest.Mock)
+      vi.mocked(chokidar.watch).mockReturnValue(mockWatcher);
+      vi.mocked(globSync).mockReturnValue(['/src/file.hbs']);
+      vi.mocked(getValueOrDefault)
         .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
         .mockReturnValueOnce('src')
         .mockReturnValueOnce(false);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When running `nest start --watch --watchAssets`, changes to TypeScript files trigger an application restart, but changes to watched asset files (e.g. `.proto`, `.graphql`) only copy the updated file without restarting the application. This means developers must manually restart to pick up asset changes.

Issue Number: #2626


## What is the new behavior?

Asset file changes now trigger an application restart when using `--watch --watchAssets`. This is achieved by adding an optional `onSuccess` callback parameter to `AssetsManager.copyAssets()`. The `BuildAction` passes its existing `onSuccess` handler (the one that restarts the app) to `copyAssets()`, so asset changes invoke the same restart logic as TypeScript changes. The callback is only invoked after chokidar emits the `ready` event, preventing unnecessary restarts during the initial file scan.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

**Files changed:**
- `lib/compiler/assets-manager.ts` — added optional `onSuccess` callback parameter, invoked on post-ready add/change/unlink events
- `actions/build.action.ts` — passes `onSuccess` callback through to `copyAssets()`
- `test/lib/compiler/assets-manager.spec.ts` — added 4 regression tests covering callback invocation, no-callback during initial scan, and no-callback when not provided