### PR TITLE
test(remaining-flags): add unit tests for flag parsing

### DIFF
--- a/test/lib/utils/remaining-flags.spec.ts
+++ b/test/lib/utils/remaining-flags.spec.ts
@@ -1,0 +1,42 @@
+import { Command } from 'commander';
+import { getRemainingFlags } from '../../../lib/utils/remaining-flags';
+
+describe('getRemainingFlags', () => {
+  it('should return flags not consumed by commander', () => {
+    const program = new Command();
+    program.option('-p, --project <project>', 'project name');
+    program.parse(['node', 'nest', 'build', '--project', 'app', '--custom']);
+
+    const remaining = getRemainingFlags(program as any);
+    expect(remaining).toContain('--custom');
+  });
+
+  it('should exclude flags consumed by commander', () => {
+    const program = new Command();
+    program.option('-w, --watch', 'watch mode');
+    program.parse(['node', 'nest', 'build', '--watch', '--extra']);
+
+    const remaining = getRemainingFlags(program as any);
+    expect(remaining).not.toContain('--watch');
+    expect(remaining).toContain('--extra');
+  });
+
+  it('should return all args when no flags start with dashes', () => {
+    const program = new Command();
+    program.parse(['node', 'nest', 'build']);
+
+    const remaining = getRemainingFlags(program as any);
+    // When no --flag is found, splice(0) returns all raw args
+    expect(remaining).toEqual(['node', 'nest', 'build']);
+  });
+
+  it('should handle multiple unknown flags', () => {
+    const program = new Command();
+    program.parse(['node', 'nest', 'build', '--foo', '--bar', '--baz']);
+
+    const remaining = getRemainingFlags(program as any);
+    expect(remaining).toContain('--foo');
+    expect(remaining).toContain('--bar');
+    expect(remaining).toContain('--baz');
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tests

## What is the current behavior?

No tests exist for `getRemainingFlags()` in `lib/utils/remaining-flags.ts`.

## What is the new behavior?

Added 4 unit tests covering:
- Unknown flags pass through to the result
- Commander-consumed flags (registered options) are excluded
- Behavior when no dashed flags are present
- Multiple unknown flags are all returned

## Test plan
- [x] All 4 tests pass