### PR TITLE
fix(swc): stop spinner when watch-mode type checker setup throws

### DIFF
--- a/lib/compiler/swc/type-checker-host.ts
+++ b/lib/compiler/swc/type-checker-host.ts
@@ -40,8 +40,13 @@ export class TypeCheckerHost {
       console.log();
 
       spinner.start();
-      this.runInWatchMode(tsconfigPath, tsBinary, options);
-      spinner.succeed();
+      try {
+        this.runInWatchMode(tsconfigPath, tsBinary, options);
+        spinner.succeed();
+      } catch (err) {
+        spinner.fail();
+        throw err;
+      }
       return;
     }
     spinner.start();

--- a/test/lib/compiler/swc/type-checker-host.spec.ts
+++ b/test/lib/compiler/swc/type-checker-host.spec.ts
@@ -413,5 +413,61 @@ describe('TypeCheckerHost', () => {
       expect(onProgramInit).toHaveBeenCalledTimes(1);
       expect(onProgramInit).toHaveBeenCalledWith(mockProgram);
     });
+
+    it('should call spinner.succeed and not spinner.fail when watch setup completes', () => {
+      setupWatchMocks();
+
+      typeCheckerHost.run('tsconfig.json', {
+        watch: true,
+        onTypeCheck: vi.fn(),
+      });
+
+      expect(spinnerMock.start).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.succeed).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.fail).not.toHaveBeenCalled();
+    });
+
+    it('should call spinner.fail and rethrow when tsconfig parsing fails in watch mode', () => {
+      setupWatchMocks();
+      const parseError = new Error('Could not parse TypeScript config');
+      Object.defineProperty(typeCheckerHost, 'tsConfigProvider', {
+        value: {
+          getByConfigFilename: vi.fn(() => {
+            throw parseError;
+          }),
+        },
+        writable: true,
+      });
+
+      expect(() => {
+        typeCheckerHost.run('tsconfig.json', {
+          watch: true,
+          onTypeCheck: vi.fn(),
+        });
+      }).toThrow(parseError);
+
+      expect(spinnerMock.start).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.fail).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.succeed).not.toHaveBeenCalled();
+    });
+
+    it('should call spinner.fail and rethrow when createWatchProgram throws in watch mode', () => {
+      const { mockTsBinary } = setupWatchMocks();
+      const watchError = new Error('createWatchProgram failed');
+      mockTsBinary.createWatchProgram = vi.fn(() => {
+        throw watchError;
+      });
+
+      expect(() => {
+        typeCheckerHost.run('tsconfig.json', {
+          watch: true,
+          onTypeCheck: vi.fn(),
+        });
+      }).toThrow(watchError);
+
+      expect(spinnerMock.start).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.fail).toHaveBeenCalledTimes(1);
+      expect(spinnerMock.succeed).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

`TypeCheckerHost.run` in `lib/compiler/swc/type-checker-host.ts` starts an `ora` spinner before delegating to either `runOnce` or `runInWatchMode`. The non-watch branch already wraps `runOnce` in `try/catch` so `spinner.fail()` is called before the error is rethrown — but the watch branch didn't, so any throw inside `runInWatchMode` (invalid tsconfig path, `getParsedCommandLineOfConfigFile` returning `undefined`, `createWatchProgram` rejecting on bad options, etc.) bubbled up while the spinner kept spinning forever on stdout. The frozen `Initializing type checker...` line masks the real failure.

This PR mirrors the non-watch branch's behavior so both paths fail the spinner symmetrically before rethrowing.

```diff
       spinner.start();
-      this.runInWatchMode(tsconfigPath, tsBinary, options);
-      spinner.succeed();
+      try {
+        this.runInWatchMode(tsconfigPath, tsBinary, options);
+        spinner.succeed();
+      } catch (err) {
+        spinner.fail();
+        throw err;
+      }
```

## Test plan

Three new unit tests in `test/lib/compiler/swc/type-checker-host.spec.ts`:

- [x] Happy-path watch setup still calls `spinner.succeed` and never `spinner.fail`
- [x] When `tsConfigProvider.getByConfigFilename` throws inside `runInWatchMode`, the error is rethrown **and** `spinner.fail` is called once (regression test for the bug)
- [x] When `tsBinary.createWatchProgram` throws, same expectation: rethrown + `spinner.fail` called

Verified the new tests fail against the original source and pass with the fix.

```
✓ test/lib/compiler/swc/type-checker-host.spec.ts (16 tests) 191ms
```

`npm run build` and the swc test suite (`test/lib/compiler/swc/`) pass cleanly. Pre-existing failures in `tsconfig-paths.hook.spec.ts` and the Windows e2e `scaffoldApp` `ERR_REQUIRE_CYCLE` are unrelated to this change.