### PR TITLE
test(file-system-reader): cover permission-error and fallback paths

### DIFF
--- a/test/lib/readers/file-system.reader.spec.ts
+++ b/test/lib/readers/file-system.reader.spec.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'fs';
+import * as path from 'path';
 import { FileSystemReader, Reader } from '../../../lib/readers/index.js';
+import { ReaderFileLackPermissionsError } from '../../../lib/readers/reader.js';
 
 vi.mock('fs', () => ({
   readdirSync: vi.fn().mockReturnValue([]),
@@ -10,17 +12,47 @@ vi.mock('fs', () => ({
 const dir: string = process.cwd();
 const reader: Reader = new FileSystemReader(dir);
 
+interface FsCodeError extends Error {
+  code: string;
+  path?: string;
+}
+
+function createFsError(code: string, filePath?: string): FsCodeError {
+  const err = new Error(code) as FsCodeError;
+  err.code = code;
+  if (filePath !== undefined) {
+    err.path = filePath;
+  }
+  return err;
+}
+
 describe('File System Reader', () => {
-  afterAll(() => {
-    vi.clearAllMocks();
+  beforeEach(() => {
+    vi.mocked(fs.readdirSync).mockReset().mockReturnValue([]);
+    vi.mocked(fs.readFileSync).mockReset().mockReturnValue('content');
   });
+
   it('should use fs.readdirSync when list (for performance reasons)', async () => {
     reader.list();
     expect(fs.readdirSync).toHaveBeenCalled();
   });
+
+  it('should pass the configured directory to fs.readdirSync', () => {
+    reader.list();
+    expect(fs.readdirSync).toHaveBeenCalledWith(dir);
+  });
+
   it('should use fs.readFileSync when read (for performance reasons)', async () => {
     reader.read('filename');
     expect(fs.readFileSync).toHaveBeenCalled();
+  });
+
+  it('should join directory with filename when reading', () => {
+    reader.read('nest-cli.json');
+    expect(fs.readFileSync).toHaveBeenCalledWith(
+      path.join(dir, 'nest-cli.json'),
+      'utf8',
+    );
   });
 
   describe('readAnyOf tests', () => {
@@ -35,5 +67,154 @@ describe('File System Reader', () => {
       const content = reader.readAnyOf([]);
       expect(content).toEqual(undefined);
     });
+
+    it('should return content of the first file that exists', () => {
+      vi.mocked(fs.readFileSync).mockReturnValueOnce('first-file-content');
+
+      const content = reader.readAnyOf(['nest-cli.json', '.nest-cli.json']);
+
+      expect(content).toBe('first-file-content');
+      expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall through to next file when ENOENT is thrown', () => {
+      vi.mocked(fs.readFileSync)
+        .mockImplementationOnce(() => {
+          throw createFsError('ENOENT');
+        })
+        .mockReturnValueOnce('second-file-content');
+
+      const content = reader.readAnyOf(['nest-cli.json', '.nest-cli.json']);
+
+      expect(content).toBe('second-file-content');
+      expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return undefined when all files throw non-permission errors', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw createFsError('ENOENT');
+      });
+
+      const content = reader.readAnyOf(['missing1', 'missing2']);
+
+      expect(content).toBeUndefined();
+    });
+
+    it('should return ReaderFileLackPermissionsError when EACCES is the only failure', () => {
+      const blockedPath = path.join(dir, 'nest-cli.json');
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw createFsError('EACCES', blockedPath);
+      });
+
+      const content = reader.readAnyOf(['nest-cli.json']);
+
+      expect(content).toBeInstanceOf(ReaderFileLackPermissionsError);
+      const err = content as ReaderFileLackPermissionsError;
+      expect(err.filePath).toBe(blockedPath);
+      expect(err.fsErrorCode).toBe('EACCES');
+    });
+
+    it('should return ReaderFileLackPermissionsError when EPERM is the only failure', () => {
+      const blockedPath = path.join(dir, '.nest-cli.json');
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw createFsError('EPERM', blockedPath);
+      });
+
+      const content = reader.readAnyOf(['.nest-cli.json']);
+
+      expect(content).toBeInstanceOf(ReaderFileLackPermissionsError);
+      const err = content as ReaderFileLackPermissionsError;
+      expect(err.filePath).toBe(blockedPath);
+      expect(err.fsErrorCode).toBe('EPERM');
+    });
+
+    it('should preserve the first permission-error path even if a later file is missing', () => {
+      const blockedPath = path.join(dir, 'nest-cli.json');
+      vi.mocked(fs.readFileSync)
+        .mockImplementationOnce(() => {
+          throw createFsError('EACCES', blockedPath);
+        })
+        .mockImplementationOnce(() => {
+          throw createFsError('ENOENT');
+        });
+
+      const content = reader.readAnyOf(['nest-cli.json', '.nest-cli.json']);
+
+      expect(content).toBeInstanceOf(ReaderFileLackPermissionsError);
+      const err = content as ReaderFileLackPermissionsError;
+      // The error must point at the EACCES file we encountered first,
+      // not at the ENOENT file processed last.
+      expect(err.filePath).toBe(blockedPath);
+    });
+
+    it('should not record subsequent permission errors after the first one', () => {
+      const firstBlocked = path.join(dir, 'nest-cli.json');
+      const secondBlocked = path.join(dir, '.nest-cli.json');
+      vi.mocked(fs.readFileSync)
+        .mockImplementationOnce(() => {
+          throw createFsError('EACCES', firstBlocked);
+        })
+        .mockImplementationOnce(() => {
+          throw createFsError('EPERM', secondBlocked);
+        });
+
+      const content = reader.readAnyOf(['nest-cli.json', '.nest-cli.json']);
+
+      expect(content).toBeInstanceOf(ReaderFileLackPermissionsError);
+      const err = content as ReaderFileLackPermissionsError;
+      expect(err.filePath).toBe(firstBlocked);
+      // Code is taken from the *last* error in the loop, but path must
+      // remain the *first* permission-blocked file.
+      expect(err.fsErrorCode).toBe('EPERM');
+    });
+
+    it('should return content of a later file even if an earlier one was permission-blocked', () => {
+      const blockedPath = path.join(dir, 'nest-cli.json');
+      vi.mocked(fs.readFileSync)
+        .mockImplementationOnce(() => {
+          throw createFsError('EACCES', blockedPath);
+        })
+        .mockReturnValueOnce('fallback-content');
+
+      const content = reader.readAnyOf(['nest-cli.json', '.nest-cli.json']);
+
+      expect(content).toBe('fallback-content');
+    });
+
+    it('should ignore errors that do not have a string code property', () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        // Throw a plain Error with no `code` field at all.
+        throw new Error('weird');
+      });
+
+      const content = reader.readAnyOf(['nest-cli.json']);
+
+      // No permission marker recorded => undefined, never an error instance.
+      expect(content).toBeUndefined();
+    });
+  });
+});
+
+describe('ReaderFileLackPermissionsError', () => {
+  it('should be an Error instance', () => {
+    const err = new ReaderFileLackPermissionsError('/tmp/x', 'EACCES');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ReaderFileLackPermissionsError);
+  });
+
+  it('should expose filePath and fsErrorCode on the instance', () => {
+    const err = new ReaderFileLackPermissionsError('/tmp/x', 'EPERM');
+    expect(err.filePath).toBe('/tmp/x');
+    expect(err.fsErrorCode).toBe('EPERM');
+  });
+
+  it('should embed the file path in the human-readable message', () => {
+    const err = new ReaderFileLackPermissionsError(
+      '/var/log/secret.json',
+      'EACCES',
+    );
+    expect(err.message).toBe(
+      'File /var/log/secret.json lacks read permissions!',
+    );
   });
 });


### PR DESCRIPTION
## Summary

The existing `file-system.reader.spec.ts` only exercises the happy path of `FileSystemReader` and the empty-input branch of `readAnyOf`, leaving the EACCES/EPERM permission-error flow and the fall-through-on-error logic uncovered. This PR adds targeted tests for those branches; **no production code is touched**.

New coverage:

- `list()` and `read()` pass the configured directory through to `fs` (joined with the filename for `read`).
- `readAnyOf` falls through to a later file after `ENOENT` and returns its content.
- `readAnyOf` returns `ReaderFileLackPermissionsError` with the correct `filePath` / `fsErrorCode` for the EACCES and EPERM branches.
- `readAnyOf` keeps `filePath` pinned to the **first** permission-blocked file even when later iterations throw `ENOENT` or another `EPERM` (this is a subtle invariant of the loop's `firstFilePathFoundButWithInsufficientPermissions` guard).
- A successful later `read` still wins over an earlier permission error (no premature `ReaderFileLackPermissionsError` leak).
- Errors without a `string` `code` property are ignored cleanly and yield `undefined`.
- The `ReaderFileLackPermissionsError` class itself: `instanceof Error`, exposed `filePath` / `fsErrorCode`, and the human-readable message.

These are the branches inside `lib/readers/file-system.reader.ts` that previously had zero coverage; pinning them down protects against regressions in the EACCES surfacing path that nest-cli relies on when reading `nest-cli.json` / `.nest-cli.json` from a workspace.

## Test plan

- [x] `npx vitest run test/lib/readers/file-system.reader.spec.ts` — 18 / 18 pass (was 4)
- [x] `npx prettier --check test/lib/readers/file-system.reader.spec.ts` — clean
- [x] Branched off latest `upstream/v12.0.0`, full vitest run shows the 4 pre-existing `tsconfig-paths.hook.spec.ts` Windows failures unchanged and unrelated to this PR