### PR TITLE
fix(compiler): preserve original error and extract package name correctly when peer deps fail to load

### DIFF
--- a/lib/compiler/defaults/rspack-defaults.ts
+++ b/lib/compiler/defaults/rspack-defaults.ts
@@ -18,12 +18,23 @@ function loadRspackDeps() {
       };
     return { nodeExternals: externals, TsconfigPathsPlugin, rspack };
   } catch (e: any) {
+    if (e?.code !== 'MODULE_NOT_FOUND' && e?.code !== 'ERR_MODULE_NOT_FOUND') {
+      // Only the "package missing" branch is wrapped with install advice.
+      // Surfacing unrelated errors as "package not found" would mislead
+      // users into reinstalling perfectly valid dependencies.
+      throw e;
+    }
+    // Use a non-greedy match so error messages that contain multiple
+    // quoted paths (e.g. ESM "Cannot find package 'foo' imported from
+    // '/abs/path.mjs'") still extract the package name rather than the
+    // importing file path.
     const pkg =
-      e?.message?.match?.(/Cannot find.*'([^']+)'/)?.[1] ??
+      e?.message?.match?.(/Cannot find.*?'([^']+)'/)?.[1] ??
       'webpack-node-externals';
     throw new Error(
       `The "${pkg}" package is required when using the rspack compiler but could not be found. ` +
         `Please install it:\n\n  npm install --save-dev @rspack/core webpack-node-externals tsconfig-paths-webpack-plugin\n`,
+      { cause: e },
     );
   }
 }

--- a/lib/compiler/defaults/webpack-defaults.ts
+++ b/lib/compiler/defaults/webpack-defaults.ts
@@ -19,10 +19,22 @@ function loadWebpackDeps() {
       };
     return { webpack: wp, nodeExternals: externals, TsconfigPathsPlugin };
   } catch (e: any) {
-    const pkg = e?.message?.match?.(/Cannot find.*'([^']+)'/)?.[1] ?? 'webpack';
+    if (e?.code !== 'MODULE_NOT_FOUND' && e?.code !== 'ERR_MODULE_NOT_FOUND') {
+      // Only the "package missing" branch is wrapped with install advice.
+      // Surfacing unrelated errors as "package not found" would mislead
+      // users into reinstalling perfectly valid dependencies.
+      throw e;
+    }
+    // Use a non-greedy match so error messages that contain multiple
+    // quoted paths (e.g. ESM "Cannot find package 'foo' imported from
+    // '/abs/path.mjs'") still extract the package name rather than the
+    // importing file path.
+    const pkg =
+      e?.message?.match?.(/Cannot find.*?'([^']+)'/)?.[1] ?? 'webpack';
     throw new Error(
       `The "${pkg}" package is required when using the webpack compiler but could not be found. ` +
         `Please install it:\n\n  npm install --save-dev webpack webpack-node-externals tsconfig-paths-webpack-plugin ts-loader fork-ts-checker-webpack-plugin\n`,
+      { cause: e },
     );
   }
 }

--- a/test/lib/compiler/defaults/rspack-defaults.spec.ts
+++ b/test/lib/compiler/defaults/rspack-defaults.spec.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { requireFns } = vi.hoisted(() => {
+  return {
+    requireFns: {
+      '@rspack/core': vi.fn(),
+      'webpack-node-externals': vi.fn(),
+      'tsconfig-paths-webpack-plugin': vi.fn(),
+      'fork-ts-checker-webpack-plugin': vi.fn(),
+    } as Record<string, ReturnType<typeof vi.fn>>,
+  };
+});
+
+vi.mock('module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('module')>();
+  return {
+    ...actual,
+    createRequire: (url: string | URL) => {
+      const realReq = actual.createRequire(url);
+      const mockedReq: any = (id: string) => {
+        if (Object.prototype.hasOwnProperty.call(requireFns, id)) {
+          return requireFns[id](id);
+        }
+        return realReq(id);
+      };
+      mockedReq.resolve = realReq.resolve.bind(realReq);
+      mockedReq.resolve.paths = realReq.resolve.paths?.bind(realReq.resolve);
+      return mockedReq;
+    },
+  };
+});
+
+import { rspackDefaultsFactory } from '../../../../lib/compiler/defaults/rspack-defaults.js';
+import { MultiNestCompilerPlugins } from '../../../../lib/compiler/plugins/plugins-loader.js';
+
+const emptyPlugins: MultiNestCompilerPlugins = {
+  beforeHooks: [],
+  afterHooks: [],
+  afterDeclarationsHooks: [],
+};
+
+// vi.fn() can be used with `new`; arrow functions cannot. The factory
+// invokes `new IgnorePlugin(...)` and `new TsconfigPathsPlugin(...)`,
+// so the mocks must be plain `vi.fn()` (which acts as a constructor).
+const makeMockRspack = () => ({
+  IgnorePlugin: vi.fn(),
+});
+
+const makeMockExternals = () => vi.fn(() => () => undefined);
+
+const makeMockTsconfigPathsPlugin = () => ({
+  TsconfigPathsPlugin: vi.fn(),
+});
+
+const moduleNotFoundError = (pkg: string, message?: string) => {
+  const err = new Error(message ?? `Cannot find module '${pkg}'`) as Error & {
+    code: string;
+  };
+  err.code = 'MODULE_NOT_FOUND';
+  return err;
+};
+
+describe('rspackDefaultsFactory', () => {
+  beforeEach(() => {
+    requireFns['@rspack/core'].mockReset();
+    requireFns['webpack-node-externals'].mockReset();
+    requireFns['tsconfig-paths-webpack-plugin'].mockReset();
+    requireFns['fork-ts-checker-webpack-plugin'].mockReset();
+
+    requireFns['@rspack/core'].mockReturnValue(makeMockRspack());
+    requireFns['webpack-node-externals'].mockReturnValue(makeMockExternals());
+    requireFns['tsconfig-paths-webpack-plugin'].mockReturnValue(
+      makeMockTsconfigPathsPlugin(),
+    );
+    requireFns['fork-ts-checker-webpack-plugin'].mockReturnValue(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('should produce a configuration object with expected entry filename', () => {
+      const config = rspackDefaultsFactory(
+        '/abs/src',
+        'src',
+        'main',
+        false,
+        'tsconfig.build.json',
+        emptyPlugins,
+      );
+
+      expect(config.entry).toContain('main.ts');
+      expect(config.target).toBe('node');
+      expect(config.mode).toBe('none');
+    });
+
+    it('should normalize output filename to forward slashes', () => {
+      const config = rspackDefaultsFactory(
+        '/abs/src',
+        'apps\\my-app\\src',
+        'main',
+        false,
+        'tsconfig.build.json',
+        emptyPlugins,
+      );
+
+      expect(config.output.filename).not.toMatch(/\\/);
+      expect(config.output.filename).toContain('/');
+    });
+
+    it('should configure ESM output when isEsm is true', () => {
+      const config = rspackDefaultsFactory(
+        '/abs/src',
+        'src',
+        'main',
+        false,
+        'tsconfig.json',
+        emptyPlugins,
+        true,
+      );
+
+      expect(config.experiments?.outputModule).toBe(true);
+      expect(config.output.module).toBe(true);
+      expect(config.externalsPresets).toEqual({ node: false });
+    });
+
+    it('should configure CJS output when isEsm is false', () => {
+      const config = rspackDefaultsFactory(
+        '/abs/src',
+        'src',
+        'main',
+        false,
+        'tsconfig.json',
+        emptyPlugins,
+        false,
+      );
+
+      expect(config.experiments).toBeUndefined();
+      expect(config.output.module).toBeUndefined();
+      expect(config.externalsPresets).toEqual({ node: true });
+    });
+  });
+
+  describe('error handling for missing peer dependencies', () => {
+    it('should report the missing package name when @rspack/core is not installed', () => {
+      requireFns['@rspack/core'].mockImplementation(() => {
+        throw moduleNotFoundError('@rspack/core');
+      });
+
+      expect(() =>
+        rspackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        ),
+      ).toThrow(/"@rspack\/core" package is required/);
+    });
+
+    it('should report the missing package name when webpack-node-externals is not installed', () => {
+      requireFns['webpack-node-externals'].mockImplementation(() => {
+        throw moduleNotFoundError('webpack-node-externals');
+      });
+
+      expect(() =>
+        rspackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        ),
+      ).toThrow(/"webpack-node-externals" package is required/);
+    });
+
+    it('should report the missing package name from an ESM-style "Cannot find package" error', () => {
+      const err = new Error(
+        "Cannot find package '@rspack/core' imported from '/abs/path/to/file.mjs'",
+      ) as Error & { code: string };
+      err.code = 'ERR_MODULE_NOT_FOUND';
+      requireFns['@rspack/core'].mockImplementation(() => {
+        throw err;
+      });
+
+      expect(() =>
+        rspackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        ),
+      ).toThrow(/"@rspack\/core" package is required/);
+    });
+
+    it('should re-throw unrelated errors without wrapping them', () => {
+      const original = new TypeError('rspack internal type error');
+      requireFns['@rspack/core'].mockImplementation(() => {
+        throw original;
+      });
+
+      expect(() =>
+        rspackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        ),
+      ).toThrow(original);
+    });
+
+    it('should attach the original module-not-found error as cause', () => {
+      const original = moduleNotFoundError('@rspack/core');
+      requireFns['@rspack/core'].mockImplementation(() => {
+        throw original;
+      });
+
+      try {
+        rspackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        );
+        throw new Error('expected rspackDefaultsFactory to throw');
+      } catch (e) {
+        expect((e as Error).cause).toBe(original);
+      }
+    });
+  });
+});

--- a/test/lib/compiler/defaults/webpack-defaults.spec.ts
+++ b/test/lib/compiler/defaults/webpack-defaults.spec.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted module mocks. Each test resets the implementation of these
+// functions to simulate either a successful require (mock module returned)
+// or a failing require (error thrown) for the corresponding peer dep.
+const { requireFns } = vi.hoisted(() => {
+  return {
+    requireFns: {
+      webpack: vi.fn(),
+      'webpack-node-externals': vi.fn(),
+      'tsconfig-paths-webpack-plugin': vi.fn(),
+      'fork-ts-checker-webpack-plugin': vi.fn(),
+    } as Record<string, ReturnType<typeof vi.fn>>,
+  };
+});
+
+vi.mock('module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('module')>();
+  return {
+    ...actual,
+    createRequire: (url: string | URL) => {
+      const realReq = actual.createRequire(url);
+      const mockedReq: any = (id: string) => {
+        if (Object.prototype.hasOwnProperty.call(requireFns, id)) {
+          return requireFns[id](id);
+        }
+        return realReq(id);
+      };
+      mockedReq.resolve = realReq.resolve.bind(realReq);
+      mockedReq.resolve.paths = realReq.resolve.paths?.bind(realReq.resolve);
+      return mockedReq;
+    },
+  };
+});
+
+// Import AFTER vi.mock so the factory uses the mocked createRequire.
+import { webpackDefaultsFactory } from '../../../../lib/compiler/defaults/webpack-defaults.js';
+import { MultiNestCompilerPlugins } from '../../../../lib/compiler/plugins/plugins-loader.js';
+
+const emptyPlugins: MultiNestCompilerPlugins = {
+  beforeHooks: [],
+  afterHooks: [],
+  afterDeclarationsHooks: [],
+};
+
+// vi.fn() can be used with `new`; arrow functions cannot. Webpack and
+// rspack both call `new IgnorePlugin(...)` and `new TsconfigPathsPlugin(...)`,
+// so the mocks must be plain `vi.fn()` (which acts as a constructor).
+const makeMockWebpack = () =>
+  Object.assign(vi.fn(), {
+    IgnorePlugin: vi.fn(),
+  });
+
+const makeMockExternals = () => vi.fn(() => () => undefined);
+
+const makeMockTsconfigPathsPlugin = () => ({
+  TsconfigPathsPlugin: vi.fn(),
+});
+
+const moduleNotFoundError = (pkg: string, message?: string) => {
+  const err = new Error(message ?? `Cannot find module '${pkg}'`) as Error & {
+    code: string;
+  };
+  err.code = 'MODULE_NOT_FOUND';
+  return err;
+};
+
+describe('webpackDefaultsFactory', () => {
+  beforeEach(() => {
+    requireFns.webpack.mockReset();
+    requireFns['webpack-node-externals'].mockReset();
+    requireFns['tsconfig-paths-webpack-plugin'].mockReset();
+    requireFns['fork-ts-checker-webpack-plugin'].mockReset();
+
+    requireFns.webpack.mockReturnValue(makeMockWebpack());
+    requireFns['webpack-node-externals'].mockReturnValue(makeMockExternals());
+    requireFns['tsconfig-paths-webpack-plugin'].mockReturnValue(
+      makeMockTsconfigPathsPlugin(),
+    );
+    requireFns['fork-ts-checker-webpack-plugin'].mockReturnValue(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('should produce a configuration object with expected entry filename', () => {
+      const config = webpackDefaultsFactory(
+        '/abs/src',
+        'src',
+        'main',
+        false,
+        'tsconfig.build.json',
+        emptyPlugins,
+      );
+
+      expect(config.entry).toContain('main.ts');
+      expect(config.target).toBe('node');
+      expect(config.mode).toBe('none');
+    });
+
+    it('should normalize output filename to forward slashes', () => {
+      const config = webpackDefaultsFactory(
+        '/abs/src',
+        'apps\\my-app\\src',
+        'main',
+        false,
+        'tsconfig.build.json',
+        emptyPlugins,
+      );
+
+      // Even on Windows where path.join would use backslashes, the output
+      // filename must use forward slashes so webpack treats it as a single
+      // path segment instead of an escape-sequence-laden literal.
+      expect((config.output as any).filename).not.toMatch(/\\/);
+      expect((config.output as any).filename).toContain('/');
+    });
+
+    it('should register ForkTsCheckerWebpackPlugin when no compiler plugins are provided', () => {
+      const config = webpackDefaultsFactory(
+        '/abs/src',
+        'src',
+        'main',
+        false,
+        'tsconfig.json',
+        emptyPlugins,
+      );
+
+      expect(requireFns['fork-ts-checker-webpack-plugin']).toHaveBeenCalled();
+      expect(config.plugins).toBeDefined();
+      // IgnorePlugin + ForkTsCheckerWebpackPlugin
+      expect((config.plugins as any[]).length).toBe(2);
+    });
+
+    it('should not register ForkTsCheckerWebpackPlugin when compiler plugins are provided', () => {
+      const config = webpackDefaultsFactory(
+        '/abs/src',
+        'src',
+        'main',
+        false,
+        'tsconfig.json',
+        {
+          beforeHooks: [vi.fn()],
+          afterHooks: [],
+          afterDeclarationsHooks: [],
+        },
+      );
+
+      expect(
+        requireFns['fork-ts-checker-webpack-plugin'],
+      ).not.toHaveBeenCalled();
+      // IgnorePlugin only
+      expect((config.plugins as any[]).length).toBe(1);
+    });
+  });
+
+  describe('error handling for missing peer dependencies', () => {
+    it('should report the missing package name when webpack itself is not installed', () => {
+      requireFns.webpack.mockImplementation(() => {
+        throw moduleNotFoundError('webpack');
+      });
+
+      expect(() =>
+        webpackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        ),
+      ).toThrow(/"webpack" package is required/);
+    });
+
+    it('should report the missing package name when webpack-node-externals is not installed', () => {
+      requireFns['webpack-node-externals'].mockImplementation(() => {
+        throw moduleNotFoundError('webpack-node-externals');
+      });
+
+      expect(() =>
+        webpackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        ),
+      ).toThrow(/"webpack-node-externals" package is required/);
+    });
+
+    it('should report the missing package name from an ESM-style "Cannot find package" error', () => {
+      // Node's ESM resolver formats missing-package errors with two quoted
+      // segments: the missing package and the importing file. The earlier
+      // greedy regex captured the importing file path, which the user is
+      // told to install — clearly nonsense advice. Verify the new
+      // non-greedy regex captures the package name instead.
+      const err = new Error(
+        "Cannot find package 'webpack-node-externals' imported from '/abs/path/to/file.mjs'",
+      ) as Error & { code: string };
+      err.code = 'ERR_MODULE_NOT_FOUND';
+      requireFns['webpack-node-externals'].mockImplementation(() => {
+        throw err;
+      });
+
+      expect(() =>
+        webpackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        ),
+      ).toThrow(/"webpack-node-externals" package is required/);
+    });
+
+    it('should fall back to "webpack" when the error message does not match', () => {
+      const err = new Error('some unparseable error') as Error & {
+        code: string;
+      };
+      err.code = 'MODULE_NOT_FOUND';
+      requireFns.webpack.mockImplementation(() => {
+        throw err;
+      });
+
+      expect(() =>
+        webpackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        ),
+      ).toThrow(/"webpack" package is required/);
+    });
+
+    it('should re-throw unrelated errors without wrapping them', () => {
+      // If a peer dep is installed but its own initialization explodes
+      // (e.g. version mismatch, syntax error), the original error must
+      // surface — wrapping it in "package missing, please install" sends
+      // the user on a wild goose chase.
+      const original = new TypeError('webpack internal type error');
+      requireFns.webpack.mockImplementation(() => {
+        throw original;
+      });
+
+      expect(() =>
+        webpackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        ),
+      ).toThrow(original);
+    });
+
+    it('should attach the original module-not-found error as cause', () => {
+      const original = moduleNotFoundError('webpack');
+      requireFns.webpack.mockImplementation(() => {
+        throw original;
+      });
+
+      try {
+        webpackDefaultsFactory(
+          '/abs/src',
+          'src',
+          'main',
+          false,
+          'tsconfig.json',
+          emptyPlugins,
+        );
+        throw new Error('expected webpackDefaultsFactory to throw');
+      } catch (e) {
+        expect((e as Error).cause).toBe(original);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`webpack-defaults.ts` / `rspack-defaults.ts` wrap a `require('webpack')` / `require('@rspack/core')` failure with a friendlier "please install …" error so users on `nest build --builder webpack` get install advice instead of a raw stack trace. Two issues with the existing logic:

1. **The wrapping fired for any thrown error**, including ones unrelated to a missing module (e.g. peer-version mismatch, a syntax error inside the dep, an internal init failure). The user got told to reinstall packages that were already installed, and the actual failure was hidden. Now only `MODULE_NOT_FOUND` / `ERR_MODULE_NOT_FOUND` errors are wrapped — anything else rethrows untouched. The original error is also attached as the wrapped error's `cause` for diagnostics.

2. **The package-name regex was greedy.** `/Cannot find.*'([^']+)'/` captures the *last* quoted segment in the message. For Node's ESM-style error format —

   ```
   Cannot find package 'webpack-node-externals' imported from '/abs/path/to/file.mjs'
   ```

   that meant we captured `/abs/path/to/file.mjs` and told the user to install it as a package. Since v12 is fully ESM (`"type": "module"`), this format is exactly what users would see when a transitive peer dep is missing. Switched to a non-greedy match so the first quoted segment (the actual missing package) is captured.

## Test plan

Added `test/lib/compiler/defaults/webpack-defaults.spec.ts` and `test/lib/compiler/defaults/rspack-defaults.spec.ts` covering both factories:

- [x] Happy path: produces an entry filename, normalizes output filename to forward slashes, registers `ForkTsCheckerWebpackPlugin` only when no compiler plugins are provided.
- [x] rspack: ESM vs CJS output config differs as expected (experiments, externalsPresets, output.module).
- [x] Reports the missing package name for CJS-style `Cannot find module 'foo'` errors.
- [x] Reports the missing package name for ESM-style `Cannot find package 'foo' imported from '…'` errors (the bug fix).
- [x] Falls back to a sensible default when the error message doesn't match the regex.
- [x] Re-throws unrelated (non-`MODULE_NOT_FOUND`) errors verbatim instead of wrapping them.
- [x] Attaches the original module-not-found error as `cause` on the wrapped error.
- [x] `npm test` — 19 new tests pass; full suite has the same 4 pre-existing failures in `tsconfig-paths.hook.spec.ts` (unrelated to this change, present on `v12.0.0` HEAD).
- [x] `npm run build` passes.