### PR TITLE
fix(compiler): normalize output filename path separators

### DIFF
--- a/lib/compiler/defaults/rspack-defaults.ts
+++ b/lib/compiler/defaults/rspack-defaults.ts
@@ -46,7 +46,10 @@ export const rspackDefaultsFactory = (
     devtool: isDebugEnabled ? 'inline-source-map' : false,
     target: 'node',
     output: {
-      filename: join(relativeSourceRoot, `${entryFilename}.js`),
+      filename: join(relativeSourceRoot, `${entryFilename}.js`).replace(
+        /\\/g,
+        '/',
+      ),
       ...(isEsm && {
         module: true,
         library: { type: 'module' },

--- a/lib/compiler/defaults/webpack-defaults.ts
+++ b/lib/compiler/defaults/webpack-defaults.ts
@@ -47,7 +47,10 @@ export const webpackDefaultsFactory = (
     devtool: isDebugEnabled ? 'inline-source-map' : false,
     target: 'node',
     output: {
-      filename: join(relativeSourceRoot, `${entryFilename}.js`),
+      filename: join(relativeSourceRoot, `${entryFilename}.js`).replace(
+        /\\/g,
+        '/',
+      ),
     },
     ignoreWarnings: [/^(?!CriticalDependenciesWarning$)/],
     externals: [externals() as any],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Both `rspack-defaults.ts` and `webpack-defaults.ts` use `path.join()` to construct `output.filename`. On Windows, `join()` produces backslashes (e.g., `apps\my-app\main.js`), but webpack and rspack require forward slashes in `output.filename` regardless of platform.

## What is the new behavior?

Added `.replace(/\/g, '/')` to normalize backslashes to forward slashes in both files, matching the pattern already used elsewhere in the codebase (e.g., `swc-defaults.ts` has a `convertPath()` helper for this purpose).