### PR TITLE
fix(assets-manager): return promise from close watchers

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -291,7 +291,7 @@ export class BuildAction extends AbstractAction {
         undefined,
         onSuccess,
       );
-      this.assetsManager.closeWatchers();
+      await this.assetsManager.closeWatchers();
     }
   }
 

--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -22,7 +22,7 @@ export class AssetsManager {
    * ensuring all assets are copied regardless of system speed.
    */
   public closeWatchers() {
-    Promise.all(this.watcherReadyPromises).then(() => {
+    return Promise.all(this.watcherReadyPromises).then(() => {
       this.watchers.forEach((watcher) => watcher.close());
     });
   }

--- a/lib/compiler/swc/swc-compiler.ts
+++ b/lib/compiler/swc/swc-compiler.ts
@@ -73,7 +73,7 @@ export class SwcCompiler extends BaseCompiler {
         onSuccess();
       }
 
-      extras.assetsManager?.closeWatchers();
+      await extras.assetsManager?.closeWatchers();
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`closeWatchers()` calls `Promise.all()` without returning the result — a fire-and-forget. Callers (`build.action.ts`, `swc-compiler.ts`) have no way to await watcher cleanup, risking the build process exiting before in-flight asset copies complete.

## What is the new behavior?

- `closeWatchers()` now returns the promise
- `build.action.ts` and `swc-compiler.ts` now `await` the result