### PR TITLE
feat(generate): accept type and crud options on the resource schematic

### DIFF
--- a/actions/generate.action.ts
+++ b/actions/generate.action.ts
@@ -161,6 +161,10 @@ const mapContextToSchematicOptions = (
     options.push(new SchematicOption('project', context.project));
   if (context.skipImport !== undefined)
     options.push(new SchematicOption('skipImport', context.skipImport));
+  if (context.type !== undefined)
+    options.push(new SchematicOption('type', context.type));
+  if (context.crud === true)
+    options.push(new SchematicOption('crud', true));
   // 'schematic', 'spec', 'flat', 'specFileSuffix' are handled separately
   return options;
 };

--- a/commands/context/generate.context.ts
+++ b/commands/context/generate.context.ts
@@ -10,4 +10,6 @@ export interface GenerateCommandContext {
   project?: string;
   skipImport: boolean;
   format: boolean;
+  type?: string;
+  crud?: boolean;
 }

--- a/commands/generate.command.ts
+++ b/commands/generate.command.ts
@@ -52,6 +52,11 @@ export class GenerateCommand extends AbstractCommand {
         '-c, --collection [collectionName]',
         'Schematics collection to use.',
       )
+      .option(
+        '--type [type]',
+        'Transport layer type (rest, graphql-code-first, graphql-schema-first, microservice, ws).',
+      )
+      .option('--crud', 'Generate CRUD entry points for a resource.')
       .action(
         async (
           schematic: string,
@@ -71,6 +76,8 @@ export class GenerateCommand extends AbstractCommand {
             project: options.project,
             skipImport: options.skipImport,
             format: options.format === true,
+            type: options.type,
+            crud: options.crud === true ? true : undefined,
           };
 
           await this.action.handle(context);

--- a/test/actions/generate.action.spec.ts
+++ b/test/actions/generate.action.spec.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecute = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../lib/schematics/index.js', async () => {
+  const original = await vi.importActual('../../lib/schematics/index.js');
+  return {
+    ...original,
+    CollectionFactory: {
+      create: () => ({
+        execute: mockExecute,
+      }),
+    },
+  };
+});
+
+vi.mock('../../lib/utils/load-configuration.js', () => ({
+  loadConfiguration: vi.fn().mockResolvedValue({
+    language: 'ts',
+    sourceRoot: 'src',
+    collection: '@nestjs/schematics',
+    entryFile: 'main',
+    exec: 'node',
+    projects: {},
+    monorepo: false,
+    compilerOptions: {},
+    generateOptions: {},
+  }),
+}));
+
+import { GenerateAction } from '../../actions/generate.action.js';
+import { GenerateCommandContext } from '../../commands/context/generate.context.js';
+import { SchematicOption } from '../../lib/schematics/index.js';
+
+describe('GenerateAction', () => {
+  let action: GenerateAction;
+
+  const baseContext = (
+    overrides: Partial<GenerateCommandContext> = {},
+  ): GenerateCommandContext => ({
+    schematic: 'resource',
+    name: 'users',
+    path: undefined,
+    dryRun: false,
+    flat: false,
+    spec: { value: true, passedAsInput: false },
+    specFileSuffix: undefined,
+    collection: undefined,
+    project: undefined,
+    skipImport: false,
+    format: false,
+    ...overrides,
+  });
+
+  const findOption = (
+    schematicOptions: SchematicOption[],
+    name: string,
+  ): SchematicOption | undefined =>
+    schematicOptions.find((opt) =>
+      opt.toCommandString().startsWith(`--${name}=`) ||
+      opt.toCommandString() === `--${name}`,
+    );
+
+  beforeEach(() => {
+    mockExecute.mockClear();
+    action = new GenerateAction();
+  });
+
+  describe('--type option', () => {
+    it('should forward --type to the schematic when provided', async () => {
+      await action.handle(baseContext({ type: 'rest' }));
+
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const [, schematicOptions] = mockExecute.mock.calls[0];
+      const typeOption = findOption(schematicOptions, 'type');
+      expect(typeOption).toBeDefined();
+      expect(typeOption!.toCommandString()).toBe('--type="rest"');
+    });
+
+    it('should not forward --type when undefined', async () => {
+      await action.handle(baseContext({ type: undefined }));
+
+      const [, schematicOptions] = mockExecute.mock.calls[0];
+      const typeOption = findOption(schematicOptions, 'type');
+      expect(typeOption).toBeUndefined();
+    });
+  });
+
+  describe('--crud option', () => {
+    it('should forward --crud to the schematic when true', async () => {
+      await action.handle(baseContext({ crud: true }));
+
+      const [, schematicOptions] = mockExecute.mock.calls[0];
+      const crudOption = findOption(schematicOptions, 'crud');
+      expect(crudOption).toBeDefined();
+      expect(crudOption!.toCommandString()).toBe('--crud');
+    });
+
+    it('should not forward --crud when falsy', async () => {
+      await action.handle(baseContext({ crud: false }));
+
+      const [, schematicOptions] = mockExecute.mock.calls[0];
+      const crudOption = findOption(schematicOptions, 'crud');
+      expect(crudOption).toBeUndefined();
+    });
+
+    it('should not forward --crud when undefined', async () => {
+      await action.handle(baseContext({ crud: undefined }));
+
+      const [, schematicOptions] = mockExecute.mock.calls[0];
+      const crudOption = findOption(schematicOptions, 'crud');
+      expect(crudOption).toBeUndefined();
+    });
+  });
+
+  it('should support --type and --crud together on the resource schematic', async () => {
+    await action.handle(
+      baseContext({ schematic: 'resource', type: 'rest', crud: true }),
+    );
+
+    const [schematicName, schematicOptions] = mockExecute.mock.calls[0];
+    expect(schematicName).toBe('resource');
+    expect(findOption(schematicOptions, 'type')!.toCommandString()).toBe(
+      '--type="rest"',
+    );
+    expect(findOption(schematicOptions, 'crud')!.toCommandString()).toBe(
+      '--crud',
+    );
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug-fix backport from master to v12.0.0, with added unit tests.

## What is the current behavior?

The `@nestjs/schematics` resource generator defines `--type` and `--crud` options in its `schema.json`. On master the CLI registers and forwards them (see [#3275](https://github.com/nestjs/nest-cli/pull/3275), which closed [#3229](https://github.com/nestjs/nest-cli/issues/3229)). On v12.0.0 neither flag is wired up, so:

```bash
nest g resource users --type rest --crud
```

exits with `error: unknown option '--type'` even though the schematic itself would consume both flags correctly.

## What is the new behavior?

- Register `--type [type]` and `--crud` on the `generate` command
- Forward both into `GenerateCommandContext` and on to the schematic
- Only forward `--crud` when explicitly passed so users who never opted in aren't affected

After this PR:

```bash
nest g resource users --type rest --crud
# Generates src/users/{users.module.ts, users.controller.ts, users.service.ts, dto/, entities/}
```

## Additional context

The original master PR noted "No automated tests were added because there are no existing e2e tests for generate resource." This PR adds a focused unit spec (`test/actions/generate.action.spec.ts`) covering the new option wiring end-to-end at the action layer — forwarded when set, omitted when undefined/false.

Files changed:

- `commands/generate.command.ts` — register `--type` / `--crud`, populate context
- `commands/context/generate.context.ts` — extend `GenerateCommandContext`
- `actions/generate.action.ts` — push `type` / `crud` schematic options
- `test/actions/generate.action.spec.ts` — new unit spec (6 cases)

Closes [#3229](https://github.com/nestjs/nest-cli/issues/3229) for the v12 line.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run test/actions/generate.action.spec.ts` — 6/6 pass
- [x] Full `npm test` local: 488 pass, 5 fail — the 5 failures are the pre-existing Windows-only issues in `tsconfig-paths.hook.spec.ts` (tracked separately in #3398)