### PR TITLE
fix(build): align asset path stripping with effective TypeScript rootDir (#3387)

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -6,6 +6,7 @@ import { BuildCommandContext } from '../commands/index.js';
 import { AssetsManager } from '../lib/compiler/assets-manager.js';
 import { deleteOutDirIfEnabled } from '../lib/compiler/helpers/delete-out-dir.js';
 import { getBuilder } from '../lib/compiler/helpers/get-builder.js';
+import { getEffectiveRootDir } from '../lib/compiler/helpers/get-effective-root-dir.js';
 import { getRspackConfigPath } from '../lib/compiler/helpers/get-rspack-config-path.js';
 import { getTscConfigPath } from '../lib/compiler/helpers/get-tsc-config.path.js';
 import { getValueOrDefault } from '../lib/compiler/helpers/get-value-or-default.js';
@@ -82,9 +83,10 @@ export class BuildAction extends AbstractAction {
 
     const buildApp = async (appName: string | undefined) => {
       const pathToTsconfig = getTscConfigPath(configuration, options, appName);
-      const { options: tsOptions } =
+      const { options: tsOptions, fileNames: tsFileNames } =
         this.tsConfigProvider.getByConfigFilename(pathToTsconfig);
       const outDir = tsOptions.outDir || defaultOutDir;
+      const tsRootDir = getEffectiveRootDir(tsOptions.rootDir, tsFileNames);
 
       const isWebpackEnabled = getValueOrDefault<boolean>(
         configuration,
@@ -104,6 +106,7 @@ export class BuildAction extends AbstractAction {
         outDir,
         watchAssetsMode,
         onSuccess,
+        tsRootDir,
       );
       this.warnOnIgnoredLibraryAssets(configuration, appName);
 

--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -35,6 +35,7 @@ export class AssetsManager {
     outDir: string,
     watchAssetsMode: boolean,
     onSuccess?: () => void,
+    rootDir?: string,
   ) {
     const assets =
       getValueOrDefault<Asset[]>(
@@ -63,6 +64,14 @@ export class AssetsManager {
     try {
       let sourceRoot = getValueOrDefault(configuration, 'sourceRoot', appName);
       sourceRoot = join(process.cwd(), sourceRoot);
+
+      // The asset path stripping must mirror how the TypeScript compiler emits
+      // files. When the effective rootDir (either explicit or computed from
+      // input files) differs from the configured `sourceRoot` — typically the
+      // case when `--path` points at a tsconfig with a different rootDir — we
+      // use that rootDir instead so copied assets stay aligned with the
+      // emitted JavaScript output. See nestjs/nest-cli#3387.
+      const stripRoot = rootDir ? join(rootDir) : sourceRoot;
 
       const filesToCopy = assets.map<AssetEntry>((item) => {
         let includePath = typeof item === 'string' ? item : item.include!;
@@ -109,7 +118,11 @@ export class AssetsManager {
       }
 
       for (const item of allFilesToCopy) {
-        const itemSourceRoot = (item as any)._sourceRoot || sourceRoot;
+        // Library assets carry their own `_sourceRoot` so the per-library
+        // directory layout is preserved verbatim. For application assets we
+        // strip relative to the effective tsconfig rootDir (falls back to
+        // sourceRoot when no rootDir is supplied or computable).
+        const itemSourceRoot = (item as any)._sourceRoot || stripRoot;
         const option: ActionOnFile = {
           action: 'change',
           item,

--- a/lib/compiler/helpers/get-effective-root-dir.ts
+++ b/lib/compiler/helpers/get-effective-root-dir.ts
@@ -1,0 +1,59 @@
+import { dirname, isAbsolute, normalize, resolve, sep } from 'path';
+
+/**
+ * Computes the effective TypeScript rootDir for an emit, mirroring how the
+ * TypeScript compiler determines it when `rootDir` is not set in tsconfig.
+ *
+ * When `rootDir` is explicitly configured, its absolute, normalized form is
+ * returned. Otherwise the longest common parent directory of the input file
+ * list is used (the same heuristic TypeScript applies through
+ * `Program#getCommonSourceDirectory`).
+ *
+ * Returns `undefined` if no rootDir can be determined (e.g. no input files).
+ *
+ * @param explicitRootDir Value of `compilerOptions.rootDir` from tsconfig, if any.
+ * @param fileNames List of TypeScript input files (absolute paths).
+ * @param cwd Current working directory used to resolve relative paths.
+ */
+export function getEffectiveRootDir(
+  explicitRootDir: string | undefined,
+  fileNames: readonly string[] | undefined,
+  cwd: string = process.cwd(),
+): string | undefined {
+  if (explicitRootDir) {
+    return normalize(
+      isAbsolute(explicitRootDir)
+        ? explicitRootDir
+        : resolve(cwd, explicitRootDir),
+    );
+  }
+
+  if (!fileNames || fileNames.length === 0) {
+    return undefined;
+  }
+
+  const absolutePaths = fileNames.map((file) =>
+    normalize(isAbsolute(file) ? file : resolve(cwd, file)),
+  );
+
+  let commonDir = dirname(absolutePaths[0]);
+  for (let i = 1; i < absolutePaths.length; i++) {
+    commonDir = commonParentDir(commonDir, dirname(absolutePaths[i]));
+    if (!commonDir) {
+      return undefined;
+    }
+  }
+  return commonDir;
+}
+
+function commonParentDir(a: string, b: string): string {
+  const aSegments = a.split(sep);
+  const bSegments = b.split(sep);
+  const length = Math.min(aSegments.length, bSegments.length);
+
+  let i = 0;
+  while (i < length && aSegments[i] === bSegments[i]) {
+    i++;
+  }
+  return aSegments.slice(0, i).join(sep);
+}

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -2,8 +2,10 @@ import * as chokidar from 'chokidar';
 import { EventEmitter } from 'events';
 import { copyFileSync, statSync} from 'fs';
 import { sync as globSync } from 'glob';
+import { join, sep } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AssetsManager } from '../../../lib/compiler/assets-manager.js';
+import { copyPathResolve } from '../../../lib/compiler/helpers/copy-path-resolve.js';
 import { getValueOrDefault } from '../../../lib/compiler/helpers/get-value-or-default.js';
 
 vi.mock('chokidar', () => ({
@@ -512,6 +514,101 @@ describe('AssetsManager', () => {
         ignore: expectedExclude,
         dot: true,
       });
+    });
+  });
+
+  describe('rootDir-aware path stripping (#3387)', () => {
+    it('strips against the supplied tsconfig rootDir instead of sourceRoot', () => {
+      (getValueOrDefault as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce([{ include: '**/*.txt' }]) // assets
+        .mockReturnValueOnce([]) // includeLibraryAssets
+        .mockReturnValueOnce('app') // sourceRoot (legacy / wrong for this build)
+        .mockReturnValueOnce(false); // compilerOptions.watchAssets
+
+      (globSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue([
+        '/abs/asset.txt',
+      ]);
+
+      const rootDir = join(process.cwd(), 'src');
+      assetsManager.copyAssets(
+        {} as any,
+        undefined,
+        'dist',
+        false,
+        undefined,
+        rootDir,
+      );
+
+      // copyPathResolve must receive the rootDir-derived depth, not sourceRoot.
+      expect(copyPathResolve).toHaveBeenCalledWith(
+        '/abs/asset.txt',
+        'dist',
+        rootDir.split(sep).length,
+      );
+    });
+
+    it('falls back to sourceRoot when rootDir is undefined', () => {
+      (getValueOrDefault as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce([{ include: '**/*.txt' }]) // assets
+        .mockReturnValueOnce([]) // includeLibraryAssets
+        .mockReturnValueOnce('app') // sourceRoot
+        .mockReturnValueOnce(false); // compilerOptions.watchAssets
+
+      (globSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue([
+        '/abs/asset.txt',
+      ]);
+
+      assetsManager.copyAssets({} as any, undefined, 'dist', false);
+
+      const expectedSourceRoot = join(process.cwd(), 'app');
+      expect(copyPathResolve).toHaveBeenCalledWith(
+        '/abs/asset.txt',
+        'dist',
+        expectedSourceRoot.split(sep).length,
+      );
+    });
+
+    it('still uses each library asset _sourceRoot even when rootDir is set', () => {
+      const configuration = {
+        projects: {
+          'my-lib': {
+            type: 'library',
+            root: 'libs/my-lib',
+            sourceRoot: 'libs/my-lib/src',
+            compilerOptions: {
+              assets: [{ include: '**/*.graphql' }],
+            },
+          },
+        },
+      } as any;
+
+      (getValueOrDefault as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce([]) // app assets (empty)
+        .mockReturnValueOnce(['my-lib']) // includeLibraryAssets
+        .mockReturnValueOnce('apps/my-app/src') // sourceRoot (unused for the lib path)
+        .mockReturnValueOnce(false); // compilerOptions.watchAssets
+
+      (globSync as unknown as ReturnType<typeof vi.fn>).mockReturnValue([
+        '/abs/lib/file.graphql',
+      ]);
+
+      const rootDir = join(process.cwd(), 'apps/my-app/src');
+      assetsManager.copyAssets(
+        configuration,
+        'my-app',
+        'dist',
+        false,
+        undefined,
+        rootDir,
+      );
+
+      const expectedLibSourceRoot = join(process.cwd(), 'libs/my-lib/src');
+      // Library entry must keep its own _sourceRoot, not be replaced by rootDir.
+      expect(copyPathResolve).toHaveBeenCalledWith(
+        '/abs/lib/file.graphql',
+        'dist',
+        expectedLibSourceRoot.split(sep).length,
+      );
     });
   });
 });

--- a/test/lib/compiler/helpers/get-effective-root-dir.spec.ts
+++ b/test/lib/compiler/helpers/get-effective-root-dir.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { join, normalize, resolve } from 'path';
+import { getEffectiveRootDir } from '../../../../lib/compiler/helpers/get-effective-root-dir.js';
+
+describe('getEffectiveRootDir', () => {
+  const cwd = '/project';
+
+  describe('when rootDir is explicitly configured', () => {
+    it('returns the absolute, normalized path of an absolute rootDir', () => {
+      const result = getEffectiveRootDir('/project/src', undefined, cwd);
+      expect(result).toBe(normalize('/project/src'));
+    });
+
+    it('resolves a relative rootDir against cwd', () => {
+      const result = getEffectiveRootDir('./src', undefined, cwd);
+      expect(result).toBe(normalize(resolve(cwd, 'src')));
+    });
+
+    it('ignores fileNames when rootDir is set', () => {
+      const result = getEffectiveRootDir(
+        '/project/src',
+        ['/project/lib/a.ts', '/project/lib/b.ts'],
+        cwd,
+      );
+      expect(result).toBe(normalize('/project/src'));
+    });
+  });
+
+  describe('when rootDir is not set', () => {
+    it('returns undefined for empty file list', () => {
+      expect(getEffectiveRootDir(undefined, [], cwd)).toBeUndefined();
+      expect(getEffectiveRootDir(undefined, undefined, cwd)).toBeUndefined();
+    });
+
+    it('returns the file directory when only one file is given', () => {
+      const result = getEffectiveRootDir(
+        undefined,
+        ['/project/src/main.ts'],
+        cwd,
+      );
+      expect(result).toBe(normalize('/project/src'));
+    });
+
+    it('computes the longest common parent dir for multiple files', () => {
+      const result = getEffectiveRootDir(
+        undefined,
+        ['/project/src/a/foo.ts', '/project/src/b/bar.ts'],
+        cwd,
+      );
+      expect(result).toBe(normalize('/project/src'));
+    });
+
+    it('returns a deeper common dir when all files share it', () => {
+      const result = getEffectiveRootDir(
+        undefined,
+        [
+          '/project/src/feature/x.ts',
+          '/project/src/feature/y.ts',
+          '/project/src/feature/sub/z.ts',
+        ],
+        cwd,
+      );
+      expect(result).toBe(normalize('/project/src/feature'));
+    });
+
+    it('resolves relative file paths against cwd before computing common dir', () => {
+      const result = getEffectiveRootDir(
+        undefined,
+        ['src/a.ts', 'src/nested/b.ts'],
+        cwd,
+      );
+      expect(result).toBe(normalize(resolve(cwd, 'src')));
+    });
+  });
+});


### PR DESCRIPTION
## What

Re-implementation of #3403 on top of `v12.0.0`, addressing the same issue (#3387) but integrated with the new structure (vitest tests, library-assets support, debounced watch-mode restart).

## Why

When `nest build --path` (or any tsconfig override) results in an emit whose `compilerOptions.rootDir` differs from the configured `sourceRoot`, `AssetsManager` strips asset paths against `sourceRoot`. The emitted JavaScript ends up under `outDir` derived from `rootDir`, so the copied assets land one level above the build output — the bug reported in #3387.

## How

- New helper `lib/compiler/helpers/get-effective-root-dir.ts` mirrors how the TypeScript compiler determines `rootDir`: explicit `compilerOptions.rootDir` when set, otherwise the longest common parent of the input file list (matching `Program#getCommonSourceDirectory`).
- `BuildAction` now resolves the input files via `tsConfigProvider.getByConfigFilename().fileNames`, computes the effective `rootDir`, and passes it to `AssetsManager#copyAssets`.
- `AssetsManager#copyAssets` uses that `rootDir` (when supplied) as the strip root for application assets. Library assets continue to use their per-library `_sourceRoot` (introduced for `includeLibraryAssets`), so their layout is preserved unchanged.
- New parameter is appended at the end of the signature and is fully optional, so external callers compile and behave exactly as before when they don't supply it.

## Tests

- 8 new vitest cases for `getEffectiveRootDir` (explicit absolute / relative rootDir, no rootDir + 1/N files, common-dir computation, cwd-relative file paths).
- 3 new vitest cases on `AssetsManager`:
  - rootDir-aware path stripping passes the rootDir-derived depth to `copyPathResolve`,
  - falls back to `sourceRoot` when no rootDir is supplied,
  - library `_sourceRoot` is still honored even when rootDir is set.
- Full test suite locally on v12.0.0: 58 files / 524 tests pass; the only red is the pre-existing `tsconfig-paths.hook.spec.ts` flake (4 tests) unrelated to this PR.

## Closes

Closes #3387. Supersedes #3403 (will close that one in favor of this).