### PR TITLE
test: add missing unit tests across compiler, runners, schematics, utils

### DIFF
--- a/test/lib/compiler/base-compiler.spec.ts
+++ b/test/lib/compiler/base-compiler.spec.ts
@@ -1,0 +1,113 @@
+import { join, normalize } from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { Configuration } from '../../../lib/configuration/index.js';
+import { BaseCompiler } from '../../../lib/compiler/base-compiler.js';
+import { PluginsLoader } from '../../../lib/compiler/plugins/plugins-loader.js';
+
+class TestCompiler extends BaseCompiler {
+  public run() {}
+
+  // Expose protected methods for testing
+  public testGetPathToSource(
+    configuration: Required<Configuration>,
+    tsConfigPath: string,
+    appName: string | undefined,
+  ) {
+    return this.getPathToSource(configuration, tsConfigPath, appName);
+  }
+
+  public testLoadPlugins(
+    configuration: Required<Configuration>,
+    tsConfigPath: string,
+    appName: string | undefined,
+  ) {
+    return this.loadPlugins(configuration, tsConfigPath, appName);
+  }
+}
+
+function makeConfig(
+  overrides: Partial<Configuration> = {},
+): Required<Configuration> {
+  return {
+    language: 'ts',
+    sourceRoot: 'src',
+    collection: '@nestjs/schematics',
+    entryFile: 'main',
+    exec: 'node',
+    projects: {},
+    monorepo: false,
+    compilerOptions: {},
+    generateOptions: {},
+    ...overrides,
+  } as Required<Configuration>;
+}
+
+describe('BaseCompiler', () => {
+  describe('getPathToSource', () => {
+    it('should return cwd + sourceRoot when tsconfig is in cwd', () => {
+      const pluginsLoader = new PluginsLoader();
+      const compiler = new TestCompiler(pluginsLoader);
+      const config = makeConfig({ sourceRoot: 'src' });
+      const cwd = process.cwd();
+
+      const result = compiler.testGetPathToSource(
+        config,
+        'tsconfig.json',
+        undefined,
+      );
+
+      expect(result).toBe(join(cwd, 'src'));
+    });
+
+    it('should use project-specific sourceRoot when appName is provided', () => {
+      const pluginsLoader = new PluginsLoader();
+      const compiler = new TestCompiler(pluginsLoader);
+      const config = makeConfig({
+        sourceRoot: 'src',
+        projects: {
+          'my-app': {
+            sourceRoot: 'apps/my-app/src',
+          },
+        },
+      });
+      const cwd = process.cwd();
+
+      const result = compiler.testGetPathToSource(
+        config,
+        'tsconfig.json',
+        'my-app',
+      );
+
+      expect(result).toBe(join(cwd, 'apps/my-app/src'));
+    });
+  });
+
+  describe('loadPlugins', () => {
+    it('should return empty hooks when no plugins are configured', () => {
+      const loadMock = vi.fn().mockReturnValue({
+        beforeHooks: [],
+        afterHooks: [],
+        afterDeclarationsHooks: [],
+        readonlyVisitors: [],
+      });
+      const pluginsLoader = {
+        load: loadMock,
+      } as unknown as PluginsLoader;
+      const compiler = new TestCompiler(pluginsLoader);
+      const config = makeConfig();
+
+      const result = compiler.testLoadPlugins(
+        config,
+        'tsconfig.json',
+        undefined,
+      );
+
+      expect(result.beforeHooks).toHaveLength(0);
+      expect(result.afterHooks).toHaveLength(0);
+      expect(loadMock).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ pathToSource: expect.any(String) }),
+      );
+    });
+  });
+});

--- a/test/lib/compiler/helpers/manual-restart.spec.ts
+++ b/test/lib/compiler/helpers/manual-restart.spec.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  displayManualRestartTip,
+  listenForManualRestart,
+} from '../../../../lib/compiler/helpers/manual-restart.js';
+
+describe('manual-restart helpers', () => {
+  describe('listenForManualRestart', () => {
+    let originalStdin: typeof process.stdin;
+    let stdinMock: EventEmitter;
+
+    beforeEach(() => {
+      originalStdin = process.stdin;
+      stdinMock = new EventEmitter() as any;
+      Object.defineProperty(process, 'stdin', {
+        value: stdinMock,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'stdin', {
+        value: originalStdin,
+        configurable: true,
+      });
+    });
+
+    it('should invoke the callback when "rs" is entered', () => {
+      const callback = vi.fn();
+      listenForManualRestart(callback);
+
+      stdinMock.emit('data', Buffer.from('rs\n'));
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should invoke the callback when "rs" is entered with surrounding whitespace', () => {
+      const callback = vi.fn();
+      listenForManualRestart(callback);
+
+      stdinMock.emit('data', Buffer.from('  rs  \n'));
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not invoke the callback for other input', () => {
+      const callback = vi.fn();
+      listenForManualRestart(callback);
+
+      stdinMock.emit('data', Buffer.from('hello\n'));
+      stdinMock.emit('data', Buffer.from('restart\n'));
+      stdinMock.emit('data', Buffer.from('r\n'));
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should remove the listener after first invocation', () => {
+      const callback = vi.fn();
+      listenForManualRestart(callback);
+
+      stdinMock.emit('data', Buffer.from('rs\n'));
+      stdinMock.emit('data', Buffer.from('rs\n'));
+
+      // Should only fire once because listener removes itself
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should support multiple independent listeners', () => {
+      const first = vi.fn();
+      const second = vi.fn();
+
+      listenForManualRestart(first);
+      listenForManualRestart(second);
+
+      stdinMock.emit('data', Buffer.from('rs\n'));
+
+      expect(first).toHaveBeenCalledTimes(1);
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('displayManualRestartTip', () => {
+    it('should log a tip message to the console', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      displayManualRestartTip();
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls[0][0]).toContain('rs');
+
+      logSpy.mockRestore();
+    });
+  });
+});

--- a/test/lib/compiler/plugins/plugins-loader.spec.ts
+++ b/test/lib/compiler/plugins/plugins-loader.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as ts from 'typescript';
+import { PluginsLoader } from '../../../../lib/compiler/plugins/plugins-loader.js';
+
+// Mock module resolution to avoid filesystem access
+vi.mock('module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('module')>();
+  return {
+    ...actual,
+    createRequire: (url: string | URL) => {
+      const realReq = actual.createRequire(url);
+      const mockedReq: any = (id: string) => {
+        if (id.includes('test-plugin')) {
+          return {
+            before: (options: any, program?: ts.Program) =>
+              (ctx: ts.TransformationContext) =>
+                (sf: ts.SourceFile) =>
+                  sf,
+            after: (options: any, program?: ts.Program) =>
+              (ctx: ts.TransformationContext) =>
+                (sf: ts.SourceFile) =>
+                  sf,
+          };
+        }
+        if (id.includes('invalid-plugin')) {
+          return {};
+        }
+        return realReq(id);
+      };
+      mockedReq.resolve = (id: string, opts?: any) => {
+        if (id.includes('test-plugin') || id.includes('invalid-plugin')) {
+          return id;
+        }
+        return realReq.resolve(id, opts);
+      };
+      mockedReq.resolve.paths = realReq.resolve.paths?.bind(realReq.resolve);
+      return mockedReq;
+    },
+  };
+});
+
+describe('PluginsLoader', () => {
+  it('should return empty hooks when no plugins are provided', () => {
+    const loader = new PluginsLoader();
+    const result = loader.load([]);
+
+    expect(result.beforeHooks).toEqual([]);
+    expect(result.afterHooks).toEqual([]);
+    expect(result.afterDeclarationsHooks).toEqual([]);
+    expect(result.readonlyVisitors).toEqual([]);
+  });
+
+  it('should return empty hooks when plugins is undefined', () => {
+    const loader = new PluginsLoader();
+    const result = loader.load();
+
+    expect(result.beforeHooks).toHaveLength(0);
+    expect(result.afterHooks).toHaveLength(0);
+  });
+
+  it('should load before and after hooks from a valid plugin', () => {
+    const loader = new PluginsLoader();
+    const result = loader.load(['test-plugin']);
+
+    expect(result.beforeHooks).toHaveLength(1);
+    expect(result.afterHooks).toHaveLength(1);
+    expect(typeof result.beforeHooks[0]).toBe('function');
+    expect(typeof result.afterHooks[0]).toBe('function');
+  });
+
+  it('should throw for a plugin that exports no hooks', () => {
+    const loader = new PluginsLoader();
+    expect(() => loader.load(['invalid-plugin'])).toThrow(/plugin/i);
+  });
+
+  it('should throw for a plugin that is not installed', () => {
+    const loader = new PluginsLoader();
+    expect(() =>
+      loader.load(['@nonexistent/plugin-that-does-not-exist']),
+    ).toThrow(/not installed/i);
+  });
+
+  it('should handle plugin options from object format', () => {
+    const loader = new PluginsLoader();
+    const result = loader.load([
+      { name: 'test-plugin', options: { introspectComments: true } },
+    ]);
+
+    expect(result.beforeHooks).toHaveLength(1);
+    expect(typeof result.beforeHooks[0]).toBe('function');
+  });
+});

--- a/test/lib/compiler/swc/constants.spec.ts
+++ b/test/lib/compiler/swc/constants.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FOUND_NO_ISSUES_GENERATING_METADATA,
+  FOUND_NO_ISSUES_METADATA_GENERATION_SKIPPED,
+  INITIALIZING_TYPE_CHECKER,
+  SWC_LOG_PREFIX,
+  TSC_LOG_ERROR_PREFIX,
+  TSC_LOG_PREFIX,
+  TSC_LOG_SUCCESS_PREFIX,
+  TSC_NO_ERRORS_MESSAGE,
+} from '../../../../lib/compiler/swc/constants.js';
+
+describe('SWC/TSC Constants', () => {
+  it('should define TSC_NO_ERRORS_MESSAGE for watch mode detection', () => {
+    expect(TSC_NO_ERRORS_MESSAGE).toBe(
+      'Found 0 errors. Watching for file changes.',
+    );
+  });
+
+  it('should define all log prefix constants as non-empty strings', () => {
+    expect(SWC_LOG_PREFIX).toBeDefined();
+    expect(SWC_LOG_PREFIX.length).toBeGreaterThan(0);
+    expect(TSC_LOG_PREFIX.length).toBeGreaterThan(0);
+    expect(TSC_LOG_ERROR_PREFIX.length).toBeGreaterThan(0);
+    expect(TSC_LOG_SUCCESS_PREFIX.length).toBeGreaterThan(0);
+  });
+
+  it('should define metadata generation messages', () => {
+    expect(FOUND_NO_ISSUES_GENERATING_METADATA).toContain('metadata');
+    expect(FOUND_NO_ISSUES_METADATA_GENERATION_SKIPPED).toContain('0 issues');
+  });
+
+  it('should define the initializing type checker message', () => {
+    expect(INITIALIZING_TYPE_CHECKER).toContain('type checker');
+  });
+});

--- a/test/lib/compiler/typescript-loader.spec.ts
+++ b/test/lib/compiler/typescript-loader.spec.ts
@@ -1,0 +1,43 @@
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { TypeScriptBinaryLoader } from '../../../lib/compiler/typescript-loader.js';
+
+describe('TypeScriptBinaryLoader', () => {
+  it('should load the typescript binary', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const tsBinary = loader.load();
+    expect(tsBinary).toBeDefined();
+    expect(typeof tsBinary.createProgram).toBe('function');
+  });
+
+  it('should return the same cached instance on subsequent calls', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const first = loader.load();
+    const second = loader.load();
+    expect(first).toBe(second);
+  });
+
+  it('should expose TypeScript namespace utilities', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const tsBinary = loader.load();
+    expect(tsBinary.sys).toBeDefined();
+    expect(tsBinary.ScriptTarget).toBeDefined();
+    expect(tsBinary.ModuleKind).toBeDefined();
+  });
+
+  it('should return the same TypeScript instance used by the test process', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const tsBinary = loader.load();
+    // Both should have the same version string since they resolve from
+    // the same node_modules/typescript.
+    expect(tsBinary.version).toBe(ts.version);
+  });
+
+  it('getModulePaths should return an array of resolution paths', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const paths = loader.getModulePaths();
+    expect(Array.isArray(paths)).toBe(true);
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths.every((p) => typeof p === 'string')).toBe(true);
+  });
+});

--- a/test/lib/configuration/defaults.spec.ts
+++ b/test/lib/configuration/defaults.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultConfiguration,
+  defaultGitIgnore,
+  defaultOutDir,
+  defaultRspackConfigFilename,
+  defaultTsconfigFilename,
+  defaultWebpackConfigFilename,
+} from '../../../lib/configuration/defaults.js';
+
+describe('Configuration Defaults', () => {
+  describe('defaultConfiguration', () => {
+    it('should use TypeScript as the default language', () => {
+      expect(defaultConfiguration.language).toBe('ts');
+    });
+
+    it('should use src as the default source root', () => {
+      expect(defaultConfiguration.sourceRoot).toBe('src');
+    });
+
+    it('should use @nestjs/schematics as the default collection', () => {
+      expect(defaultConfiguration.collection).toBe('@nestjs/schematics');
+    });
+
+    it('should use main as the default entry file', () => {
+      expect(defaultConfiguration.entryFile).toBe('main');
+    });
+
+    it('should use node as the default exec', () => {
+      expect(defaultConfiguration.exec).toBe('node');
+    });
+
+    it('should have empty projects by default', () => {
+      expect(defaultConfiguration.projects).toEqual({});
+    });
+
+    it('should not be a monorepo by default', () => {
+      expect(defaultConfiguration.monorepo).toBe(false);
+    });
+
+    it('should use tsc as the default builder', () => {
+      expect(defaultConfiguration.compilerOptions.builder).toEqual(
+        expect.objectContaining({ type: 'tsc' }),
+      );
+    });
+
+    it('should have webpack disabled by default', () => {
+      expect(defaultConfiguration.compilerOptions.webpack).toBe(false);
+    });
+
+    it('should have empty plugins by default', () => {
+      expect(defaultConfiguration.compilerOptions.plugins).toEqual([]);
+    });
+
+    it('should have empty assets by default', () => {
+      expect(defaultConfiguration.compilerOptions.assets).toEqual([]);
+    });
+
+    it('should have manual restart disabled by default', () => {
+      expect(defaultConfiguration.compilerOptions.manualRestart).toBe(false);
+    });
+
+    it('should have empty generate options by default', () => {
+      expect(defaultConfiguration.generateOptions).toEqual({});
+    });
+  });
+
+  describe('default filenames', () => {
+    it('should define a default tsconfig filename', () => {
+      expect(defaultTsconfigFilename).toBeDefined();
+      expect(typeof defaultTsconfigFilename).toBe('string');
+    });
+
+    it('should use webpack.config.js as the default webpack config', () => {
+      expect(defaultWebpackConfigFilename).toBe('webpack.config.js');
+    });
+
+    it('should use rspack.config.js as the default rspack config', () => {
+      expect(defaultRspackConfigFilename).toBe('rspack.config.js');
+    });
+
+    it('should use dist as the default output directory', () => {
+      expect(defaultOutDir).toBe('dist');
+    });
+  });
+
+  describe('defaultGitIgnore', () => {
+    it('should include common directories to ignore', () => {
+      expect(defaultGitIgnore).toContain('/dist');
+      expect(defaultGitIgnore).toContain('/node_modules');
+      expect(defaultGitIgnore).toContain('.DS_Store');
+    });
+
+    it('should include dotenv files', () => {
+      expect(defaultGitIgnore).toContain('.env');
+    });
+
+    it('should include IDE directories', () => {
+      expect(defaultGitIgnore).toContain('/.idea');
+      expect(defaultGitIgnore).toContain('.vscode');
+    });
+  });
+});

--- a/test/lib/runners/runner-implementations.spec.ts
+++ b/test/lib/runners/runner-implementations.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { GitRunner } from '../../../lib/runners/git.runner.js';
+import { NpmRunner } from '../../../lib/runners/npm.runner.js';
+import { PnpmRunner } from '../../../lib/runners/pnpm.runner.js';
+import { YarnRunner } from '../../../lib/runners/yarn.runner.js';
+
+describe('Runner Implementations', () => {
+  describe('NpmRunner', () => {
+    it('should use "npm" as the binary', () => {
+      const runner = new NpmRunner();
+      expect(runner.rawFullCommand('install')).toContain('npm');
+    });
+
+    it('should produce the correct full command', () => {
+      const runner = new NpmRunner();
+      expect(runner.rawFullCommand('install')).toBe('npm install');
+    });
+  });
+
+  describe('YarnRunner', () => {
+    it('should use "yarn" as the binary', () => {
+      const runner = new YarnRunner();
+      expect(runner.rawFullCommand('add')).toContain('yarn');
+    });
+
+    it('should produce the correct full command', () => {
+      const runner = new YarnRunner();
+      expect(runner.rawFullCommand('add lodash')).toBe('yarn add lodash');
+    });
+  });
+
+  describe('PnpmRunner', () => {
+    it('should use "pnpm" as the binary', () => {
+      const runner = new PnpmRunner();
+      expect(runner.rawFullCommand('install')).toContain('pnpm');
+    });
+
+    it('should produce the correct full command', () => {
+      const runner = new PnpmRunner();
+      expect(runner.rawFullCommand('add lodash')).toBe('pnpm add lodash');
+    });
+  });
+
+  describe('GitRunner', () => {
+    it('should use "git" as the binary', () => {
+      const runner = new GitRunner();
+      expect(runner.rawFullCommand('init')).toContain('git');
+    });
+
+    it('should produce the correct full command', () => {
+      const runner = new GitRunner();
+      expect(runner.rawFullCommand('init')).toBe('git init');
+    });
+  });
+});

--- a/test/lib/runners/runner.factory.spec.ts
+++ b/test/lib/runners/runner.factory.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { NpmRunner } from '../../../lib/runners/npm.runner.js';
+import { PnpmRunner } from '../../../lib/runners/pnpm.runner.js';
+import { Runner } from '../../../lib/runners/runner.js';
+import { RunnerFactory } from '../../../lib/runners/runner.factory.js';
+import { SchematicRunner } from '../../../lib/runners/schematic.runner.js';
+import { YarnRunner } from '../../../lib/runners/yarn.runner.js';
+
+describe('RunnerFactory', () => {
+  it('should create a SchematicRunner for Runner.SCHEMATIC', () => {
+    const runner = RunnerFactory.create(Runner.SCHEMATIC);
+    expect(runner).toBeInstanceOf(SchematicRunner);
+  });
+
+  it('should create an NpmRunner for Runner.NPM', () => {
+    const runner = RunnerFactory.create(Runner.NPM);
+    expect(runner).toBeInstanceOf(NpmRunner);
+  });
+
+  it('should create a YarnRunner for Runner.YARN', () => {
+    const runner = RunnerFactory.create(Runner.YARN);
+    expect(runner).toBeInstanceOf(YarnRunner);
+  });
+
+  it('should create a PnpmRunner for Runner.PNPM', () => {
+    const runner = RunnerFactory.create(Runner.PNPM);
+    expect(runner).toBeInstanceOf(PnpmRunner);
+  });
+
+  it('should throw for an unsupported runner', () => {
+    expect(() => RunnerFactory.create(999 as Runner)).toThrow(
+      'Unsupported runner: 999',
+    );
+  });
+
+  it('should return a new instance on each call', () => {
+    const runner1 = RunnerFactory.create(Runner.NPM);
+    const runner2 = RunnerFactory.create(Runner.NPM);
+    expect(runner1).not.toBe(runner2);
+    expect(runner1).toBeInstanceOf(NpmRunner);
+    expect(runner2).toBeInstanceOf(NpmRunner);
+  });
+});

--- a/test/lib/schematics/abstract.collection.spec.ts
+++ b/test/lib/schematics/abstract.collection.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AbstractRunner } from '../../../lib/runners/abstract.runner.js';
+import { AbstractCollection } from '../../../lib/schematics/abstract.collection.js';
+import { SchematicOption } from '../../../lib/schematics/schematic.option.js';
+
+class TestCollection extends AbstractCollection {
+  getSchematics() {
+    return [{ name: 'test', alias: 't', description: 'Test schematic' }];
+  }
+}
+
+describe('AbstractCollection', () => {
+  it('should build a command line from schematic name and options', async () => {
+    const runMock = vi.fn().mockResolvedValue(null);
+    const runner = { run: runMock } as unknown as AbstractRunner;
+    const collection = new TestCollection('@test/schematics', runner);
+
+    await collection.execute('controller', [
+      new SchematicOption('name', 'users'),
+    ]);
+
+    expect(runMock).toHaveBeenCalledWith(
+      '@test/schematics:controller --name=users',
+    );
+  });
+
+  it('should concatenate multiple options', async () => {
+    const runMock = vi.fn().mockResolvedValue(null);
+    const runner = { run: runMock } as unknown as AbstractRunner;
+    const collection = new TestCollection('@test/schematics', runner);
+
+    await collection.execute('service', [
+      new SchematicOption('name', 'auth'),
+      new SchematicOption('flat', true),
+      new SchematicOption('spec', false),
+    ]);
+
+    expect(runMock).toHaveBeenCalledWith(
+      '@test/schematics:service --name=auth --flat --spec=false',
+    );
+  });
+
+  it('should append extra flags to the command', async () => {
+    const runMock = vi.fn().mockResolvedValue(null);
+    const runner = { run: runMock } as unknown as AbstractRunner;
+    const collection = new TestCollection('@test/schematics', runner);
+
+    await collection.execute(
+      'resource',
+      [new SchematicOption('name', 'posts')],
+      '--dry-run',
+    );
+
+    expect(runMock).toHaveBeenCalledWith(
+      '@test/schematics:resource --name=posts --dry-run',
+    );
+  });
+
+  it('should handle empty options array', async () => {
+    const runMock = vi.fn().mockResolvedValue(null);
+    const runner = { run: runMock } as unknown as AbstractRunner;
+    const collection = new TestCollection('@test/schematics', runner);
+
+    await collection.execute('module', []);
+
+    expect(runMock).toHaveBeenCalledWith('@test/schematics:module');
+  });
+
+  it('should not append extra flags when undefined', async () => {
+    const runMock = vi.fn().mockResolvedValue(null);
+    const runner = { run: runMock } as unknown as AbstractRunner;
+    const collection = new TestCollection('@test/schematics', runner);
+
+    await collection.execute('guard', [new SchematicOption('name', 'auth')]);
+
+    expect(runMock).toHaveBeenCalledWith(
+      '@test/schematics:guard --name=auth',
+    );
+  });
+});

--- a/test/lib/schematics/collection.factory.spec.ts
+++ b/test/lib/schematics/collection.factory.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { CollectionFactory } from '../../../lib/schematics/collection.factory.js';
+import { Collection } from '../../../lib/schematics/collection.js';
+import { CustomCollection } from '../../../lib/schematics/custom.collection.js';
+import { NestCollection } from '../../../lib/schematics/nest.collection.js';
+
+describe('CollectionFactory', () => {
+  it('should create a NestCollection for the NestJS collection', () => {
+    const collection = CollectionFactory.create(Collection.NESTJS);
+    expect(collection).toBeInstanceOf(NestCollection);
+  });
+
+  it('should create a NestCollection when passed the string value', () => {
+    const collection = CollectionFactory.create('@nestjs/schematics');
+    expect(collection).toBeInstanceOf(NestCollection);
+  });
+
+  it('should create a CustomCollection for a non-NestJS collection', () => {
+    const collection = CollectionFactory.create('@custom/schematics');
+    expect(collection).toBeInstanceOf(CustomCollection);
+  });
+
+  it('should create a CustomCollection for any arbitrary collection name', () => {
+    const collection = CollectionFactory.create('my-local-schematics');
+    expect(collection).toBeInstanceOf(CustomCollection);
+  });
+});

--- a/test/lib/utils/is-module-available.spec.ts
+++ b/test/lib/utils/is-module-available.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isModuleAvailable } from '../../../lib/utils/is-module-available.js';
+
+describe('isModuleAvailable', () => {
+  it('should return true for a module that can be resolved', () => {
+    // typescript is a direct dependency of nest-cli
+    expect(isModuleAvailable('typescript')).toBe(true);
+  });
+
+  it('should return true for a built-in Node.js module', () => {
+    expect(isModuleAvailable('fs')).toBe(true);
+  });
+
+  it('should return true for another built-in Node.js module', () => {
+    expect(isModuleAvailable('path')).toBe(true);
+  });
+
+  it('should return false for a non-existent package', () => {
+    expect(
+      isModuleAvailable('this-module-really-does-not-exist-abcxyz123'),
+    ).toBe(false);
+  });
+
+  it('should return false for an invalid relative path', () => {
+    expect(isModuleAvailable('../../../does/not/exist.js')).toBe(false);
+  });
+
+  it('should return false when resolution throws for an empty string', () => {
+    expect(isModuleAvailable('')).toBe(false);
+  });
+});

--- a/test/lib/utils/load-configuration.spec.ts
+++ b/test/lib/utils/load-configuration.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadConfiguration } from '../../../lib/utils/load-configuration.js';
+
+// Mock the NestConfigurationLoader to avoid filesystem access
+vi.mock('../../../lib/configuration/nest-configuration.loader.js', () => {
+  return {
+    NestConfigurationLoader: class {
+      load() {
+        return {
+          language: 'ts',
+          sourceRoot: 'src',
+          collection: '@nestjs/schematics',
+          entryFile: 'main',
+          exec: 'node',
+          projects: {},
+          monorepo: false,
+          compilerOptions: {},
+          generateOptions: {},
+        };
+      }
+    },
+  };
+});
+
+vi.mock('../../../lib/readers/index.js', () => {
+  return {
+    FileSystemReader: class {
+      constructor() {}
+    },
+  };
+});
+
+describe('loadConfiguration', () => {
+  it('should return a configuration object', async () => {
+    const config = await loadConfiguration();
+    expect(config).toBeDefined();
+    expect(config.language).toBe('ts');
+    expect(config.sourceRoot).toBe('src');
+  });
+
+  it('should return default entry file', async () => {
+    const config = await loadConfiguration();
+    expect(config.entryFile).toBe('main');
+  });
+
+  it('should return default collection', async () => {
+    const config = await loadConfiguration();
+    expect(config.collection).toBe('@nestjs/schematics');
+  });
+
+  it('should return an object with all required configuration fields', async () => {
+    const config = await loadConfiguration();
+    expect(config).toHaveProperty('language');
+    expect(config).toHaveProperty('sourceRoot');
+    expect(config).toHaveProperty('collection');
+    expect(config).toHaveProperty('entryFile');
+    expect(config).toHaveProperty('exec');
+    expect(config).toHaveProperty('projects');
+    expect(config).toHaveProperty('monorepo');
+    expect(config).toHaveProperty('compilerOptions');
+    expect(config).toHaveProperty('generateOptions');
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tests

Consolidated from the following individual PRs as requested by @micalevisk:
- #3375 — isModuleAvailable, RunnerFactory
- #3377 — TypeScriptBinaryLoader, manual-restart
- #3379 — CollectionFactory
- #3380 — npm/yarn/pnpm/git runners
- #3381 — PluginsLoader
- #3382 — AbstractCollection command building
- #3383 — BaseCompiler
- #3384 — SWC constants
- #3385 — loadConfiguration
- #3386 — configuration defaults

The individual PRs will be closed once this is merged.

## What is the current behavior?

Twelve source modules have no direct unit test coverage on v12.

## What is the new behavior?

Adds **77 unit tests across 12 files** covering:

### Compiler (24 tests)
- `base-compiler.spec.ts` (3) — `getPathToSource` resolution, `loadPlugins` delegation
- `typescript-loader.spec.ts` (5) — binary resolution, caching, module paths
- `plugins/plugins-loader.spec.ts` (6) — hook loading, error handling, options binding
- `swc/constants.spec.ts` (4) — log prefixes, watch-mode message
- `helpers/manual-restart.spec.ts` (6) — `rs` listener, cleanup, tip display

### Runners (14 tests)
- `runner.factory.spec.ts` (6) — all runner enum values + error cases
- `runner-implementations.spec.ts` (8) — npm, yarn, pnpm, git binary + command verification

### Schematics (9 tests)
- `collection.factory.spec.ts` (4) — NestCollection vs CustomCollection creation
- `abstract.collection.spec.ts` (5) — command line building, options, extra flags

### Configuration (20 tests)
- `defaults.spec.ts` (20) — all default fields, filenames, outDir, gitignore content

### Utils (10 tests)
- `is-module-available.spec.ts` (6) — resolution, built-ins, missing modules
- `load-configuration.spec.ts` (4) — default values, required fields

## Test plan
- [x] All 77 tests pass