### PR TITLE
fix(plugins): add ts-nocheck to generated metadata file

### DIFF
--- a/lib/compiler/plugins/plugin-metadata-printer.ts
+++ b/lib/compiler/plugins/plugin-metadata-printer.ts
@@ -74,10 +74,10 @@ export class PluginMetadataPrinter {
       options.outputDir!,
       options.filename ?? SERIALIZED_METADATA_FILENAME,
     );
-    const eslintPrefix = `/* eslint-disable */\n`;
+    const generatedPrefix = `/* eslint-disable */\n// @ts-nocheck\n`;
     writeFileSync(
       filename,
-      eslintPrefix +
+      generatedPrefix +
         printer.printNode(
           tsBinary.EmitHint.Unspecified,
           exportAssignment,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The generated `metadata.ts` file contains dynamic `import()` statements without file extensions (e.g., `import("./hello.dto")`). When using `moduleResolution: nodenext`, TypeScript reports type errors because it requires explicit `.js` extensions in imports.

The imports work correctly at runtime — the issue is only with type-checking.

Ref: #3364

## What is the new behavior?

Added `// @ts-nocheck` directive to the generated metadata file, alongside the existing `/* eslint-disable */` comment. Since this file is entirely auto-generated and not meant to be manually edited or type-checked, suppressing TypeScript errors is the correct approach.

Generated file header is now:
```typescript
/* eslint-disable */
// @ts-nocheck
export default async () => { ... }
```

## Additional context

As noted by the reporter, adding `.js` extensions to the dynamic imports would break the NestJS application at runtime. `// @ts-nocheck` is the simplest correct fix that doesn't affect runtime behavior.