### PR TITLE
fix(new): prefer process.stdout.columns over tput for terminal width

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -201,6 +201,13 @@ const print =
 
 export const retrieveCols = () => {
   const defaultCols = 80;
+  // Prefer process.stdout.columns: it works on every platform (including
+  // Windows, where `tput` is not available by default) and reflects the
+  // actual terminal size instead of always falling back to the default.
+  const stdoutCols = process.stdout.columns;
+  if (typeof stdoutCols === 'number' && stdoutCols > 0) {
+    return stdoutCols;
+  }
   try {
     const terminalCols = execSync('tput cols', {
       stdio: ['pipe', 'pipe', 'ignore'],

--- a/test/actions/new.action.spec.ts
+++ b/test/actions/new.action.spec.ts
@@ -53,9 +53,10 @@ vi.mock('../../lib/runners/git.runner.js', () => {
   };
 });
 
-import { NewAction } from '../../actions/new.action.js';
+import { NewAction, retrieveCols } from '../../actions/new.action.js';
 import { NewCommandContext } from '../../commands/context/new.context.js';
 import { SchematicOption } from '../../lib/schematics/index.js';
+import { execSync } from 'child_process';
 
 describe('NewAction', () => {
   let action: NewAction;
@@ -127,6 +128,66 @@ describe('NewAction', () => {
           opt.toCommandString().includes('skip-tests'),
       );
       expect(skipTestsOption).toBeUndefined();
+    });
+  });
+
+  describe('retrieveCols', () => {
+    const originalColumns = process.stdout.columns;
+
+    afterEach(() => {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: originalColumns,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('should return process.stdout.columns when set to a positive number', () => {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: 132,
+        configurable: true,
+        writable: true,
+      });
+
+      expect(retrieveCols()).toBe(132);
+      // tput should never be spawned when stdout.columns is usable.
+      expect(execSync).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to tput cols when stdout.columns is undefined', () => {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: undefined,
+        configurable: true,
+        writable: true,
+      });
+      vi.mocked(execSync).mockReturnValueOnce('120' as any);
+
+      expect(retrieveCols()).toBe(120);
+      expect(execSync).toHaveBeenCalledWith('tput cols', expect.any(Object));
+    });
+
+    it('should fall back to tput cols when stdout.columns is zero (not a TTY)', () => {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: 0,
+        configurable: true,
+        writable: true,
+      });
+      vi.mocked(execSync).mockReturnValueOnce('100' as any);
+
+      expect(retrieveCols()).toBe(100);
+    });
+
+    it('should return default 80 when neither stdout.columns nor tput is usable', () => {
+      Object.defineProperty(process.stdout, 'columns', {
+        value: undefined,
+        configurable: true,
+        writable: true,
+      });
+      vi.mocked(execSync).mockImplementationOnce(() => {
+        throw new Error('tput: command not found');
+      });
+
+      expect(retrieveCols()).toBe(80);
     });
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (small, cross-platform). No public API change.

## What is the current behavior?

`retrieveCols` in `actions/new.action.ts` — used by `printCollective` to center the "Thanks for installing Nest" banner after `nest new` — only asks the shell for the terminal width via `tput cols`:

```ts
export const retrieveCols = () => {
  const defaultCols = 80;
  try {
    const terminalCols = execSync('tput cols', {
      stdio: ['pipe', 'pipe', 'ignore'],
    });
    return parseInt(terminalCols.toString(), 10) || defaultCols;
  } catch {
    return defaultCols;
  }
};
```

On Windows, `tput` is not installed by default, so `execSync` throws and the function silently returns the hard-coded 80, regardless of the user's actual terminal width. Same fallback hits on minimal/sandboxed Linux images without `ncurses`.

## What is the new behavior?

Ask Node first. `process.stdout.columns` is maintained by the runtime on every platform and reflects the real terminal size (or `undefined` / `0` when stdout is not a TTY). When it's a positive number, return it directly and skip the `execSync` call — which also avoids spawning a process for every line of banner output. `tput cols` and the 80-column default remain as secondary / tertiary fallbacks for the non-TTY case, so behavior is unchanged anywhere that was already working.

## Additional context

- Adds unit tests in `test/actions/new.action.spec.ts` covering all three branches (stdout.columns set, tput fallback, default).
- No observable change for users on *nix with a TTY that had `tput` available — `process.stdout.columns` and `tput cols` return the same value there.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run test/actions/new.action.spec.ts` — 7/7 pass (4 new)
- [x] Remaining failures on full `npm test` are the pre-existing Windows-only failures in `tsconfig-paths.hook.spec.ts` (tracked in #3398)