### PR TITLE
fix(build): validate --parallel value and guard against infinite loop

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -188,8 +188,15 @@ export class BuildAction extends AbstractAction {
 
     const parallel = options.parallel;
     if (parallel && appNames.length > 1) {
-      const concurrency =
+      // Coerce to a positive integer; fall back to unlimited (= appNames.length)
+      // for any non-positive or non-finite value to guard against an infinite
+      // loop when `i += concurrency` would never advance.
+      const requested =
         typeof parallel === 'number' ? parallel : appNames.length;
+      const concurrency =
+        Number.isFinite(requested) && requested >= 1
+          ? Math.floor(requested)
+          : appNames.length;
       for (let i = 0; i < appNames.length; i += concurrency) {
         const chunk = appNames.slice(i, i + concurrency);
         await Promise.all(chunk.map((appName) => buildApp(appName)));

--- a/commands/build.command.ts
+++ b/commands/build.command.ts
@@ -61,6 +61,22 @@ export class BuildCommand extends AbstractCommand {
           return;
         }
 
+        let parallel: number | boolean | undefined;
+        if (options.parallel === true || options.parallel === undefined) {
+          // `--parallel` with no value means unlimited; absent means sequential.
+          parallel = options.parallel;
+        } else {
+          const parsed = parseInt(options.parallel, 10);
+          if (!Number.isFinite(parsed) || parsed < 1) {
+            console.error(
+              ERROR_PREFIX +
+                ` Invalid --parallel value: "${options.parallel}". Expected a positive integer (e.g. --parallel 4) or no value for unlimited concurrency.`,
+            );
+            return;
+          }
+          parallel = parsed;
+        }
+
         const context: BuildCommandContext = {
           apps: apps.length > 0 ? apps : [],
           config: options.config,
@@ -79,11 +95,7 @@ export class BuildCommand extends AbstractCommand {
             !!options.watch &&
             !isWebpackEnabled,
           all: !!options.all,
-          parallel: options.parallel === true
-            ? true
-            : options.parallel
-              ? parseInt(options.parallel, 10)
-              : undefined,
+          parallel,
         };
 
         await this.action.handle(context);

--- a/test/actions/build.action.spec.ts
+++ b/test/actions/build.action.spec.ts
@@ -162,4 +162,64 @@ describe('BuildAction - Rspack', () => {
       expect(RspackCompiler).not.toHaveBeenCalled();
     });
   });
+
+  describe('runBuild parallel concurrency', () => {
+    // Each test in this suite uses three apps so the parallel branch is taken.
+    // We replace `runRspack` with a fast tracker so we can assert how many
+    // apps were built — and, critically, that the loop terminates instead of
+    // spinning forever on a non-positive concurrency value.
+    const buildAllThreeApps = async (parallel: unknown) => {
+      const builtApps: Array<string | undefined> = [];
+      (buildAction as any).runRspack = vi.fn(
+        async (_config: unknown, appName: string | undefined) => {
+          builtApps.push(appName);
+        },
+      );
+
+      await buildAction.runBuild(
+        ['a', 'b', 'c'],
+        { builder: 'rspack', parallel },
+        false,
+        false,
+      );
+
+      return builtApps;
+    };
+
+    it('should build sequentially when parallel is 0 (falsy)', async () => {
+      // 0 is falsy so the action takes the sequential branch — every app
+      // should still build exactly once.
+      const built = await buildAllThreeApps(0);
+
+      expect(built.sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should not loop forever when parallel is a negative number', async () => {
+      // Without the guard, `concurrency = -1` makes `i += -1` decrement
+      // forever. Vitest will hit the test timeout if the regression returns.
+      const built = await buildAllThreeApps(-1);
+
+      expect(built.sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should not loop forever when parallel is NaN', async () => {
+      // Without the guard, `i += NaN` keeps `i` at NaN and the loop never
+      // exits.
+      const built = await buildAllThreeApps(Number.NaN);
+
+      expect(built.sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should respect a positive parallel concurrency and build every app once', async () => {
+      const built = await buildAllThreeApps(2);
+
+      expect(built.sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should treat `parallel: true` as unlimited and build every app once', async () => {
+      const built = await buildAllThreeApps(true);
+
+      expect(built.sort()).toEqual(['a', 'b', 'c']);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`nest build --all --parallel <n>` accepted any value `parseInt` could partially parse, including `0`, negative numbers, and non-numeric strings:

- `nest build --all --parallel -1` → `parseInt('-1', 10) === -1`, then `i += -1` makes `i` count down forever, slicing empty arrays.
- `nest build --all --parallel abc` → `parseInt('abc', 10) === NaN`, treated as `typeof number`, slips into the parallel branch with a `NaN` concurrency.
- `nest build --all --parallel 0` → falsy, silently fell into the sequential branch with no feedback that the value was ignored.

This PR:
1. Validates the user-supplied value in `commands/build.command.ts` and prints a clear error referencing the bad input (matching the existing `--builder` validation pattern):
   ```
   [ERROR] Invalid --parallel value: "-1". Expected a positive integer (e.g. --parallel 4) or no value for unlimited concurrency.
   ```
2. Hardens `actions/build.action.ts` so any non-positive or non-finite value coming through programmatic callers falls back to unlimited concurrency (`= appNames.length`) instead of looping forever.
3. Adds five unit tests in `test/actions/build.action.spec.ts` covering `-1`, `NaN`, `true`, a positive integer, and `0` (sequential).

Scope is limited to the existing `--parallel` surface introduced in #3371 — no behavior change for valid inputs.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run test/actions/build.action.spec.ts` — 9/9 pass (was 4)
- [x] `npx vitest run test/actions/` — 48/48 pass
- [x] Verified the new tests fail without the action-side guard (regression coverage)
- [x] Verified the command-side validation rejects `--parallel -1`, `--parallel 0`, `--parallel abc` with a readable error and exits without invoking the builder