### PR TITLE
test(schematics): add unit tests for collection factory

### DIFF
--- a/test/lib/schematics/collection.factory.spec.ts
+++ b/test/lib/schematics/collection.factory.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { CollectionFactory } from '../../../lib/schematics/collection.factory.js';
+import { Collection } from '../../../lib/schematics/collection.js';
+import { CustomCollection } from '../../../lib/schematics/custom.collection.js';
+import { NestCollection } from '../../../lib/schematics/nest.collection.js';
+
+describe('CollectionFactory', () => {
+  it('should create a NestCollection for the NestJS collection', () => {
+    const collection = CollectionFactory.create(Collection.NESTJS);
+    expect(collection).toBeInstanceOf(NestCollection);
+  });
+
+  it('should create a NestCollection when passed the string value', () => {
+    const collection = CollectionFactory.create('@nestjs/schematics');
+    expect(collection).toBeInstanceOf(NestCollection);
+  });
+
+  it('should create a CustomCollection for a non-NestJS collection', () => {
+    const collection = CollectionFactory.create('@custom/schematics');
+    expect(collection).toBeInstanceOf(CustomCollection);
+  });
+
+  it('should create a CustomCollection for any arbitrary collection name', () => {
+    const collection = CollectionFactory.create('my-local-schematics');
+    expect(collection).toBeInstanceOf(CustomCollection);
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tests

## What is the current behavior?

No tests exist for `CollectionFactory` in `lib/schematics/collection.factory.ts`.

## What is the new behavior?

Added 4 tests covering NestCollection and CustomCollection creation via the factory.

## Test plan
- [x] All 4 tests pass