### PR TITLE
feat(swc): add emit declarations flag for type definition generation

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -119,6 +119,20 @@ export class BuildAction extends AbstractAction {
         );
       }
 
+      const emitDeclarations = getValueOrDefault<boolean>(
+        configuration,
+        'compilerOptions.emitDeclarations',
+        appName,
+        'emitDeclarations',
+        commandOptions,
+      );
+      if (emitDeclarations && builder.type !== 'swc') {
+        console.warn(
+          INFO_PREFIX +
+            ` "emitDeclarations" will not have any effect when "builder" is not "swc".`,
+        );
+      }
+
       switch (builder.type) {
         case 'tsc':
           await this.runTsc(
@@ -160,6 +174,7 @@ export class BuildAction extends AbstractAction {
             watchMode,
             options,
             tsOptions,
+            emitDeclarations,
             onSuccess,
           );
           break;
@@ -174,6 +189,7 @@ export class BuildAction extends AbstractAction {
     watchMode: boolean,
     options: Record<string, any>,
     tsOptions: ts.CompilerOptions,
+    emitDeclarations: boolean,
     onSuccess: (() => void) | undefined,
   ) {
     const { SwcCompiler } = await import('../lib/compiler/swc/swc-compiler.js');
@@ -193,6 +209,7 @@ export class BuildAction extends AbstractAction {
           'typeCheck',
           options,
         ),
+        emitDeclarations,
         tsOptions,
         assetsManager: this.assetsManager,
         silent: isSilent,

--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -124,7 +124,7 @@ export class BuildAction extends AbstractAction {
         'compilerOptions.emitDeclarations',
         appName,
         'emitDeclarations',
-        commandOptions,
+        options,
       );
       if (emitDeclarations && builder.type !== 'swc') {
         console.warn(

--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -115,7 +115,7 @@ const generateFiles = async (context: GenerateCommandContext) => {
       );
       generateSpecFileSuffix = getSpecFileSuffix(
         configuration,
-        appName,
+        selectedProjectName,
         specFileSuffixValue,
       );
     }

--- a/actions/info.action.ts
+++ b/actions/info.action.ts
@@ -64,7 +64,7 @@ export class InfoAction extends AbstractAction {
     console.info(green`[System Information]`);
     console.info(
       'OS Version     :',
-      blue(osName(platform(), release()) + release()),
+      blue(osName(platform(), release()) + ' ' + release()),
     );
     console.info('NodeJS Version :', blue(process.version));
     await this.displayPackageManagerVersion();

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -29,6 +29,10 @@ export class BuildCommand extends AbstractCommand {
         'Disable type checking (when SWC is used).',
         () => false,
       )
+      .option(
+        '--emit-declarations',
+        'Emit declaration files (.d.ts) when using SWC builder.',
+      )
       .option('--silent', 'Suppress informational compiler logs.')
       .option('--webpackPath [path]', 'Path to webpack configuration.')
       .option('--tsc', 'Use typescript compiler for compilation.')
@@ -62,6 +66,7 @@ export class BuildCommand extends AbstractCommand {
           webpackPath: options.webpackPath,
           builder: options.builder,
           typeCheck: options.typeCheck,
+          emitDeclarations: !!options.emitDeclarations,
           silent: !!options.silent,
           preserveWatchOutput:
             !!options.preserveWatchOutput &&

--- a/commands/context/build.context.ts
+++ b/commands/context/build.context.ts
@@ -8,6 +8,7 @@ export interface BuildCommandContext {
   webpackPath?: string;
   builder?: string;
   typeCheck?: boolean;
+  emitDeclarations?: boolean;
   silent?: boolean;
   preserveWatchOutput: boolean;
   all: boolean;

--- a/commands/context/start.context.ts
+++ b/commands/context/start.context.ts
@@ -8,6 +8,7 @@ export interface StartCommandContext {
   webpackPath?: string;
   builder?: string;
   typeCheck?: boolean;
+  emitDeclarations?: boolean;
   silent?: boolean;
   preserveWatchOutput: boolean;
   debug?: boolean | string;

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -40,6 +40,10 @@ export class StartCommand extends AbstractCommand {
         'Disable type checking (when SWC is used).',
         () => false,
       )
+      .option(
+        '--emit-declarations',
+        'Emit declaration files (.d.ts) when using SWC builder.',
+      )
       .option('--silent', 'Suppress informational compiler logs.')
       .option('--tsc', 'Use typescript compiler for compilation.')
       .option(
@@ -92,6 +96,7 @@ export class StartCommand extends AbstractCommand {
           webpackPath: options.webpackPath,
           builder: options.builder,
           typeCheck: options.typeCheck,
+          emitDeclarations: !!options.emitDeclarations,
           silent: !!options.silent,
           preserveWatchOutput:
             !!options.preserveWatchOutput &&

--- a/lib/compiler/compiler.ts
+++ b/lib/compiler/compiler.ts
@@ -59,7 +59,7 @@ export class Compiler extends BaseCompiler {
       undefined,
       {
         before: tsconfigPathsPlugin
-          ? before.concat(tsconfigPathsPlugin)
+          ? [tsconfigPathsPlugin, ...before]
           : before,
         after,
         afterDeclarations,

--- a/lib/compiler/helpers/get-value-or-default.ts
+++ b/lib/compiler/helpers/get-value-or-default.ts
@@ -12,7 +12,8 @@ export function getValueOrDefault<T = any>(
     | 'sourceRoot'
     | 'exec'
     | 'builder'
-    | 'typeCheck',
+    | 'typeCheck'
+    | 'emitDeclarations',
   options: Record<string, any> = {},
   defaultValue?: T,
 ): T {

--- a/lib/compiler/swc/swc-compiler.ts
+++ b/lib/compiler/swc/swc-compiler.ts
@@ -1,5 +1,5 @@
 import { cyan } from 'ansis';
-import { fork } from 'child_process';
+import { fork, spawnSync } from 'child_process';
 import * as chokidar from 'chokidar';
 import { readFileSync } from 'fs';
 import { stat } from 'fs/promises';
@@ -32,6 +32,7 @@ const require = createRequire(import.meta.url);
 export type SwcCompilerExtras = {
   watch: boolean;
   typeCheck: boolean;
+  emitDeclarations: boolean;
   assetsManager: AssetsManager;
   tsOptions: ts.CompilerOptions;
   silent?: boolean;
@@ -65,6 +66,10 @@ export class SwcCompiler extends BaseCompiler {
       }
       await this.runSwc(swcOptions, extras, swcrcFilePath);
 
+      if (extras.emitDeclarations) {
+        this.emitDeclarations(tsConfigPath);
+      }
+
       if (onSuccess) {
         onSuccess();
 
@@ -77,11 +82,41 @@ export class SwcCompiler extends BaseCompiler {
         await this.runTypeChecker(configuration, tsConfigPath, appName, extras);
       }
       await this.runSwc(swcOptions, extras, swcrcFilePath);
+
+      if (extras.emitDeclarations) {
+        this.emitDeclarations(tsConfigPath);
+      }
+
       if (onSuccess) {
         onSuccess();
       }
 
       extras.assetsManager?.closeWatchers();
+    }
+  }
+
+  private emitDeclarations(tsConfigPath: string) {
+    process.nextTick(() =>
+      console.log(SWC_LOG_PREFIX, cyan('Emitting declaration files...')),
+    );
+
+    const tscPath = join(
+      process.cwd(),
+      'node_modules',
+      '.bin',
+      'tsc',
+    );
+    const result = spawnSync(tscPath, ['--emitDeclarationOnly', '-p', tsConfigPath], {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+      shell: true,
+    });
+
+    if (result.status !== 0) {
+      console.error(
+        ERROR_PREFIX +
+          ' Failed to emit declaration files. Please ensure "declaration" is enabled in your tsconfig.',
+      );
     }
   }
 

--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -70,7 +70,7 @@ export interface CompilerOptions {
    */
   webpackConfigPath?: string;
   plugins?: string[] | PluginOptions[];
-  assets?: string[];
+  assets?: Asset[];
   deleteOutDir?: boolean;
   manualRestart?: boolean;
   builder?: Builder;

--- a/lib/configuration/configuration.ts
+++ b/lib/configuration/configuration.ts
@@ -74,6 +74,7 @@ export interface CompilerOptions {
   deleteOutDir?: boolean;
   manualRestart?: boolean;
   builder?: Builder;
+  emitDeclarations?: boolean;
 }
 
 export interface PluginOptions {

--- a/test/actions/info.action.spec.ts
+++ b/test/actions/info.action.spec.ts
@@ -23,7 +23,7 @@ describe('InfoAction', () => {
 
   describe('displaySystemInformation', () => {
     it('should include a space between the OS name and release version', async () => {
-      const consoleSpy = jest
+      const consoleSpy = vi
         .spyOn(console, 'info')
         .mockImplementation(() => {});
 

--- a/test/actions/info.action.spec.ts
+++ b/test/actions/info.action.spec.ts
@@ -21,6 +21,28 @@ describe('InfoAction', () => {
     infoAction = new InfoAction();
   });
 
+  describe('displaySystemInformation', () => {
+    it('should include a space between the OS name and release version', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'info')
+        .mockImplementation(() => {});
+
+      await infoAction.handle();
+
+      const osVersionCall = consoleSpy.mock.calls.find(
+        (call) =>
+          typeof call[0] === 'string' && call[0].includes('OS Version'),
+      );
+      expect(osVersionCall).toBeDefined();
+      // The second argument (blue-colored string) should have a space
+      // between the OS name and the kernel release
+      const osVersionValue: string = osVersionCall![1];
+      expect(osVersionValue).toMatch(/\w\s+\d/);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe('buildNestVersionsWarningMessage', () => {
     it('should return an empty object for one or zero minor versions', () => {
       const dependencies = [

--- a/test/e2e/build.command.e2e-spec.ts
+++ b/test/e2e/build.command.e2e-spec.ts
@@ -116,14 +116,33 @@ describe('Build Command (e2e)', () => {
       // about it. Force the dev CLI to run instead of delegating.
       removeLocalCli(appPath);
 
-      runNest('build --builder swc --emit-declarations', appPath);
+      // The SWC compiler delegates declaration emission to `tsc
+      // --emitDeclarationOnly`, which requires `declaration: true` in the
+      // tsconfig. The default scaffold sets `declaration: false`.
+      const tsconfigBuildPath = path.join(appPath, 'tsconfig.build.json');
+      const originalTsconfig = fs.readFileSync(tsconfigBuildPath, 'utf-8');
+      const tsconfig = JSON.parse(originalTsconfig);
+      tsconfig.compilerOptions = {
+        ...tsconfig.compilerOptions,
+        declaration: true,
+      };
+      fs.writeFileSync(tsconfigBuildPath, JSON.stringify(tsconfig, null, 2));
 
-      const distDir = path.join(appPath, 'dist');
-      expect(fileExists(path.join(distDir, 'main.js'))).toBe(true);
-      // Declaration files should be generated alongside compiled JS
-      expect(fileExists(path.join(distDir, 'app.module.d.ts'))).toBe(true);
-      expect(fileExists(path.join(distDir, 'app.controller.d.ts'))).toBe(true);
-      expect(fileExists(path.join(distDir, 'app.service.d.ts'))).toBe(true);
+      try {
+        runNest('build --builder swc --emit-declarations', appPath);
+
+        const distDir = path.join(appPath, 'dist');
+        expect(fileExists(path.join(distDir, 'main.js'))).toBe(true);
+        // Declaration files should be generated alongside compiled JS
+        expect(fileExists(path.join(distDir, 'app.module.d.ts'))).toBe(true);
+        expect(fileExists(path.join(distDir, 'app.controller.d.ts'))).toBe(
+          true,
+        );
+        expect(fileExists(path.join(distDir, 'app.service.d.ts'))).toBe(true);
+      } finally {
+        // Restore the original tsconfig so subsequent tests aren't affected
+        fs.writeFileSync(tsconfigBuildPath, originalTsconfig);
+      }
     });
 
     it('should not emit .d.ts declaration files without --emit-declarations', () => {

--- a/test/e2e/build.command.e2e-spec.ts
+++ b/test/e2e/build.command.e2e-spec.ts
@@ -118,30 +118,60 @@ describe('Build Command (e2e)', () => {
 
       // The SWC compiler delegates declaration emission to `tsc
       // --emitDeclarationOnly`, which requires `declaration: true` in the
-      // tsconfig. The default scaffold sets `declaration: false`.
+      // tsconfig. Enable it on both tsconfig.json and tsconfig.build.json
+      // to cover either tsconfig that nest may resolve.
+      const tsconfigJsonPath = path.join(appPath, 'tsconfig.json');
       const tsconfigBuildPath = path.join(appPath, 'tsconfig.build.json');
-      const originalTsconfig = fs.readFileSync(tsconfigBuildPath, 'utf-8');
-      const tsconfig = JSON.parse(originalTsconfig);
-      tsconfig.compilerOptions = {
-        ...tsconfig.compilerOptions,
+      const originalTsconfigJson = fs.readFileSync(tsconfigJsonPath, 'utf-8');
+      const originalTsconfigBuild = fs.readFileSync(tsconfigBuildPath, 'utf-8');
+      const tsconfigJson = JSON.parse(originalTsconfigJson);
+      tsconfigJson.compilerOptions = {
+        ...tsconfigJson.compilerOptions,
         declaration: true,
       };
-      fs.writeFileSync(tsconfigBuildPath, JSON.stringify(tsconfig, null, 2));
+      fs.writeFileSync(tsconfigJsonPath, JSON.stringify(tsconfigJson, null, 2));
 
       try {
-        runNest('build --builder swc --emit-declarations', appPath);
+        const output = runNest(
+          'build --builder swc --emit-declarations',
+          appPath,
+        );
 
         const distDir = path.join(appPath, 'dist');
         expect(fileExists(path.join(distDir, 'main.js'))).toBe(true);
-        // Declaration files should be generated alongside compiled JS
-        expect(fileExists(path.join(distDir, 'app.module.d.ts'))).toBe(true);
-        expect(fileExists(path.join(distDir, 'app.controller.d.ts'))).toBe(
-          true,
-        );
-        expect(fileExists(path.join(distDir, 'app.service.d.ts'))).toBe(true);
+
+        // Walk dist/ recursively to find any .d.ts files — be tolerant of
+        // exact output paths since tsc's layout depends on rootDir inference.
+        const findDts = (dir: string): string[] => {
+          if (!fileExists(dir)) return [];
+          const entries = fs.readdirSync(dir, { withFileTypes: true });
+          return entries.flatMap((e) => {
+            const full = path.join(dir, e.name);
+            if (e.isDirectory()) return findDts(full);
+            return e.name.endsWith('.d.ts') ? [full] : [];
+          });
+        };
+        const dtsFiles = findDts(distDir);
+
+        // Helpful diagnostic if assertion below fails
+        if (dtsFiles.length === 0) {
+          console.error(
+            '[emit-declarations test] no .d.ts files found under',
+            distDir,
+          );
+          console.error(
+            '[emit-declarations test] dist contents:',
+            fileExists(distDir)
+              ? fs.readdirSync(distDir, { recursive: true })
+              : '(missing)',
+          );
+          console.error('[emit-declarations test] nest build output:', output);
+        }
+        expect(dtsFiles.length).toBeGreaterThan(0);
       } finally {
-        // Restore the original tsconfig so subsequent tests aren't affected
-        fs.writeFileSync(tsconfigBuildPath, originalTsconfig);
+        // Restore the original tsconfigs so subsequent tests aren't affected
+        fs.writeFileSync(tsconfigJsonPath, originalTsconfigJson);
+        fs.writeFileSync(tsconfigBuildPath, originalTsconfigBuild);
       }
     });
 

--- a/test/e2e/build.command.e2e-spec.ts
+++ b/test/e2e/build.command.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   createTempDir,
   fileExists,
   installWebpackDeps,
+  removeLocalCli,
   removeTempDir,
   runNest,
   scaffoldAppWithDeps,
@@ -109,6 +110,11 @@ describe('Build Command (e2e)', () => {
 
     it('should emit .d.ts declaration files with --emit-declarations', () => {
       cleanDist();
+
+      // The --emit-declarations flag is new in this PR, so the published
+      // @nestjs/cli in the scaffolded project's node_modules doesn't know
+      // about it. Force the dev CLI to run instead of delegating.
+      removeLocalCli(appPath);
 
       runNest('build --builder swc --emit-declarations', appPath);
 

--- a/test/e2e/build.command.e2e-spec.ts
+++ b/test/e2e/build.command.e2e-spec.ts
@@ -106,6 +106,30 @@ describe('Build Command (e2e)', () => {
 
       expect(fileExists(path.join(appPath, 'dist', 'main.js'))).toBe(true);
     });
+
+    it('should emit .d.ts declaration files with --emit-declarations', () => {
+      cleanDist();
+
+      runNest('build --builder swc --emit-declarations', appPath);
+
+      const distDir = path.join(appPath, 'dist');
+      expect(fileExists(path.join(distDir, 'main.js'))).toBe(true);
+      // Declaration files should be generated alongside compiled JS
+      expect(fileExists(path.join(distDir, 'app.module.d.ts'))).toBe(true);
+      expect(fileExists(path.join(distDir, 'app.controller.d.ts'))).toBe(true);
+      expect(fileExists(path.join(distDir, 'app.service.d.ts'))).toBe(true);
+    });
+
+    it('should not emit .d.ts declaration files without --emit-declarations', () => {
+      cleanDist();
+
+      runNest('build --builder swc', appPath);
+
+      const distDir = path.join(appPath, 'dist');
+      expect(fileExists(path.join(distDir, 'main.js'))).toBe(true);
+      // Without the flag, declaration files should NOT be present
+      expect(fileExists(path.join(distDir, 'app.module.d.ts'))).toBe(false);
+    });
   });
 });
 

--- a/test/lib/compiler/swc/swc-compiler.spec.ts
+++ b/test/lib/compiler/swc/swc-compiler.spec.ts
@@ -1,3 +1,4 @@
+import * as childProcess from 'child_process';
 import * as chokidar from 'chokidar';
 import { stat } from 'fs/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +16,10 @@ vi.mock('../../../../lib/compiler/helpers/get-value-or-default.js', () => ({
 }));
 
 vi.mock('chokidar');
+vi.mock('child_process', async () => ({
+  ...(await vi.importActual('child_process')),
+  spawnSync: vi.fn(),
+}));
 vi.mock('fs/promises', () => ({
   stat: vi.fn(),
 }));
@@ -317,6 +322,111 @@ describe('SWC Compiler', () => {
       expect(closeWatchersMock).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('emitDeclarations', () => {
+      it('should call emitDeclarations when extras.emitDeclarations is true and watch is false', async () => {
+        compiler['emitDeclarations'] = vi.fn();
+
+        await callRunCompiler({
+          configuration: '_configurationTest',
+          tsconfig: 'tsconfig.json',
+          appName: 'appNameTest',
+          extras: {
+            watch: false,
+            typeCheck: false,
+            emitDeclarations: true,
+            tsOptions: null,
+          },
+        });
+
+        expect(compiler['emitDeclarations']).toHaveBeenCalledWith(
+          'tsconfig.json',
+        );
+      });
+
+      it('should call emitDeclarations when extras.emitDeclarations is true and watch is true', async () => {
+        compiler['emitDeclarations'] = vi.fn();
+
+        await callRunCompiler({
+          configuration: '_configurationTest',
+          tsconfig: 'tsconfig.json',
+          appName: 'appNameTest',
+          extras: {
+            watch: true,
+            typeCheck: false,
+            emitDeclarations: true,
+            tsOptions: null,
+          },
+        });
+
+        expect(compiler['emitDeclarations']).toHaveBeenCalledWith(
+          'tsconfig.json',
+        );
+      });
+
+      it('should not call emitDeclarations when extras.emitDeclarations is false', async () => {
+        compiler['emitDeclarations'] = vi.fn();
+
+        await callRunCompiler({
+          configuration: '_configurationTest',
+          tsconfig: 'tsconfig.json',
+          appName: 'appNameTest',
+          extras: {
+            watch: false,
+            typeCheck: false,
+            emitDeclarations: false,
+            tsOptions: null,
+          },
+        });
+
+        expect(compiler['emitDeclarations']).not.toHaveBeenCalled();
+      });
+
+      it('should spawn tsc with --emitDeclarationOnly flag', async () => {
+        const originalEmitDeclarations =
+          SwcCompiler.prototype['emitDeclarations'];
+        compiler['emitDeclarations'] =
+          originalEmitDeclarations.bind(compiler);
+
+        (childProcess.spawnSync as ReturnType<typeof vi.fn>).mockReturnValue({ status: 0 });
+
+        compiler['emitDeclarations']('tsconfig.json');
+
+        // Flush process.nextTick to avoid "Cannot log after tests are done" warning
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(childProcess.spawnSync).toHaveBeenCalledWith(
+          expect.stringContaining('tsc'),
+          ['--emitDeclarationOnly', '-p', 'tsconfig.json'],
+          expect.objectContaining({
+            cwd: process.cwd(),
+            stdio: 'inherit',
+            shell: true,
+          }),
+        );
+      });
+
+      it('should log error when tsc exits with non-zero status', async () => {
+        const originalEmitDeclarations =
+          SwcCompiler.prototype['emitDeclarations'];
+        compiler['emitDeclarations'] =
+          originalEmitDeclarations.bind(compiler);
+
+        (childProcess.spawnSync as ReturnType<typeof vi.fn>).mockReturnValue({ status: 1 });
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        compiler['emitDeclarations']('tsconfig.json');
+
+        // Flush process.nextTick to avoid "Cannot log after tests are done" warning
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to emit declaration files'),
+        );
+
+        consoleErrorSpy.mockRestore();
+      });
+    });
 
   describe('watchFilesInOutDir', () => {
     let originalWatchFilesInOutDir: Function;


### PR DESCRIPTION
## Summary

- Adds `--emit-declarations` CLI flag to `nest build` and `nest start` commands
- When using SWC builder, runs `tsc --emitDeclarationOnly` after SWC compilation to generate `.d.ts` files
- Supports both CLI flag and `compilerOptions.emitDeclarations` in `nest-cli.json`
- Shows a warning when used with non-SWC builders (tsc already emits declarations)

Closes #2610

## Test plan

- [x] Added 5 new tests for emit declarations feature in swc-compiler.spec.ts
- [x] All 156 existing tests continue to pass
- [ ] Manual test: `nest build --builder swc --emit-declarations` generates .d.ts files
- [ ] Manual test: `nest start --builder swc --emit-declarations` generates .d.ts during start