### PR TITLE
feat(compiler): rewrite path aliases in emitted declaration files

### DIFF
--- a/lib/compiler/compiler.ts
+++ b/lib/compiler/compiler.ts
@@ -62,7 +62,9 @@ export class Compiler extends BaseCompiler {
           ? [tsconfigPathsPlugin, ...before]
           : before,
         after,
-        afterDeclarations,
+        afterDeclarations: tsconfigPathsPlugin
+          ? [tsconfigPathsPlugin, ...afterDeclarations]
+          : afterDeclarations,
       },
     );
 

--- a/lib/compiler/watch-compiler.ts
+++ b/lib/compiler/watch-compiler.ts
@@ -147,6 +147,7 @@ export class WatchCompiler extends BaseCompiler<TypescriptWatchCompilerExtras> {
         );
         if (tsconfigPathsPlugin) {
           before.unshift(tsconfigPathsPlugin);
+          afterDeclarations.unshift(tsconfigPathsPlugin);
         }
 
         transforms.before = before.concat(transforms.before || []);

--- a/test/lib/compiler/hooks/fixtures/aliased-dts-imports/src/bar.ts
+++ b/test/lib/compiler/hooks/fixtures/aliased-dts-imports/src/bar.ts
@@ -1,0 +1,3 @@
+export class Bar {
+  value: number = 0;
+}

--- a/test/lib/compiler/hooks/fixtures/aliased-dts-imports/src/foo.ts
+++ b/test/lib/compiler/hooks/fixtures/aliased-dts-imports/src/foo.ts
@@ -1,0 +1,3 @@
+export class Foo {
+  name: string = '';
+}

--- a/test/lib/compiler/hooks/fixtures/aliased-dts-imports/src/main.ts
+++ b/test/lib/compiler/hooks/fixtures/aliased-dts-imports/src/main.ts
@@ -1,0 +1,2 @@
+export { Foo } from '~/foo';
+export { Bar } from '~/bar';

--- a/test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts
+++ b/test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts
@@ -42,6 +42,46 @@ function createSpec(
   return output;
 }
 
+function createSpecWithDeclarations(
+  baseUrl: string,
+  fileNames: string[],
+  compilerOptions?: ts.CompilerOptions,
+) {
+  const options: ts.CompilerOptions = {
+    baseUrl,
+    outDir: path.join(baseUrl, 'dist'),
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.CommonJS,
+    declaration: true,
+    ...compilerOptions,
+  };
+
+  const program = ts.createProgram({
+    rootNames: fileNames.map((name) => path.join(baseUrl, name)),
+    options,
+  });
+  const output = new Map<string, string>();
+  const transformer = tsconfigPathsBeforeHookFactory(options);
+  program.emit(
+    undefined,
+    (fileName, data) => {
+      // Store with forward-slash keys so assertions work on Windows too.
+      const relativePath = path
+        .relative(baseUrl, fileName)
+        .split(path.sep)
+        .join('/');
+      output.set(relativePath, data);
+    },
+    undefined,
+    undefined,
+    {
+      before: transformer ? [transformer] : [],
+      afterDeclarations: transformer ? [transformer] : [],
+    },
+  );
+  return output;
+}
+
 describe('tsconfig paths hooks', () => {
   describe('CJS output (module: CommonJS)', () => {
     it('should remove type imports', () => {
@@ -139,6 +179,44 @@ describe('tsconfig paths hooks', () => {
       expect(mainJs).toContain('from "./baz"');
       expect(mainJs).toContain('from "./qux"');
       expect(mainJs).not.toContain('~/');
+    });
+  });
+
+  describe('declaration files (afterDeclarations)', () => {
+    it('should replace path aliases in emitted .d.ts files', () => {
+      const output = createSpecWithDeclarations(
+        path.join(__dirname, './fixtures/aliased-dts-imports'),
+        ['src/main.ts', 'src/foo.ts', 'src/bar.ts'],
+        { paths: { '~/*': ['./src/*'] } },
+      );
+
+      const dtsEntries = Array.from(output.entries()).filter(([key]) =>
+        key.endsWith('.d.ts'),
+      );
+      expect(dtsEntries.length).toBeGreaterThan(0);
+
+      const mainDts = output.get('dist/main.d.ts')!;
+      expect(mainDts).toBeDefined();
+      expect(mainDts).not.toContain('~/foo');
+      expect(mainDts).not.toContain('~/bar');
+      expect(mainDts).toContain('./foo');
+      expect(mainDts).toContain('./bar');
+    });
+
+    it('should not leave any path aliases in .d.ts files', () => {
+      const output = createSpecWithDeclarations(
+        path.join(__dirname, './fixtures/aliased-dts-imports'),
+        ['src/main.ts', 'src/foo.ts', 'src/bar.ts'],
+        { paths: { '~/*': ['./src/*'] } },
+      );
+
+      const dtsEntries = Array.from(output.entries()).filter(([key]) =>
+        key.endsWith('.d.ts'),
+      );
+
+      for (const [, content] of dtsEntries) {
+        expect(content).not.toMatch(/from\s+['"]~\//);
+      }
     });
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug-fix backport from master to v12.0.0.

## What is the current behavior?

On master, [PR #3318 / commit 73e1aeb4](https://github.com/nestjs/nest-cli/commit/73e1aeb4) (closes #1749) wired the `tsconfigPaths` transformer into `afterDeclarations` in both `Compiler.run` and `WatchCompiler.overrideCreateProgramFn`, so that path aliases such as `~/foo` in emitted `.d.ts` files get rewritten to relative paths, matching the `.js` output.

That change never reached `v12.0.0`: `git log upstream/v12.0.0 -- lib/compiler/compiler.ts` stops at `fix(compiler): run tsconfig paths plugin before user plugins in tsc compiler`, with no follow-up. On v12.0.0 the transformer is still only installed on `before`, so consumers importing a library's `.d.ts` see unresolved aliases like:

```ts
// dist/main.d.ts (before this PR)
export { Foo } from '~/foo';
export { Bar } from '~/bar';
```

## What is the new behavior?

`.d.ts` output now gets the same transformer treatment as the JS output:

```ts
// dist/main.d.ts (after this PR)
export { Foo } from './foo';
export { Bar } from './bar';
```

## Additional context

- Minimal port — identical two-line additions to `compiler.ts` and `watch-compiler.ts`.
- Master's test file pairs a new declaration-file describe block with a `describe.skip` for the flaky older tests. On v12.0.0 those older tests have already been replaced by comprehensive CJS/ESM suites (`test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts`), so this PR keeps those intact and only appends the new `declaration files (afterDeclarations)` describe block plus its fixtures.
- The new `createSpecWithDeclarations` helper normalizes emit paths to forward slashes so the assertions work on Windows as well as CI.
- Closes [#1749](https://github.com/nestjs/nest-cli/issues/1749) for the v12 line.

## Test plan

- [x] `npm run build` clean (tsc)
- [x] The two new declaration-file tests pass locally
- [x] No change to the existing CJS/ESM describe blocks
- [x] Pre-existing Windows-only failures in the unchanged `createSpec` helper are tracked in #3398; this PR does not regress them