### PR TITLE
feat(build): add parallel project builds for monorepos

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -80,7 +80,7 @@ export class BuildAction extends AbstractAction {
       appNames.push(undefined);
     }
 
-    for (const appName of appNames) {
+    const buildApp = async (appName: string | undefined) => {
       const pathToTsconfig = getTscConfigPath(configuration, options, appName);
       const { options: tsOptions } =
         this.tsConfigProvider.getByConfigFilename(pathToTsconfig);
@@ -163,6 +163,20 @@ export class BuildAction extends AbstractAction {
             onSuccess,
           );
           break;
+      }
+    };
+
+    const parallel = options.parallel;
+    if (parallel && appNames.length > 1) {
+      const concurrency =
+        typeof parallel === 'number' ? parallel : appNames.length;
+      for (let i = 0; i < appNames.length; i += concurrency) {
+        const chunk = appNames.slice(i, i + concurrency);
+        await Promise.all(chunk.map((appName) => buildApp(appName)));
+      }
+    } else {
+      for (const appName of appNames) {
+        await buildApp(appName);
       }
     }
   }

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -37,6 +37,10 @@ export class BuildCommand extends AbstractCommand {
         'Use "preserveWatchOutput" option when using tsc watch mode.',
       )
       .option('--all', 'Build all projects in a monorepo.')
+      .option(
+        '--parallel [concurrency]',
+        'Build projects in parallel (with --all). Optionally limit concurrency.',
+      )
       .description('Build Nest application.')
       .action(async (apps: string[], options: Record<string, any>) => {
         const isWebpackEnabled = options.tsc ? false : options.webpack;
@@ -68,6 +72,11 @@ export class BuildCommand extends AbstractCommand {
             !!options.watch &&
             !isWebpackEnabled,
           all: !!options.all,
+          parallel: options.parallel === true
+            ? true
+            : options.parallel
+              ? parseInt(options.parallel, 10)
+              : undefined,
         };
 
         await this.action.handle(context);

--- a/commands/context/build.context.ts
+++ b/commands/context/build.context.ts
@@ -11,4 +11,5 @@ export interface BuildCommandContext {
   silent?: boolean;
   preserveWatchOutput: boolean;
   all: boolean;
+  parallel?: number | boolean;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

`nest build --all` builds each monorepo project sequentially in a for loop. For large monorepos with many projects, this is unnecessarily slow since most projects are independent.

## What is the new behavior?

Adds a `--parallel` flag to `nest build`:

```bash
nest build --all --parallel       # Build all projects concurrently
nest build --all --parallel 4     # Max 4 concurrent builds
```

**Implementation:** Extracts the per-app build logic into a `buildApp()` closure, then either runs it sequentially (default) or in parallel chunks based on the `--parallel` flag.

```typescript
if (parallel && appNames.length > 1) {
  const concurrency = typeof parallel === 'number' ? parallel : appNames.length;
  for (let i = 0; i < appNames.length; i += concurrency) {
    const chunk = appNames.slice(i, i + concurrency);
    await Promise.all(chunk.map((appName) => buildApp(appName)));
  }
} else {
  for (const appName of appNames) {
    await buildApp(appName);
  }
}
```

**Key design decisions:**
- Sequential remains the default — no behavior change for existing users
- The `--parallel` flag is opt-in
- Concurrency can be limited with `--parallel N`
- The refactor is minimal — existing build logic is just wrapped in a closure

### Files changed
- `commands/build.command.ts` — add `--parallel` option
- `commands/context/build.context.ts` — add `parallel` field
- `actions/build.action.ts` — extract `buildApp()` closure + parallel execution

## Test plan
- [x] TypeScript type-checks with zero errors
- [x] All 3 existing build action tests pass
- [x] Sequential behavior unchanged when `--parallel` is not provided

Closes #3367