### PR TITLE
fix(remaining-flags): handle empty strings in camel case helper

### DIFF
--- a/lib/utils/remaining-flags.ts
+++ b/lib/utils/remaining-flags.ts
@@ -40,7 +40,10 @@ export function getRemainingFlags(cli: Command) {
  */
 
 function camelCase(flag: string) {
-  return flag.split('-').reduce((str, word) => {
-    return str + word[0].toUpperCase() + word.slice(1);
-  });
+  return flag
+    .split('-')
+    .filter((word) => word.length > 0)
+    .reduce((str, word) => {
+      return str + word[0].toUpperCase() + word.slice(1);
+    });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (rebased to v12.0.0 as requested in #3348)

## What is the current behavior?

The `camelCase()` helper in `remaining-flags.ts` crashes when `flag.split('-')` produces empty strings (from leading or consecutive dashes). `word[0]` returns `undefined`, and calling `.toUpperCase()` on it throws `TypeError: Cannot read properties of undefined`.

This can happen when `getRemainingFlags()` processes flags after stripping `--` and `no` prefixes (line 23: `prevKeyRaw.replace(/--/g, '').replace('no', '')`), which can leave leading dashes in the result.

## What is the new behavior?

Added `.filter((word) => word.length > 0)` before `.reduce()` to skip empty strings, preventing the crash.