### PR TITLE
test(package-managers): use vitest mock type and cover readdir rejection

### DIFF
--- a/test/lib/package-managers/package-manager.factory.spec.ts
+++ b/test/lib/package-managers/package-manager.factory.spec.ts
@@ -48,17 +48,32 @@ describe('PackageManagerFactory', () => {
     });
 
     it('should return BunPackageManager when "bun.lock" file is found', async () => {
-      (fs.promises.readdir as jest.Mock).mockResolvedValue(['bun.lock']);
+      (fs.promises.readdir as Mock).mockResolvedValue(['bun.lock']);
 
-      const manager = await PackageManagerFactory.find();
-      expect(manager).toBeInstanceOf(BunPackageManager);
+      const whenPackageManager = PackageManagerFactory.find();
+      await expect(whenPackageManager).resolves.toBeInstanceOf(
+        BunPackageManager,
+      );
     });
 
     it('should return BunPackageManager when "bun.lockb" file is found', async () => {
-      (fs.promises.readdir as jest.Mock).mockResolvedValue(['bun.lockb']);
+      (fs.promises.readdir as Mock).mockResolvedValue(['bun.lockb']);
 
-      const manager = await PackageManagerFactory.find();
-      expect(manager).toBeInstanceOf(BunPackageManager);
+      const whenPackageManager = PackageManagerFactory.find();
+      await expect(whenPackageManager).resolves.toBeInstanceOf(
+        BunPackageManager,
+      );
+    });
+
+    it('should fall back to NpmPackageManager when readdir rejects', async () => {
+      (fs.promises.readdir as Mock).mockRejectedValue(
+        Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
+      );
+
+      const whenPackageManager = PackageManagerFactory.find();
+      await expect(whenPackageManager).resolves.toBeInstanceOf(
+        NpmPackageManager,
+      );
     });
 
     describe('when there are all supported lock files', () => {


### PR DESCRIPTION
## Summary

- Replaces two leftover `jest.Mock` casts in `package-manager.factory.spec.ts` with vitest's `Mock` type that the rest of the file already imports and uses. The casts came in via #3258 — the surrounding tests on v12 are vitest-based and there is no `@types/jest` in the project, so the casts only worked because vitest does not type-check by default. Once the suite is run with `vitest --typecheck` (or anyone reads them in an editor with the vitest types), the references resolve to a missing global.
- While in the file, the two re-typed cases were also adjusted to follow the same `await expect(promise).resolves.toBeInstanceOf(...)` style that the other six tests use, so the spec stays consistent.
- Adds a unit test that exercises the existing `catch` branch in `PackageManagerFactory.find` — when `fs.promises.readdir` rejects (e.g. `ENOENT` on a directory the cli was launched from but cannot read), `find` should still resolve to an `NpmPackageManager`. Verified the assertion fails if the catch is removed.

No production code changes.

## Test plan

- [x] `npm run build`
- [x] `npx vitest run test/lib/package-managers/package-manager.factory.spec.ts` — 7 passed (was 6)
- [x] `npx vitest run` — only the pre-existing `tsconfig-paths.hook.spec.ts` failures (compiler scope, unrelated) remain