### PR TITLE
test(swc): cover watch mode and spinner failure in type-checker-host

### DIFF
--- a/test/lib/compiler/swc/type-checker-host.spec.ts
+++ b/test/lib/compiler/swc/type-checker-host.spec.ts
@@ -1,15 +1,17 @@
 import * as ts from 'typescript';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TSC_NO_ERRORS_MESSAGE } from '../../../../lib/compiler/swc/constants.js';
 import { TypeCheckerHost } from '../../../../lib/compiler/swc/type-checker-host.js';
 
-vi.mock('ora', () => {
-  const spinner = {
-    start: vi.fn().mockReturnThis(),
-    succeed: vi.fn().mockReturnThis(),
-    fail: vi.fn().mockReturnThis(),
-  };
-  return { default: vi.fn(() => spinner) };
-});
+const spinnerMock = {
+  start: vi.fn().mockReturnThis(),
+  succeed: vi.fn().mockReturnThis(),
+  fail: vi.fn().mockReturnThis(),
+};
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => spinnerMock),
+}));
 
 describe('TypeCheckerHost', () => {
   let typeCheckerHost: TypeCheckerHost;
@@ -17,6 +19,23 @@ describe('TypeCheckerHost', () => {
   beforeEach(() => {
     typeCheckerHost = new TypeCheckerHost();
     vi.clearAllMocks();
+    spinnerMock.start.mockClear();
+    spinnerMock.succeed.mockClear();
+    spinnerMock.fail.mockClear();
+  });
+
+  describe('run', () => {
+    it('should throw when tsconfigPath is undefined', () => {
+      expect(() => typeCheckerHost.run(undefined, {})).toThrow(
+        '"tsconfigPath" is required when "tsProgramRef" is not provided.',
+      );
+    });
+
+    it('should throw when tsconfigPath is an empty string', () => {
+      expect(() => typeCheckerHost.run('', {})).toThrow(
+        '"tsconfigPath" is required when "tsProgramRef" is not provided.',
+      );
+    });
   });
 
   describe('runOnce (via run)', () => {
@@ -172,6 +191,227 @@ describe('TypeCheckerHost', () => {
           onTypeCheck: vi.fn(),
         });
       }).toThrow('Found 3 type error(s) during compilation.');
+    });
+
+    it('should call spinner.fail when type errors are thrown and not call spinner.succeed', () => {
+      const mockDiagnostic: ts.Diagnostic = {
+        file: undefined,
+        start: undefined,
+        length: undefined,
+        messageText: 'Type error mock',
+        category: ts.DiagnosticCategory.Error,
+        code: 2322,
+      };
+
+      setupMocks([mockDiagnostic]);
+
+      try {
+        typeCheckerHost.run('tsconfig.json', {
+          watch: false,
+          onTypeCheck: vi.fn(),
+        });
+      } catch {
+        // Expected to throw
+      }
+
+      expect(spinnerMock.start).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.fail).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.succeed).not.toHaveBeenCalled();
+    });
+
+    it('should call spinner.succeed and not spinner.fail when no type errors are found', () => {
+      setupMocks([]);
+
+      typeCheckerHost.run('tsconfig.json', {
+        watch: false,
+        onTypeCheck: vi.fn(),
+      });
+
+      expect(spinnerMock.start).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.succeed).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.fail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('runInWatchMode (via run)', () => {
+    function setupWatchMocks() {
+      const mockProgram = {
+        getSourceFiles: vi.fn().mockReturnValue([]),
+        getCompilerOptions: vi.fn().mockReturnValue({}),
+      } as unknown as ts.Program;
+
+      const mockBuilderProgram = {
+        getProgram: vi.fn().mockReturnValue({
+          getProgram: vi.fn().mockReturnValue(mockProgram),
+        }),
+      };
+
+      let capturedReportWatchStatusCallback:
+        | ((diagnostic: ts.Diagnostic) => void)
+        | undefined;
+
+      const mockTsConfigProvider = {
+        getByConfigFilename: vi.fn().mockReturnValue({
+          options: { strict: true },
+          fileNames: [],
+          projectReferences: undefined,
+        }),
+      };
+
+      const createWatchCompilerHostMock = vi.fn(
+        (
+          _configPath: string,
+          options: ts.CompilerOptions,
+          _sys: any,
+          _create: any,
+          _reportDiagnostic: any,
+          reportWatchStatusCallback: ts.WatchStatusReporter,
+        ) => {
+          capturedReportWatchStatusCallback = reportWatchStatusCallback;
+          return { compilerOptions: options };
+        },
+      );
+
+      const mockTsBinary = {
+        ...ts,
+        sys: ts.sys,
+        createDiagnosticReporter: vi.fn().mockReturnValue(vi.fn()),
+        createWatchCompilerHost: createWatchCompilerHostMock,
+        createWatchProgram: vi.fn().mockReturnValue(mockBuilderProgram),
+      };
+
+      const mockTypescriptLoader = {
+        load: vi.fn().mockReturnValue(mockTsBinary),
+      };
+
+      Object.defineProperty(typeCheckerHost, 'tsConfigProvider', {
+        value: mockTsConfigProvider,
+        writable: true,
+      });
+      Object.defineProperty(typeCheckerHost, 'typescriptLoader', {
+        value: mockTypescriptLoader,
+        writable: true,
+      });
+
+      return {
+        mockProgram,
+        mockTsBinary,
+        createWatchCompilerHostMock,
+        getReportWatchStatusCallback: () => capturedReportWatchStatusCallback!,
+      };
+    }
+
+    it('should override compiler options with noEmit and preserveWatchOutput', () => {
+      const { createWatchCompilerHostMock } = setupWatchMocks();
+
+      typeCheckerHost.run('tsconfig.json', {
+        watch: true,
+        onTypeCheck: vi.fn(),
+      });
+
+      expect(createWatchCompilerHostMock).toHaveBeenCalledTimes(1);
+      const optionsArg = createWatchCompilerHostMock.mock.calls[0][1];
+      expect(optionsArg).toMatchObject({
+        strict: true,
+        preserveWatchOutput: true,
+        noEmit: true,
+      });
+    });
+
+    it('should call onTypeCheck with the program when "no errors" message is reported', () => {
+      const { mockProgram, getReportWatchStatusCallback } = setupWatchMocks();
+
+      const onTypeCheck = vi.fn();
+      typeCheckerHost.run('tsconfig.json', {
+        watch: true,
+        onTypeCheck,
+      });
+
+      // Simulate watcher reporting a successful type check
+      getReportWatchStatusCallback()({
+        file: undefined,
+        start: undefined,
+        length: undefined,
+        messageText: TSC_NO_ERRORS_MESSAGE,
+        category: ts.DiagnosticCategory.Message,
+        code: 0,
+      });
+
+      expect(onTypeCheck).toHaveBeenCalledTimes(1);
+      expect(onTypeCheck).toHaveBeenCalledWith(mockProgram);
+    });
+
+    it('should log to console.error when "Found N errors" message is reported', () => {
+      const { getReportWatchStatusCallback } = setupWatchMocks();
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const onTypeCheck = vi.fn();
+      typeCheckerHost.run('tsconfig.json', {
+        watch: true,
+        onTypeCheck,
+      });
+
+      getReportWatchStatusCallback()({
+        file: undefined,
+        start: undefined,
+        length: undefined,
+        messageText: 'Found 2 errors. Watching for file changes.',
+        category: ts.DiagnosticCategory.Message,
+        code: 0,
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy.mock.calls[0][1]).toContain('Found 2 errors');
+      expect(onTypeCheck).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not log or call onTypeCheck for unrelated watch status messages', () => {
+      const { getReportWatchStatusCallback } = setupWatchMocks();
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const onTypeCheck = vi.fn();
+      typeCheckerHost.run('tsconfig.json', {
+        watch: true,
+        onTypeCheck,
+      });
+
+      getReportWatchStatusCallback()({
+        file: undefined,
+        start: undefined,
+        length: undefined,
+        messageText: 'Starting compilation in watch mode...',
+        category: ts.DiagnosticCategory.Message,
+        code: 0,
+      });
+
+      expect(onTypeCheck).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should call onProgramInit on the next tick with the program', async () => {
+      const { mockProgram } = setupWatchMocks();
+
+      const onProgramInit = vi.fn();
+      typeCheckerHost.run('tsconfig.json', {
+        watch: true,
+        onProgramInit,
+      });
+
+      // Not invoked synchronously — scheduled via process.nextTick
+      expect(onProgramInit).not.toHaveBeenCalled();
+
+      await new Promise<void>((resolve) => process.nextTick(resolve));
+
+      expect(onProgramInit).toHaveBeenCalledTimes(1);
+      expect(onProgramInit).toHaveBeenCalledWith(mockProgram);
     });
   });
 });


### PR DESCRIPTION
## Summary

Expands `TypeCheckerHost` test coverage on top of the existing `runOnce` diagnostic specs. The watch path, the spinner failure transition introduced in v12, the early-input validation, and the compiler-option overrides had no regression protection — this PR closes those gaps.

New behaviours covered:
- Early throw when `tsconfigPath` is `undefined` or empty.
- `spinner.fail()` is invoked when `runOnce` throws and `spinner.succeed()` is not (this branch was added in v12 to replace the prior `process.exit` and currently has no test).
- `runInWatchMode` wires the TypeScript compiler options with `noEmit: true` and `preserveWatchOutput: true` so the type checker never emits files into the SWC output directory.
- The watch-status callback dispatches correctly: `onTypeCheck(program)` on the `Found 0 errors. Watching...` message, `console.error` on `Found N errors` diagnostics, and silent ignore for unrelated status messages (e.g. `Starting compilation in watch mode...`).
- `onProgramInit` is scheduled on `process.nextTick` with the underlying `ts.Program` ref.

Net change: +9 `vitest` tests, all in `test/lib/compiler/swc/type-checker-host.spec.ts`. No production code touched.

## Test plan
- [x] `npm run build`
- [x] `npx vitest run test/lib/compiler/swc/` — 43 tests pass (3 files)
- [x] `npx vitest run test/lib/compiler/swc/type-checker-host.spec.ts` — 13 tests pass (4 prior + 9 new)
- [x] All new tests assert user-visible behaviour (callbacks fired/not fired, options shape, console output, spinner state) — no implementation-detail assertions