### PR TITLE
test(configuration): expand nest configuration loader test coverage

### DIFF
--- a/test/lib/configuration/nest-configuration.loader.spec.ts
+++ b/test/lib/configuration/nest-configuration.loader.spec.ts
@@ -85,3 +85,99 @@ describe('Nest Configuration Loader', () => {
     });
   });
 });
+
+describe('Nest Configuration Loader - extended', () => {
+  function createMockReader(
+    readResult: string | undefined,
+  ): Reader {
+    return {
+      readAnyOf: jest.fn(() => readResult),
+      read: jest.fn(() => readResult),
+      list: jest.fn(() => []),
+    } as unknown as Reader;
+  }
+
+  it('should deep merge compilerOptions with defaults', () => {
+    const reader = createMockReader(
+      JSON.stringify({
+        compilerOptions: {
+          webpack: true,
+          plugins: ['my-plugin'],
+        },
+      }),
+    );
+    const loader = new NestConfigurationLoader(reader);
+    // Use unique name to avoid cache
+    const config = loader.load('deep-merge-test.json');
+
+    // User's compilerOptions should override defaults
+    expect(config.compilerOptions.webpack).toBe(true);
+    expect(config.compilerOptions.plugins).toEqual(['my-plugin']);
+    // Default compilerOptions should be preserved
+    expect(config.compilerOptions.assets).toEqual([]);
+    expect(config.compilerOptions.manualRestart).toBe(false);
+  });
+
+  it('should return defaults when config file is empty object', () => {
+    const reader = createMockReader(JSON.stringify({}));
+    const loader = new NestConfigurationLoader(reader);
+    const config = loader.load('empty-config-test.json');
+
+    expect(config.sourceRoot).toBe('src');
+    expect(config.entryFile).toBe('main');
+    expect(config.language).toBe('ts');
+  });
+
+  it('should override only sourceRoot when specified', () => {
+    const reader = createMockReader(
+      JSON.stringify({ sourceRoot: 'custom-src' }),
+    );
+    const loader = new NestConfigurationLoader(reader);
+    const config = loader.load('sourceroot-test.json');
+
+    expect(config.sourceRoot).toBe('custom-src');
+    expect(config.entryFile).toBe('main');
+    expect(config.language).toBe('ts');
+  });
+
+  it('should preserve project-specific settings', () => {
+    const reader = createMockReader(
+      JSON.stringify({
+        projects: {
+          'my-app': {
+            sourceRoot: 'apps/my-app/src',
+            compilerOptions: { webpack: true },
+          },
+        },
+      }),
+    );
+    const loader = new NestConfigurationLoader(reader);
+    const config = loader.load('projects-test.json');
+
+    expect(config.projects['my-app']).toBeDefined();
+    expect(config.projects['my-app'].sourceRoot).toBe('apps/my-app/src');
+  });
+
+  it('should return defaults when readAnyOf returns undefined', () => {
+    const reader = createMockReader(undefined as any);
+    const loader = new NestConfigurationLoader(reader);
+    const config = loader.load('undefined-test.json');
+
+    expect(config.sourceRoot).toBe('src');
+    expect(config.language).toBe('ts');
+    expect(config.entryFile).toBe('main');
+  });
+
+  it('should cache config results for the same name', () => {
+    const reader = createMockReader(
+      JSON.stringify({ sourceRoot: 'cached-src' }),
+    );
+    const loader = new NestConfigurationLoader(reader);
+
+    const config1 = loader.load('cache-test.json');
+    const config2 = loader.load('cache-test.json');
+
+    expect(config1).toBe(config2); // Same reference = cached
+    expect(reader.read).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tests

## What is the current behavior?

The `NestConfigurationLoader` has only 2 tests covering basic `readAnyOf` and `read` calls.

## What is the new behavior?

Added 6 new tests covering:
- **compilerOptions deep merge**: User's compilerOptions override defaults while preserving unspecified defaults
- **Empty config file**: `{}` returns all defaults
- **sourceRoot override**: Partial config only overrides specified fields
- **Project-specific settings**: Projects with custom config are preserved through merge
- **Undefined config**: Returns defaults when no config file is found
- **Caching**: Same config name returns cached reference, reader called only once

## Test plan
- [x] All 8 tests pass (2 existing + 6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)