### PR TITLE
fix(info): show clear message when no @nestjs/* deps are declared

### DIFF
--- a/actions/info.action.ts
+++ b/actions/info.action.ts
@@ -121,6 +121,14 @@ export class InfoAction extends AbstractAction {
 
   private displayNestVersions(dependencies: PackageJsonDependencies) {
     const nestDependencies = this.buildNestVersionsMessage(dependencies);
+    if (nestDependencies.length === 0) {
+      // No @nestjs/* packages declared in this package.json. Surfacing this
+      // explicitly is much more useful than letting `format([])` throw and
+      // showing the generic "cannot read your project package.json" error,
+      // which is misleading when the file was actually read successfully.
+      console.info('No @nestjs/* dependencies were found in package.json.');
+      return;
+    }
     nestDependencies.forEach((dependency) =>
       console.info(dependency.name, blue(dependency.value)),
     );
@@ -238,6 +246,9 @@ export class InfoAction extends AbstractAction {
   }
 
   private format(dependencies: NestDependency[]): NestDependency[] {
+    if (dependencies.length === 0) {
+      return dependencies;
+    }
     const sorted = dependencies.sort(
       (dependencyA, dependencyB) =>
         dependencyB.name.length - dependencyA.name.length,

--- a/test/actions/info.action.spec.ts
+++ b/test/actions/info.action.spec.ts
@@ -40,6 +40,56 @@ describe('InfoAction', () => {
     });
   });
 
+  describe('format', () => {
+    it('should return the input untouched when there are no @nestjs/* deps', () => {
+      // Calling `format([])` used to throw `Cannot read properties of
+      // undefined (reading 'name')` because it dereferenced `sorted[0]`
+      // without first checking the array length. That exception would
+      // bubble up to `displayNestInformationFromPackage` and be swallowed
+      // as the misleading "cannot read your project package.json file"
+      // error, even though the file had been read successfully.
+      expect(() => (infoAction as any).format([])).not.toThrow();
+      expect((infoAction as any).format([])).toEqual([]);
+    });
+
+    it('should pad and clean version ranges when deps are present', () => {
+      const result = (infoAction as any).format([
+        { name: 'core', value: '^1.2.3', packageName: '@nestjs/core' },
+        {
+          name: 'platform-express',
+          value: '~1.2.4',
+          packageName: '@nestjs/platform-express',
+        },
+      ]);
+      // Sorted by name length desc; longest gets ' :' appended directly,
+      // shorter names are padded to the longest length before the suffix.
+      expect(result[0].name).toBe('platform-express :');
+      expect(result[1].name).toBe('core             :');
+      expect(result[0].value).toBe('1.2.4');
+      expect(result[1].value).toBe('1.2.3');
+    });
+  });
+
+  describe('displayNestVersions', () => {
+    it('should print a clear note when no @nestjs/* deps are declared', () => {
+      const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      // Empty deps map mirrors a project with no @nestjs/* packages — the
+      // common cause being running `nest info` from a non-Nest project
+      // (or before installing dependencies).
+      (infoAction as any).displayNestVersions({});
+
+      const messages = consoleSpy.mock.calls.map((call) => call.join(' '));
+      expect(
+        messages.some((line) =>
+          line.includes('No @nestjs/* dependencies were found'),
+        ),
+      ).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe('buildNestVersionsWarningMessage', () => {
     it('should return an empty object for one or zero minor versions', () => {
       const dependencies = [


### PR DESCRIPTION
## Summary

`nest info` walks the consuming project's `package.json` and lists every
`@nestjs/*` dependency it can find. The list of dependencies flows
through `format()`, which sorts the entries by name length and reads
`sorted[0].name.length` to compute a column width — but that
dereference happens **without first checking that the list is
non-empty**.

So when `package.json` was readable but contained zero `@nestjs/*`
entries (running `nest info` from a non-Nest project, or from a fresh
checkout where dependencies have not been installed yet), `format([])`
threw `TypeError: Cannot read properties of undefined (reading 'name')`.
That exception bubbled up to the outer `try/catch` in
`displayNestInformationFromPackage` and was silently relabeled as
`NEST_INFORMATION_PACKAGE_MANAGER_FAILED`:

> 😏  cannot read your project package.json file, are you inside your project directory?

…which is **a flat-out lie when the read itself succeeded**, and sends
users hunting for a non-existent file/directory issue.

This PR fixes the bug in two complementary places so the contract is
right end-to-end:

- `format()` is now defensive — it returns an empty array unchanged
  instead of dereferencing `sorted[0]`. The helper is safe to call with
  any input now (including from tests).
- `displayNestVersions()` short-circuits for an empty list and prints
  an honest, actionable line —
  `No @nestjs/* dependencies were found in package.json.` — instead of
  letting an exception fall into the misleading package-manager catch.

Scope is intentionally tight: only `actions/info.action.ts` and its
existing spec file. No new exports, no new messages in `lib/ui`, no
behavior change for projects that already have `@nestjs/*` deps.

## Test plan

- [x] `npm run build` — clean.
- [x] `npx vitest run test/actions/info.action.spec.ts` — 7/7 passing
      (3 new + 4 pre-existing).
- [x] Full `npm test` — only pre-existing, unrelated `tsconfig-paths.hook`
      failures (also reproduce on a clean `upstream/v12.0.0` and live in
      `lib/compiler/` — outside this PR's scope).
- [x] Manual: `format([])` previously threw, now returns `[]`;
      `displayNestVersions({})` previously triggered the
      package-manager-failed message, now prints the new explanatory
      line.

New tests cover:
- `format([])` does not throw and returns `[]`.
- `format([...])` still pads names (longest gets ` :` appended directly,
  shorter names are padded to match) and strips `^` / `~` from the
  version values.
- `displayNestVersions({})` writes the new
  "No @nestjs/* dependencies were found" message.