### PR TITLE
test(compiler): add unit tests for typescript loader and manual restart

### DIFF
--- a/test/lib/compiler/helpers/manual-restart.spec.ts
+++ b/test/lib/compiler/helpers/manual-restart.spec.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  displayManualRestartTip,
+  listenForManualRestart,
+} from '../../../../lib/compiler/helpers/manual-restart.js';
+
+describe('manual-restart helpers', () => {
+  describe('listenForManualRestart', () => {
+    let originalStdin: typeof process.stdin;
+    let stdinMock: EventEmitter;
+
+    beforeEach(() => {
+      originalStdin = process.stdin;
+      stdinMock = new EventEmitter() as any;
+      Object.defineProperty(process, 'stdin', {
+        value: stdinMock,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'stdin', {
+        value: originalStdin,
+        configurable: true,
+      });
+    });
+
+    it('should invoke the callback when "rs" is entered', () => {
+      const callback = vi.fn();
+      listenForManualRestart(callback);
+
+      stdinMock.emit('data', Buffer.from('rs\n'));
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should invoke the callback when "rs" is entered with surrounding whitespace', () => {
+      const callback = vi.fn();
+      listenForManualRestart(callback);
+
+      stdinMock.emit('data', Buffer.from('  rs  \n'));
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not invoke the callback for other input', () => {
+      const callback = vi.fn();
+      listenForManualRestart(callback);
+
+      stdinMock.emit('data', Buffer.from('hello\n'));
+      stdinMock.emit('data', Buffer.from('restart\n'));
+      stdinMock.emit('data', Buffer.from('r\n'));
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should remove the listener after first invocation', () => {
+      const callback = vi.fn();
+      listenForManualRestart(callback);
+
+      stdinMock.emit('data', Buffer.from('rs\n'));
+      stdinMock.emit('data', Buffer.from('rs\n'));
+
+      // Should only fire once because listener removes itself
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should support multiple independent listeners', () => {
+      const first = vi.fn();
+      const second = vi.fn();
+
+      listenForManualRestart(first);
+      listenForManualRestart(second);
+
+      stdinMock.emit('data', Buffer.from('rs\n'));
+
+      expect(first).toHaveBeenCalledTimes(1);
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('displayManualRestartTip', () => {
+    it('should log a tip message to the console', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      displayManualRestartTip();
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls[0][0]).toContain('rs');
+
+      logSpy.mockRestore();
+    });
+  });
+});

--- a/test/lib/compiler/typescript-loader.spec.ts
+++ b/test/lib/compiler/typescript-loader.spec.ts
@@ -1,0 +1,43 @@
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { TypeScriptBinaryLoader } from '../../../lib/compiler/typescript-loader.js';
+
+describe('TypeScriptBinaryLoader', () => {
+  it('should load the typescript binary', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const tsBinary = loader.load();
+    expect(tsBinary).toBeDefined();
+    expect(typeof tsBinary.createProgram).toBe('function');
+  });
+
+  it('should return the same cached instance on subsequent calls', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const first = loader.load();
+    const second = loader.load();
+    expect(first).toBe(second);
+  });
+
+  it('should expose TypeScript namespace utilities', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const tsBinary = loader.load();
+    expect(tsBinary.sys).toBeDefined();
+    expect(tsBinary.ScriptTarget).toBeDefined();
+    expect(tsBinary.ModuleKind).toBeDefined();
+  });
+
+  it('should return the same TypeScript instance used by the test process', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const tsBinary = loader.load();
+    // Both should have the same version string since they resolve from
+    // the same node_modules/typescript.
+    expect(tsBinary.version).toBe(ts.version);
+  });
+
+  it('getModulePaths should return an array of resolution paths', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const paths = loader.getModulePaths();
+    expect(Array.isArray(paths)).toBe(true);
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths.every((p) => typeof p === 'string')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tests

## What is the current behavior?

Two compiler modules have no test coverage on v12:
- `lib/compiler/typescript-loader.ts` — loads the TypeScript binary used throughout the compiler pipeline
- `lib/compiler/helpers/manual-restart.ts` — implements the `rs` restart-on-demand feature used in watch mode

## What is the new behavior?

### `TypeScriptBinaryLoader` (5 tests)
- Loads the TypeScript binary successfully
- Caches the instance on subsequent `load()` calls
- Exposes `sys`, `ScriptTarget`, `ModuleKind` from the loaded binary
- Returns the same TypeScript version as the test process
- `getModulePaths()` returns a non-empty array of strings

### `manual-restart` helpers (6 tests)
- Invokes the callback when `rs` is entered on stdin
- Trims surrounding whitespace before matching
- Does not fire on unrelated input (`hello`, `restart`, `r`)
- Removes the listener after first invocation (fires only once)
- Supports multiple independent listeners
- `displayManualRestartTip()` logs a message containing `rs`

## Test plan
- [x] All 11 tests pass