### PR TITLE
test(utils): add unit tests for is-module-available and runner factory

### DIFF
--- a/test/lib/runners/runner.factory.spec.ts
+++ b/test/lib/runners/runner.factory.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { NpmRunner } from '../../../lib/runners/npm.runner.js';
+import { PnpmRunner } from '../../../lib/runners/pnpm.runner.js';
+import { Runner } from '../../../lib/runners/runner.js';
+import { RunnerFactory } from '../../../lib/runners/runner.factory.js';
+import { SchematicRunner } from '../../../lib/runners/schematic.runner.js';
+import { YarnRunner } from '../../../lib/runners/yarn.runner.js';
+
+describe('RunnerFactory', () => {
+  it('should create a SchematicRunner for Runner.SCHEMATIC', () => {
+    const runner = RunnerFactory.create(Runner.SCHEMATIC);
+    expect(runner).toBeInstanceOf(SchematicRunner);
+  });
+
+  it('should create an NpmRunner for Runner.NPM', () => {
+    const runner = RunnerFactory.create(Runner.NPM);
+    expect(runner).toBeInstanceOf(NpmRunner);
+  });
+
+  it('should create a YarnRunner for Runner.YARN', () => {
+    const runner = RunnerFactory.create(Runner.YARN);
+    expect(runner).toBeInstanceOf(YarnRunner);
+  });
+
+  it('should create a PnpmRunner for Runner.PNPM', () => {
+    const runner = RunnerFactory.create(Runner.PNPM);
+    expect(runner).toBeInstanceOf(PnpmRunner);
+  });
+
+  it('should throw for an unsupported runner', () => {
+    expect(() => RunnerFactory.create(999 as Runner)).toThrow(
+      'Unsupported runner: 999',
+    );
+  });
+
+  it('should return a new instance on each call', () => {
+    const runner1 = RunnerFactory.create(Runner.NPM);
+    const runner2 = RunnerFactory.create(Runner.NPM);
+    expect(runner1).not.toBe(runner2);
+    expect(runner1).toBeInstanceOf(NpmRunner);
+    expect(runner2).toBeInstanceOf(NpmRunner);
+  });
+});

--- a/test/lib/utils/is-module-available.spec.ts
+++ b/test/lib/utils/is-module-available.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isModuleAvailable } from '../../../lib/utils/is-module-available.js';
+
+describe('isModuleAvailable', () => {
+  it('should return true for a module that can be resolved', () => {
+    // typescript is a direct dependency of nest-cli
+    expect(isModuleAvailable('typescript')).toBe(true);
+  });
+
+  it('should return true for a built-in Node.js module', () => {
+    expect(isModuleAvailable('fs')).toBe(true);
+  });
+
+  it('should return true for another built-in Node.js module', () => {
+    expect(isModuleAvailable('path')).toBe(true);
+  });
+
+  it('should return false for a non-existent package', () => {
+    expect(
+      isModuleAvailable('this-module-really-does-not-exist-abcxyz123'),
+    ).toBe(false);
+  });
+
+  it('should return false for an invalid relative path', () => {
+    expect(isModuleAvailable('../../../does/not/exist.js')).toBe(false);
+  });
+
+  it('should return false when resolution throws for an empty string', () => {
+    expect(isModuleAvailable('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tests

## What is the current behavior?

Two utility modules have no test coverage on v12:
- `lib/utils/is-module-available.ts` — used by the build action to detect optional deps
- `lib/runners/runner.factory.ts` — factory for all runner implementations

## What is the new behavior?

### `is-module-available` (6 tests)
- Resolves a direct dependency (`typescript`)
- Resolves built-in Node.js modules (`fs`, `path`)
- Returns false for non-existent packages
- Returns false for invalid relative paths
- Returns false for an empty string

### `runner.factory` (6 tests)
- Creates the correct runner for each enum value (`SCHEMATIC`, `NPM`, `YARN`, `PNPM`)
- Throws for an unsupported runner value
- Returns a new instance on each call

## Test plan
- [x] All 12 tests pass