### PR TITLE
feat(cli): add nest inspect command to display resolved configuration

### DIFF
--- a/actions/index.ts
+++ b/actions/index.ts
@@ -2,6 +2,7 @@ export * from './abstract.action.js';
 export * from './build.action.js';
 export * from './generate.action.js';
 export * from './info.action.js';
+export * from './inspect.action.js';
 export * from './new.action.js';
 export * from './start.action.js';
 export * from './add.action.js';

--- a/actions/inspect.action.ts
+++ b/actions/inspect.action.ts
@@ -1,0 +1,176 @@
+import { blue, bold, cyan, green } from 'ansis';
+import { Command } from 'commander';
+import { getBuilder } from '../lib/compiler/helpers/get-builder.js';
+import { getTscConfigPath } from '../lib/compiler/helpers/get-tsc-config.path.js';
+import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default.js';
+import { Configuration } from '../lib/configuration/index.js';
+import { loadConfiguration } from '../lib/utils/load-configuration.js';
+import { AbstractAction } from './abstract.action.js';
+
+interface InspectContext {
+  project?: string;
+  all: boolean;
+  json: boolean;
+}
+
+export class InspectAction extends AbstractAction {
+  public async handle(context: InspectContext) {
+    const configuration = await loadConfiguration();
+
+    if (context.json) {
+      this.printJson(configuration, context);
+      return;
+    }
+
+    if (context.all) {
+      this.printAllProjects(configuration);
+    } else {
+      this.printProject(configuration, context.project);
+    }
+  }
+
+  private printProject(
+    configuration: Required<Configuration>,
+    appName: string | undefined,
+  ) {
+    const label = appName || 'default';
+    console.info();
+    console.info(
+      green(bold(`Resolved Configuration for "${label}"`)),
+    );
+    console.info(green('─'.repeat(40)));
+
+    const builder = getBuilder(configuration, {}, appName);
+    const tsConfigPath = getTscConfigPath(configuration, {}, appName);
+    const sourceRoot = appName
+      ? getValueOrDefault(configuration, 'sourceRoot', appName)
+      : configuration.sourceRoot;
+    const entryFile = getValueOrDefault<string>(
+      configuration,
+      'entryFile',
+      appName,
+    );
+    const typeCheck = getValueOrDefault<boolean>(
+      configuration,
+      'compilerOptions.typeCheck',
+      appName,
+    );
+    const deleteOutDir = getValueOrDefault<boolean>(
+      configuration,
+      'compilerOptions.deleteOutDir',
+      appName,
+    );
+    const assets =
+      getValueOrDefault<any[]>(
+        configuration,
+        'compilerOptions.assets',
+        appName,
+      ) || [];
+    const plugins =
+      getValueOrDefault<any[]>(
+        configuration,
+        'compilerOptions.plugins',
+        appName,
+      ) || [];
+
+    const rows: [string, string][] = [
+      ['Source Root', sourceRoot],
+      ['Entry File', entryFile],
+      ['Builder', builder.type],
+      ['TS Config', tsConfigPath],
+      ['Type Check', String(typeCheck ?? false)],
+      ['Delete Out Dir', String(deleteOutDir ?? false)],
+      [
+        'Plugins',
+        plugins.length > 0
+          ? plugins
+              .map((p: any) => (typeof p === 'string' ? p : p.name))
+              .join(', ')
+          : 'none',
+      ],
+      [
+        'Assets',
+        assets.length > 0
+          ? assets
+              .map((a: any) => (typeof a === 'string' ? a : a.include || a.glob))
+              .join(', ')
+          : 'none',
+      ],
+    ];
+
+    const maxKeyLen = Math.max(...rows.map(([k]) => k.length));
+    for (const [key, value] of rows) {
+      console.info(`  ${cyan(key.padEnd(maxKeyLen))}  ${blue(value)}`);
+    }
+    console.info();
+  }
+
+  private printAllProjects(configuration: Required<Configuration>) {
+    console.info();
+    const projects = configuration.projects;
+    if (!projects || Object.keys(projects).length === 0) {
+      this.printProject(configuration, undefined);
+      return;
+    }
+
+    console.info(green(bold('Projects')));
+    console.info(green('─'.repeat(40)));
+    console.info(
+      `  ${cyan('Name'.padEnd(20))}  ${cyan('Builder'.padEnd(10))}  ${cyan('Source Root')}`,
+    );
+
+    for (const name of Object.keys(projects)) {
+      const builder = getBuilder(configuration, {}, name);
+      const sourceRoot = getValueOrDefault(
+        configuration,
+        'sourceRoot',
+        name,
+      );
+      console.info(
+        `  ${bold(name.padEnd(20))}  ${blue(builder.type.padEnd(10))}  ${blue(sourceRoot)}`,
+      );
+    }
+    console.info();
+  }
+
+  private printJson(
+    configuration: Required<Configuration>,
+    context: InspectContext,
+  ) {
+    if (context.all) {
+      console.info(JSON.stringify(configuration, null, 2));
+      return;
+    }
+    const appName = context.project;
+    const builder = getBuilder(configuration, {}, appName);
+    const tsConfigPath = getTscConfigPath(configuration, {}, appName);
+    const sourceRoot = appName
+      ? getValueOrDefault(configuration, 'sourceRoot', appName)
+      : configuration.sourceRoot;
+    const entryFile = getValueOrDefault<string>(
+      configuration,
+      'entryFile',
+      appName,
+    );
+
+    console.info(
+      JSON.stringify(
+        {
+          project: appName || 'default',
+          sourceRoot,
+          entryFile,
+          builder: builder.type,
+          tsConfigPath,
+          compilerOptions: getValueOrDefault(
+            configuration,
+            'compilerOptions',
+            appName,
+          ),
+          generateOptions: configuration.generateOptions,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+}

--- a/commands/command.loader.ts
+++ b/commands/command.loader.ts
@@ -5,6 +5,7 @@ import {
   BuildAction,
   GenerateAction,
   InfoAction,
+  InspectAction,
   NewAction,
   StartAction,
 } from '../actions/index.js';
@@ -13,6 +14,7 @@ import { AddCommand } from './add.command.js';
 import { BuildCommand } from './build.command.js';
 import { GenerateCommand } from './generate.command.js';
 import { InfoCommand } from './info.command.js';
+import { InspectCommand } from './inspect.command.js';
 import { NewCommand } from './new.command.js';
 import { StartCommand } from './start.command.js';
 
@@ -32,6 +34,7 @@ export class CommandLoader {
     new BuildCommand(new BuildAction()).load(program);
     new StartCommand(new StartAction()).load(program);
     new InfoCommand(new InfoAction()).load(program);
+    new InspectCommand(new InspectAction()).load(program);
     new AddCommand(new AddAction()).load(program);
     await new GenerateCommand(new GenerateAction()).load(program);
 

--- a/commands/inspect.command.ts
+++ b/commands/inspect.command.ts
@@ -1,0 +1,20 @@
+import { Command } from 'commander';
+import { AbstractCommand } from './abstract.command.js';
+
+export class InspectCommand extends AbstractCommand {
+  public load(program: Command) {
+    program
+      .command('inspect')
+      .description('Display resolved Nest project configuration.')
+      .option('-p, --project [project]', 'Project to inspect.')
+      .option('--all', 'Show all projects in a monorepo.')
+      .option('--json', 'Output as JSON.')
+      .action(async (options: Record<string, any>) => {
+        await this.action.handle({
+          project: options.project,
+          all: !!options.all,
+          json: !!options.json,
+        });
+      });
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

No way to view the resolved configuration for a project without reading source code or adding console.log statements.

## What is the new behavior?

Adds a `nest inspect` command:

```bash
nest inspect                     # Show resolved config for default project
nest inspect --project my-api    # Show config for specific project
nest inspect --all               # Overview of all monorepo projects
nest inspect --json              # Machine-readable output for CI
```

Output example:
```
Resolved Configuration for "default"
────────────────────────────────────────
  Source Root      src
  Entry File      main
  Builder         tsc
  TS Config       tsconfig.build.json
  Type Check      false
  Delete Out Dir  true
  Plugins         @nestjs/swagger
  Assets          **/*.graphql
```

### Files added/changed
- `actions/inspect.action.ts` — resolves and displays configuration
- `commands/inspect.command.ts` — CLI command definition
- `actions/index.ts` — export new action
- `commands/command.loader.ts` — register new command

Closes #3368