### PR TITLE
fix(build): warn when library assets are silently ignored

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -104,6 +104,7 @@ export class BuildAction extends AbstractAction {
         outDir,
         watchAssetsMode,
       );
+      this.warnOnIgnoredLibraryAssets(configuration, appName);
 
       const typeCheck = getValueOrDefault<boolean>(
         configuration,
@@ -342,5 +343,31 @@ export class BuildAction extends AbstractAction {
       return (_config: Record<string, any>) => ({});
     }
     return require(pathToRspackFile);
+  }
+
+  private warnOnIgnoredLibraryAssets(
+    configuration: Required<Configuration>,
+    appName: string | undefined,
+  ) {
+    if (!configuration.projects) {
+      return;
+    }
+    for (const [projectName, project] of Object.entries(
+      configuration.projects,
+    )) {
+      if (projectName === appName) {
+        continue;
+      }
+      if (
+        project.type === 'library' &&
+        project.compilerOptions?.assets?.length
+      ) {
+        console.warn(
+          INFO_PREFIX +
+            ` Assets configured for library "${projectName}" will not be copied during application build.` +
+            ` Build the library separately or move assets to the application configuration.`,
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / Improvement

## What is the current behavior?

When building an application in a monorepo, assets configured for library projects in `nest-cli.json` are silently ignored. Users expect their library assets to be copied during the app build, but nothing happens and no feedback is given.

Ref: #1845

## What is the new behavior?

During the app build, if any library project in the monorepo has `compilerOptions.assets` configured, a warning is logged:

```
[INFO] Assets configured for library "my-lib" will not be copied during application build. Build the library separately or move assets to the application configuration.
```

This makes the behavior explicit and guides users toward a working solution.

## Additional context

The warning only fires for projects with `type: "library"` that have non-empty assets. It runs once per build per library, and doesn't affect the build process itself.