### PR TITLE
fix(swc): fix inverted chokidar ignored filter in watch mode

### DIFF
--- a/lib/compiler/swc/swc-compiler.ts
+++ b/lib/compiler/swc/swc-compiler.ts
@@ -276,11 +276,11 @@ export class SwcCompiler extends BaseCompiler {
       // or any other specified directory
       return;
     }
-    const extensions = options.cliOptions?.extensions ?? ['ts'];
+    const extensions = options.cliOptions?.extensions ?? ['.ts'];
     const watcher = chokidar.watch(srcDir, {
       ignored: (file, stats) =>
         (stats?.isFile() &&
-          extensions.includes(path.extname(file).slice(1))) as boolean,
+          !extensions.some((ext) => file.endsWith(ext))) as boolean,
       ignoreInitial: true,
       awaitWriteFinish: {
         stabilityThreshold: 50,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `watchFilesInSrcDir()` method in `SwcCompiler` has a broken `ignored` filter with two layered issues:

1. **Extension format mismatch**: `extensions` from `swcDefaultsFactory` is `['.js', '.ts']` (dotted), but `path.extname(file).slice(1)` strips the dot giving `'ts'`. So `['.js', '.ts'].includes('ts')` is always `false`.

2. **Inverted logic**: Even if extensions matched, the logic says "ignore files that HAVE the right extension" — opposite of intent. Compare with the correct `watchFilesInOutDir` which uses `!(...)` to ignore files that DON'T match.

The net effect is **all** files in the source directory pass through to the watcher, causing unnecessary SWC recompilation when non-source files (`.json`, `.css`, `.env`) change.

## What is the new behavior?

- Uses `file.endsWith(ext)` for robust matching regardless of dot prefix format
- Negates the condition so source files are watched and non-source files are ignored
- Updates the fallback default from `['ts']` to `['.ts']` for consistency with `swcDefaultsFactory`

## Additional context

The fix mirrors the pattern already used in `watchFilesInOutDir` (line 301-303).