### PR TITLE
feat(cli): add rspack config path option to build and start commands

### DIFF
--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -35,6 +35,7 @@ export class BuildCommand extends AbstractCommand {
       )
       .option('--silent', 'Suppress informational compiler logs.')
       .option('--webpackPath [path]', 'Path to webpack configuration.')
+      .option('--rspackPath [path]', 'Path to rspack configuration.')
       .option('--tsc', 'Use typescript compiler for compilation.')
       .option(
         '--preserveWatchOutput',
@@ -68,6 +69,7 @@ export class BuildCommand extends AbstractCommand {
           watchAssets: !!options.watchAssets,
           path: options.path,
           webpackPath: options.webpackPath,
+          rspackPath: options.rspackPath,
           builder: options.builder,
           typeCheck: options.typeCheck,
           emitDeclarations: !!options.emitDeclarations,

--- a/commands/context/build.context.ts
+++ b/commands/context/build.context.ts
@@ -6,6 +6,7 @@ export interface BuildCommandContext {
   watchAssets: boolean;
   path?: string;
   webpackPath?: string;
+  rspackPath?: string;
   builder?: string;
   typeCheck?: boolean;
   emitDeclarations?: boolean;

--- a/commands/context/start.context.ts
+++ b/commands/context/start.context.ts
@@ -6,6 +6,7 @@ export interface StartCommandContext {
   watchAssets: boolean;
   path?: string;
   webpackPath?: string;
+  rspackPath?: string;
   builder?: string;
   typeCheck?: boolean;
   emitDeclarations?: boolean;

--- a/commands/start.command.ts
+++ b/commands/start.command.ts
@@ -30,6 +30,7 @@ export class StartCommand extends AbstractCommand {
         'Use webpack for compilation (deprecated option, use --builder instead).',
       )
       .option('--webpackPath [path]', 'Path to webpack configuration.')
+      .option('--rspackPath [path]', 'Path to rspack configuration.')
       .option(
         '--type-check',
         'Enable type checking (when SWC is used).',
@@ -94,6 +95,7 @@ export class StartCommand extends AbstractCommand {
           watchAssets: !!options.watchAssets,
           path: options.path,
           webpackPath: options.webpackPath,
+          rspackPath: options.rspackPath,
           builder: options.builder,
           typeCheck: options.typeCheck,
           emitDeclarations: !!options.emitDeclarations,

--- a/test/actions/build.action.spec.ts
+++ b/test/actions/build.action.spec.ts
@@ -3,6 +3,7 @@ import { BuildAction } from '../../actions/build.action.js';
 import { Configuration } from '../../lib/configuration/index.js';
 import { RspackCompiler } from '../../lib/compiler/rspack-compiler.js';
 import { WebpackCompiler } from '../../lib/compiler/webpack-compiler.js';
+import { getRspackConfigPath } from '../../lib/compiler/helpers/get-rspack-config-path.js';
 
 vi.mock('../../lib/compiler/rspack-compiler.js', () => ({
   RspackCompiler: vi.fn().mockImplementation(function () {
@@ -111,6 +112,25 @@ describe('BuildAction - Rspack', () => {
       );
 
       expect(RspackCompiler).toHaveBeenCalled();
+    });
+
+    it('should forward rspackPath option to getRspackConfigPath helper', async () => {
+      // Return undefined so runRspack falls back to the default config filename
+      // and the (mocked) is-module-available short-circuits the require call.
+      vi.mocked(getRspackConfigPath).mockReturnValue(undefined);
+
+      await buildAction.runBuild(
+        [undefined],
+        { builder: 'rspack', rspackPath: 'custom.rspack.config.js' },
+        false,
+        false,
+      );
+
+      expect(getRspackConfigPath).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ rspackPath: 'custom.rspack.config.js' }),
+        undefined,
+      );
     });
 
     it('should not use rspack compiler when builder type is webpack', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (small). Closes a CLI gap — no existing issue.

## What is the current behavior?

`getRspackConfigPath` already honours `cmdOptions.rspackPath` (there's even a unit test for it: `test/lib/compiler/helpers/get-rspack-config-path.spec.ts > should return the CLI rspackPath option when provided`). However, neither the `build` nor the `start` command registers the flag with commander, so `options.rspackPath` is always `undefined` at runtime and projects using the rspack builder can only point at a custom rspack config via `nest-cli.json`.

This is inconsistent with webpack, which has had `--webpackPath` wired for a long time.

## What is the new behavior?

Register `--rspackPath [path]` on both the `build` and `start` commands, mirroring the existing `--webpackPath` option. The option is forwarded into the command contexts, which the action already passes to `getRspackConfigPath`.

Changed files:

- `commands/build.command.ts` — register `--rspackPath`, forward to `BuildCommandContext`
- `commands/start.command.ts` — register `--rspackPath`, forward to `StartCommandContext`
- `commands/context/build.context.ts` / `start.context.ts` — add `rspackPath?: string`
- `test/actions/build.action.spec.ts` — new test asserting the option reaches `getRspackConfigPath`

No existing behavior changes: when the flag is not passed, `options.rspackPath` stays `undefined` and the helper falls back to `builder.options.configPath` / default filename as before.

## Test plan

- [x] `npm run build` clean (tsc)
- [x] `npx vitest run test/actions/build.action.spec.ts` — 4/4 pass
- [x] `npx vitest run test/lib/compiler/helpers/get-rspack-config-path.spec.ts` — 8/8 pass
- [x] No change to unrelated tests locally (the 5 pre-existing Windows failures in `tsconfig-paths.hook.spec.ts` are tracked separately in #3398)