### PR TITLE
test(hooks): normalize emit path separators for windows

### DIFF
--- a/test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts
+++ b/test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts
@@ -31,7 +31,13 @@ function createSpec(
   program.emit(
     undefined,
     (fileName, data) => {
-      output.set(path.relative(baseUrl, fileName), data);
+      // Normalize path separators so assertions using forward slashes
+      // also pass on Windows where TypeScript emits paths with backslashes.
+      const relativePath = path
+        .relative(baseUrl, fileName)
+        .split(path.sep)
+        .join('/');
+      output.set(relativePath, data);
     },
     undefined,
     undefined,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test fix (cross-platform). No runtime behavior change.

## What is the current behavior?

Four tests in `test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts` fail when the suite is run on Windows:

- `CJS output (module: CommonJS) > should remove unused imports`
- `CJS output (module: CommonJS) > should replace aliased imports with relative paths`
- `ESM output (module: ESNext) > should remove unused imports`
- `ESM output (module: ESNext) > should replace aliased imports with relative paths`

The `createSpec` helper stores each emitted file in a `Map` keyed by `path.relative(baseUrl, fileName)`. On Windows, `path.relative` returns backslash-separated keys like `dist\main.js`, while the assertions read the map with forward-slash keys (`output.get('dist/main.js')`). `get(...)` returns `undefined`, and the downstream `toContain` assertions fail with `AssertionError: the given combination of arguments (undefined and string) is invalid for this assertion`.

Linux CI is unaffected because `path.sep` is `/` there.

## What is the new behavior?

Normalize the relative path to forward slashes before storing it in the map so keys match the assertion style on every platform.

## Additional context

- Before: 4/6 tests in this file failing locally on Windows.
- After: 6/6 passing on Windows; no change on Linux (still 6/6).

## Test plan

- [x] `npx vitest run test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts` passes on Windows
- [x] `npm run build` clean