### PR TITLE
fix(configuration): surface clear error for invalid nest-cli.json

### DIFF
--- a/lib/configuration/nest-configuration.loader.ts
+++ b/lib/configuration/nest-configuration.loader.ts
@@ -35,7 +35,16 @@ export class NestConfigurationLoader implements ConfigurationLoader {
         process.exit(1);
       }
 
-      const fileConfig = JSON.parse(contentOrError);
+      const configFilename = name ?? 'nest-cli.json';
+      let fileConfig: Configuration;
+      try {
+        fileConfig = JSON.parse(contentOrError);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `Could not parse Nest CLI configuration file "${configFilename}". Please, ensure that the file contains valid JSON. Reason: ${reason}`,
+        );
+      }
       loadedConfig = {
         ...defaultConfiguration,
         ...fileConfig,


### PR DESCRIPTION
## Summary

`NestConfigurationLoader.load()` calls `JSON.parse(contentOrError)` directly. When `nest-cli.json` (or `.nest-cli.json`, or any explicitly-named config file passed to `load(name)`) contains malformed JSON — for example a stray trailing comma or a JSON5-style comment — the raw `SyntaxError` from V8 bubbles up to the user with no indication of which file was being parsed:

```
SyntaxError: Expected property name or '}' in JSON at position 2 (line 1 column 3)
```

This change wraps the parse call so the thrown error names the config file and includes the parser reason:

```
Could not parse Nest CLI configuration file "nest-cli.json". Please, ensure that the file contains valid JSON. Reason: Expected property name or '}' in JSON at position 2 (line 1 column 3)
```

This matches the pattern introduced for `TsConfigProvider` in #3332 (clear, file-named errors for parse failures of project configuration).

## What kind of change does this PR introduce?

Bug fix — improved error message for a real failure mode users hit when their `nest-cli.json` has a typo. No behavior change on the happy path; the existing `Configuration` typing on the parsed result is preserved.

## Test plan

- [x] `npm run build` passes (no new TS errors)
- [x] Existing `test/lib/configuration/nest-configuration.loader.spec.ts` (6 tests) passes unchanged
- [x] Existing `test/lib/utils/load-configuration.spec.ts` (the consumer) passes unchanged
- [x] Manual check: feeding the loader a fake reader that returns `'{ invalid json,, }'` now throws the formatted message above (verified in a one-off Node script)
- [x] No changes to public API (`ConfigurationLoader.load` signature unchanged); error type is still a plain `Error`