### PR TITLE
fix(build): align asset path stripping with effective TypeScript rootDir (#3387)

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -5,6 +5,7 @@ import { Input } from '../commands';
 import { AssetsManager } from '../lib/compiler/assets-manager';
 import { deleteOutDirIfEnabled } from '../lib/compiler/helpers/delete-out-dir';
 import { getBuilder } from '../lib/compiler/helpers/get-builder';
+import { getEffectiveRootDir } from '../lib/compiler/helpers/get-effective-root-dir';
 import { getTscConfigPath } from '../lib/compiler/helpers/get-tsc-config.path';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default';
 import { getWebpackConfigPath } from '../lib/compiler/helpers/get-webpack-config-path';
@@ -105,9 +106,10 @@ export class BuildAction extends AbstractAction {
         commandOptions,
         appName,
       );
-      const { options: tsOptions } =
+      const { options: tsOptions, fileNames: tsFileNames } =
         this.tsConfigProvider.getByConfigFilename(pathToTsconfig);
       const outDir = tsOptions.outDir || defaultOutDir;
+      const tsRootDir = getEffectiveRootDir(tsOptions.rootDir, tsFileNames);
 
       const isWebpackEnabled = getValueOrDefault<boolean>(
         configuration,
@@ -126,6 +128,7 @@ export class BuildAction extends AbstractAction {
         appName,
         outDir,
         watchAssetsMode,
+        tsRootDir,
       );
 
       const typeCheck = getValueOrDefault<boolean>(

--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -42,6 +42,7 @@ export class AssetsManager {
     appName: string | undefined,
     outDir: string,
     watchAssetsMode: boolean,
+    rootDir?: string,
   ) {
     const assets =
       getValueOrDefault<Asset[]>(
@@ -57,6 +58,13 @@ export class AssetsManager {
     try {
       let sourceRoot = getValueOrDefault(configuration, 'sourceRoot', appName);
       sourceRoot = join(process.cwd(), sourceRoot);
+
+      // The asset path stripping must mirror how the TypeScript compiler emits
+      // files. When `--path` (or any other tsconfig override) results in a
+      // rootDir that differs from the configured `sourceRoot`, we use that
+      // rootDir instead so that copied assets stay aligned with the emitted
+      // JavaScript output. See https://github.com/nestjs/nest-cli/issues/3387.
+      const stripRoot = rootDir ? join(rootDir) : sourceRoot;
 
       const filesToCopy = assets.map<AssetEntry>((item) => {
         let includePath = typeof item === 'string' ? item : item.include!;
@@ -89,7 +97,7 @@ export class AssetsManager {
           action: 'change',
           item,
           path: '',
-          sourceRoot,
+          sourceRoot: stripRoot,
           watchAssetsMode: isWatchEnabled,
         };
 

--- a/lib/compiler/helpers/get-effective-root-dir.ts
+++ b/lib/compiler/helpers/get-effective-root-dir.ts
@@ -1,0 +1,57 @@
+import { dirname, isAbsolute, normalize, resolve, sep } from 'path';
+
+/**
+ * Computes the effective TypeScript rootDir for an emit, mirroring how the
+ * TypeScript compiler determines it when `rootDir` is not set in tsconfig.
+ *
+ * When `rootDir` is explicitly configured, its absolute, normalized form is
+ * returned. Otherwise the longest common parent directory of the input file
+ * list is used (the same heuristic TypeScript applies through
+ * `Program#getCommonSourceDirectory`).
+ *
+ * Returns `undefined` if no rootDir can be determined (e.g. no input files).
+ *
+ * @param explicitRootDir Value of `compilerOptions.rootDir` from tsconfig, if any.
+ * @param fileNames List of TypeScript input files (absolute paths).
+ * @param cwd Current working directory used to resolve relative paths.
+ */
+export function getEffectiveRootDir(
+  explicitRootDir: string | undefined,
+  fileNames: readonly string[] | undefined,
+  cwd: string = process.cwd(),
+): string | undefined {
+  if (explicitRootDir) {
+    return normalize(
+      isAbsolute(explicitRootDir) ? explicitRootDir : resolve(cwd, explicitRootDir),
+    );
+  }
+
+  if (!fileNames || fileNames.length === 0) {
+    return undefined;
+  }
+
+  const absolutePaths = fileNames.map((file) =>
+    normalize(isAbsolute(file) ? file : resolve(cwd, file)),
+  );
+
+  let commonDir = dirname(absolutePaths[0]);
+  for (let i = 1; i < absolutePaths.length; i++) {
+    commonDir = commonParentDir(commonDir, dirname(absolutePaths[i]));
+    if (!commonDir) {
+      return undefined;
+    }
+  }
+  return commonDir;
+}
+
+function commonParentDir(a: string, b: string): string {
+  const aSegments = a.split(sep);
+  const bSegments = b.split(sep);
+  const length = Math.min(aSegments.length, bSegments.length);
+
+  let i = 0;
+  while (i < length && aSegments[i] === bSegments[i]) {
+    i++;
+  }
+  return aSegments.slice(0, i).join(sep);
+}

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -1,0 +1,116 @@
+import { resolve, sep } from 'path';
+
+jest.mock('chokidar', () => ({
+  watch: jest.fn().mockReturnValue({
+    on: jest.fn().mockReturnThis(),
+    close: jest.fn(),
+  }),
+}));
+
+jest.mock('glob', () => ({
+  sync: jest.fn(),
+}));
+
+jest.mock('fs', () => ({
+  copyFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  rmSync: jest.fn(),
+  statSync: jest.fn(() => ({
+    isFile: () => true,
+    isDirectory: () => false,
+  })),
+}));
+
+import { copyFileSync } from 'fs';
+import { sync as globSync } from 'glob';
+import { AssetsManager } from '../../../lib/compiler/assets-manager';
+import { Configuration } from '../../../lib/configuration';
+
+const mockedCopyFileSync = copyFileSync as jest.MockedFunction<typeof copyFileSync>;
+const mockedGlobSync = globSync as unknown as jest.MockedFunction<
+  (...args: any[]) => string[]
+>;
+
+function createConfiguration(
+  assetOutDir: string | undefined,
+): Required<Configuration> {
+  return {
+    monorepo: false,
+    sourceRoot: 'src',
+    entryFile: 'main',
+    exec: '',
+    projects: {},
+    language: 'ts',
+    collection: '@nestjs/schematics',
+    compilerOptions: {
+      assets: [
+        {
+          include: '**/static/**/*.txt',
+          ...(assetOutDir ? { outDir: assetOutDir } : {}),
+        } as any,
+      ],
+    },
+    generateOptions: {},
+  };
+}
+
+describe('AssetsManager', () => {
+  const cwd = process.cwd();
+
+  beforeEach(() => {
+    mockedCopyFileSync.mockReset();
+    mockedGlobSync.mockReset();
+  });
+
+  it('strips the configured sourceRoot when no rootDir is provided', () => {
+    const sourceFile = resolve(cwd, 'src', 'static', 'foo.txt');
+    mockedGlobSync.mockReturnValue([sourceFile]);
+
+    const manager = new AssetsManager();
+    manager.copyAssets(createConfiguration('dist/'), undefined, 'dist', false);
+
+    expect(mockedCopyFileSync).toHaveBeenCalledTimes(1);
+    const [, dest] = mockedCopyFileSync.mock.calls[0];
+    expect(dest).toBe(['dist', 'static', 'foo.txt'].join(sep));
+  });
+
+  it('strips the provided TypeScript rootDir instead of sourceRoot when emit moves up (regression for #3387)', () => {
+    // Reproduces `nest build --path tsconfig.json`: the effective TS rootDir
+    // widens to the project root, so JavaScript files emit under <outDir>/src/.
+    // Assets must follow the same widening, otherwise they end up at
+    // <outDir>/static/ while the runtime looks under <outDir>/src/static/.
+    const sourceFile = resolve(cwd, 'src', 'static', 'foo.txt');
+    mockedGlobSync.mockReturnValue([sourceFile]);
+
+    const manager = new AssetsManager();
+    manager.copyAssets(
+      createConfiguration('dist/'),
+      undefined,
+      'dist',
+      false,
+      cwd,
+    );
+
+    expect(mockedCopyFileSync).toHaveBeenCalledTimes(1);
+    const [, dest] = mockedCopyFileSync.mock.calls[0];
+    expect(dest).toBe(['dist', 'src', 'static', 'foo.txt'].join(sep));
+  });
+
+  it('preserves backward compatibility when the provided rootDir matches sourceRoot', () => {
+    const sourceFile = resolve(cwd, 'src', 'static', 'foo.txt');
+    mockedGlobSync.mockReturnValue([sourceFile]);
+
+    const manager = new AssetsManager();
+    manager.copyAssets(
+      createConfiguration('dist/'),
+      undefined,
+      'dist',
+      false,
+      resolve(cwd, 'src'),
+    );
+
+    expect(mockedCopyFileSync).toHaveBeenCalledTimes(1);
+    const [, dest] = mockedCopyFileSync.mock.calls[0];
+    expect(dest).toBe(['dist', 'static', 'foo.txt'].join(sep));
+  });
+});

--- a/test/lib/compiler/helpers/get-effective-root-dir.spec.ts
+++ b/test/lib/compiler/helpers/get-effective-root-dir.spec.ts
@@ -1,0 +1,65 @@
+import { normalize, resolve, sep } from 'path';
+import { getEffectiveRootDir } from '../../../../lib/compiler/helpers/get-effective-root-dir';
+
+describe('getEffectiveRootDir', () => {
+  const cwd = resolve(sep, 'workspace', 'app');
+
+  it('returns undefined when no rootDir is set and no files are provided', () => {
+    expect(getEffectiveRootDir(undefined, undefined, cwd)).toBeUndefined();
+    expect(getEffectiveRootDir(undefined, [], cwd)).toBeUndefined();
+  });
+
+  it('returns the explicit rootDir resolved against cwd when given a relative path', () => {
+    expect(getEffectiveRootDir('src', undefined, cwd)).toBe(
+      normalize(resolve(cwd, 'src')),
+    );
+  });
+
+  it('keeps the explicit rootDir as is when it is already absolute', () => {
+    const absoluteRoot = resolve(sep, 'workspace', 'app', 'src');
+    expect(getEffectiveRootDir(absoluteRoot, undefined, cwd)).toBe(
+      normalize(absoluteRoot),
+    );
+  });
+
+  it('infers the effective rootDir from the common parent of input files', () => {
+    const files = [
+      resolve(cwd, 'src', 'main.ts'),
+      resolve(cwd, 'src', 'app.module.ts'),
+      resolve(cwd, 'src', 'modules', 'foo.ts'),
+    ];
+    expect(getEffectiveRootDir(undefined, files, cwd)).toBe(
+      normalize(resolve(cwd, 'src')),
+    );
+  });
+
+  it('expands the inferred rootDir up to the project root when test files are included (regression for #3387)', () => {
+    // Reproduces `nest build --path tsconfig.json` where tsconfig.json
+    // includes test files at the project root level. TypeScript widens the
+    // effective rootDir to the project root in that case, so the asset copy
+    // logic must follow the same widening to keep assets next to the emit.
+    const files = [
+      resolve(cwd, 'src', 'main.ts'),
+      resolve(cwd, 'src', 'app.module.ts'),
+      resolve(cwd, 'test', 'app.e2e-spec.ts'),
+    ];
+    expect(getEffectiveRootDir(undefined, files, cwd)).toBe(normalize(cwd));
+  });
+
+  it('handles a single file by using its directory as the rootDir', () => {
+    const files = [resolve(cwd, 'src', 'modules', 'only.ts')];
+    expect(getEffectiveRootDir(undefined, files, cwd)).toBe(
+      normalize(resolve(cwd, 'src', 'modules')),
+    );
+  });
+
+  it('prefers the explicit rootDir over the inferred one', () => {
+    const files = [
+      resolve(cwd, 'src', 'main.ts'),
+      resolve(cwd, 'test', 'app.e2e-spec.ts'),
+    ];
+    expect(getEffectiveRootDir('src', files, cwd)).toBe(
+      normalize(resolve(cwd, 'src')),
+    );
+  });
+});


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest-cli/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Issue Number: #3387

When `nest build --path <tsconfig>` is used, assets defined under `compilerOptions.assets` in `nest-cli.json` end up at a destination path that does not match where the TypeScript compiler emits the JavaScript files. With the [reporter's repro](https://github.com/zaro/nest-cli-assets-bug), JS goes to `dist/src/main.js` but assets go to `dist/static/`, so the runtime cannot find them at `__dirname/static/`.

## What is the new behavior?
`AssetsManager.copyAssets` previously always stripped the configured `sourceRoot` when computing destination paths. But TypeScript's emit uses its own *effective rootDir*, which (when `rootDir` is unset) widens to the longest common parent of the input files. With `--path` pulling in test files at the project root, that effective rootDir becomes the project root and JS files emit one level deeper than the assets do.

This PR:
- Adds `lib/compiler/helpers/get-effective-root-dir.ts` mirroring TypeScript's `getCommonSourceDirectory` heuristic.
- Computes the effective rootDir in `BuildAction.runBuild` (explicit `tsOptions.rootDir`, else common parent of input `fileNames`) and passes it to `AssetsManager.copyAssets`.
- `copyAssets` now uses the effective rootDir for the path-strip calculation when supplied; falls back to the existing `sourceRoot`-based behavior otherwise.

Manual verification against the reporter's repro: assets now land at `dist/src/static/` matching the JS at `dist/src/main.js` when `--path` is used. Without `--path`, behavior is unchanged.

7 unit tests for the new helper + 3 unit tests in `assets-manager.spec.ts` proving the strip behavior changes when `rootDir` is supplied (regression for #3387) and stays the same when not. Full local test run: 22 suites, 158 passed, 3 skipped, 0 failed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

The new `rootDir` parameter on `AssetsManager.copyAssets` is optional; when omitted, behavior is identical to before.

## Other information
The same bug exists on `v12.0.0` (identical `sourceRoot`-based stripping logic in `lib/compiler/assets-manager.ts`). Happy to open a backport PR against `v12.0.0` if desired.

Closes #3387