### PR TITLE
fix(add): ensure get tag name always returns a string

### DIFF
--- a/actions/add.action.ts
+++ b/actions/add.action.ts
@@ -147,8 +147,13 @@ export class AddAction extends AbstractAction {
   }
 
   private getTagName(packageName: string): string {
-    return packageName.startsWith('@')
+    // For scoped packages like "@scope/pkg@1.0.0", split('@', 3) yields
+    // ["", "scope/pkg", "1.0.0"]. For "@scope/pkg" with no version,
+    // the tag slot is undefined. Fall back to an empty string so the
+    // return type stays string and installPackage can substitute "latest".
+    const tag = packageName.startsWith('@')
       ? packageName.split('@', 3)[2]
       : packageName.split('@', 2)[1];
+    return tag ?? '';
   }
 }

--- a/test/actions/add.action.spec.ts
+++ b/test/actions/add.action.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { AddAction } from '../../actions/add.action.js';
+
+// Expose private methods for targeted testing
+type AddActionInternal = AddAction & {
+  getPackageName(library: string): string;
+  getCollectionName(library: string, packageName: string): string;
+  getTagName(packageName: string): string;
+};
+
+describe('AddAction helpers', () => {
+  const action = new AddAction() as AddActionInternal;
+
+  describe('getPackageName', () => {
+    it('should return the package name for a non-scoped package', () => {
+      expect(action.getPackageName('my-lib')).toBe('my-lib');
+    });
+
+    it('should return the package name with version for a non-scoped package', () => {
+      expect(action.getPackageName('my-lib@1.0.0')).toBe('my-lib@1.0.0');
+    });
+
+    it('should return scope/name for a scoped package', () => {
+      expect(action.getPackageName('@scope/pkg')).toBe('@scope/pkg');
+    });
+
+    it('should return scope/name@version for a scoped package with version', () => {
+      expect(action.getPackageName('@scope/pkg@1.0.0')).toBe(
+        '@scope/pkg@1.0.0',
+      );
+    });
+
+    it('should strip subpaths from a non-scoped package', () => {
+      expect(action.getPackageName('my-lib/subpath')).toBe('my-lib');
+    });
+  });
+
+  describe('getTagName', () => {
+    it('should return empty string for a non-scoped package with no version', () => {
+      expect(action.getTagName('my-lib')).toBe('');
+    });
+
+    it('should return the version for a non-scoped package with version', () => {
+      expect(action.getTagName('my-lib@1.0.0')).toBe('1.0.0');
+    });
+
+    it('should return empty string for a scoped package with no version', () => {
+      expect(action.getTagName('@scope/pkg')).toBe('');
+    });
+
+    it('should return the version for a scoped package with version', () => {
+      expect(action.getTagName('@scope/pkg@1.0.0')).toBe('1.0.0');
+    });
+
+    it('should return "latest" tag when specified', () => {
+      expect(action.getTagName('my-lib@latest')).toBe('latest');
+    });
+
+    it('should return "next" tag when specified', () => {
+      expect(action.getTagName('@scope/pkg@next')).toBe('next');
+    });
+
+    it('should always return a string (not undefined)', () => {
+      const result = action.getTagName('@scope/pkg');
+      expect(typeof result).toBe('string');
+    });
+  });
+
+  describe('getCollectionName', () => {
+    it('should return the package name when no version is included', () => {
+      expect(action.getCollectionName('my-lib', 'my-lib')).toBe('my-lib');
+    });
+
+    it('should strip the version for a non-scoped package', () => {
+      expect(action.getCollectionName('my-lib@1.0.0', 'my-lib@1.0.0')).toBe(
+        'my-lib',
+      );
+    });
+
+    it('should return the scope/name for a scoped package', () => {
+      expect(action.getCollectionName('@scope/pkg', '@scope/pkg')).toBe(
+        '@scope/pkg',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (type safety) + tests

## What is the current behavior?

`AddAction.getTagName()` is typed to return `string`, but can actually return `undefined`:

```typescript
private getTagName(packageName: string): string {
  return packageName.startsWith('@')
    ? packageName.split('@', 3)[2]  // undefined for '@scope/pkg' (no version)
    : packageName.split('@', 2)[1]; // undefined for 'my-lib' (no version)
}
```

For inputs without a version (e.g., `@scope/pkg` or `my-lib`), the split-and-index produces `undefined`. The caller happens to handle it via `tagName = tagName || 'latest'`, so there's no runtime crash — but the type is unsound and a future caller that doesn't apply the same fallback could silently pass `undefined` through.

## What is the new behavior?

Return an empty string as a safe fallback so the declared return type matches the actual behavior:

```typescript
private getTagName(packageName: string): string {
  const tag = packageName.startsWith('@')
    ? packageName.split('@', 3)[2]
    : packageName.split('@', 2)[1];
  return tag ?? '';
}
```

The existing `tagName || 'latest'` fallback in `installPackage` continues to work as before.

## Tests

Adds 15 new tests covering `getPackageName`, `getTagName`, and `getCollectionName` for:
- Non-scoped packages with and without versions
- Scoped packages with and without versions
- Explicit tags (`latest`, `next`)
- Type safety of the return value

No test file existed for `add.action.ts` before this PR.