### PR TITLE
fix(assets-manager): skip watcher when asset glob matches no files

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -84,12 +84,26 @@ export class AssetsManager {
         };
 
         if (isWatchEnabled || item.watchAssets) {
+          const matchedPaths = sync(item.glob, {
+            ignore: item.exclude,
+            dot: true,
+          });
+
+          // Chokidar does not emit the 'ready' event when given an empty
+          // array of paths, which causes closeWatchers() to hang forever
+          // on Promise.all(watcherReadyPromises). Skip the watcher and
+          // warn the user so the build can finish normally.
+          if (matchedPaths.length === 0) {
+            console.warn(
+              `No files matched the asset pattern "${item.glob}". ` +
+                `Skipping watcher for this entry.`,
+            );
+            continue;
+          }
+
           // prettier-ignore
           const watcher = chokidar
-            .watch(sync(item.glob, {
-              ignore: item.exclude,
-              dot: true,
-            }))
+            .watch(matchedPaths)
             .on('add', (path: string) => this.actionOnFile({ ...option, path, action: 'change' }))
             .on('change', (path: string) => this.actionOnFile({ ...option, path, action: 'change' }))
             .on('unlink', (path: string) => this.actionOnFile({ ...option, path, action: 'unlink' }));

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -152,6 +152,35 @@ describe('AssetsManager', () => {
       // No error thrown = success
     });
 
+    it('should not stall when asset glob matches no files', async () => {
+      // Chokidar does not emit 'ready' when given an empty array,
+      // which caused closeWatchers() to hang forever.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      vi.mocked(globSync).mockReturnValue([]);
+      vi.mocked(getValueOrDefault)
+        .mockReturnValueOnce([
+          { include: 'does-not-exist/**/*', watchAssets: true },
+        ])
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      assetsManager.copyAssets({} as any, undefined, 'dist', false);
+
+      // No watcher should have been created for the empty glob
+      expect(chokidar.watch).not.toHaveBeenCalled();
+
+      // A warning should have been logged
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('does-not-exist/**/*'),
+      );
+
+      // closeWatchers should resolve immediately since no watchers exist
+      await assetsManager.closeWatchers();
+
+      warnSpy.mockRestore();
+    });
+
     it('should ensure all add events fire before watcher is closed', async () => {
       const addedFiles: string[] = [];
       const mockWatcher = new EventEmitter() as any;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`nest build` hangs indefinitely when `watchAssets: true` is set and an asset pattern matches no files. No output is produced, no error is thrown — the build just stalls with a partially populated `dist/` directory.

Reproduction (`nest-cli.json`):
```json
{
  "compilerOptions": {
    "deleteOutDir": true,
    "assets": [
      { "include": "does-not-exist/**/*" }
    ],
    "watchAssets": true
  }
}
```

Ref: #3373

## Root cause

`AssetsManager.copyAssets()` calls `glob.sync(item.glob)` and passes the result to `chokidar.watch()`. When the glob matches nothing, `chokidar.watch([])` is called with an empty array — and **chokidar does not emit the `ready` event in that case** (verified against chokidar 5.0.0).

Since `closeWatchers()` awaits `Promise.all(watcherReadyPromises)`, the watch-ready promise for the empty watcher never resolves and the build process hangs forever.

Verified with a minimal repro:
```js
import chokidar from 'chokidar';
chokidar.watch([]).on('ready', () => console.log('ready'));
// "ready" never fires
```

(Compare with `chokidar.watch(['/does/not/exist/**/*'])` which **does** fire `ready`.)

## What is the new behavior?

Before creating a watcher, check if `glob.sync()` returned any matches. If not:
1. Log a warning naming the offending glob so users know which pattern to fix
2. Skip watcher creation for that entry

The build now completes normally and the user sees:
```
No files matched the asset pattern "does-not-exist/**/*". Skipping watcher for this entry.
```

## Tests

Added a dedicated test case covering the empty-match scenario: verifies no watcher is created, a warning is emitted, and `closeWatchers()` resolves without hanging. All 6 existing + new tests pass.

Closes #3373