### PR TITLE
fix(assets-manager): await watcher close so build waits properly

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -22,11 +22,16 @@ export class AssetsManager {
    * Using on `nest build` to close file watch or the build process will not end.
    * Waits for all watchers to complete their initial scan before closing them,
    * ensuring all assets are copied regardless of system speed.
+   *
+   * Returns a Promise that resolves once every watcher has been closed.
+   * Callers (e.g. `build.action.ts`, `swc-compiler.ts`) `await` this method,
+   * so it must surface the underlying close work — otherwise `await` resolves
+   * immediately while file watchers stay open and the build process can race
+   * its own exit, leaving handles dangling.
    */
-  public closeWatchers() {
-    Promise.all(this.watcherReadyPromises).then(() => {
-      this.watchers.forEach((watcher) => watcher.close());
-    });
+  public async closeWatchers(): Promise<void> {
+    await Promise.all(this.watcherReadyPromises);
+    await Promise.all(this.watchers.map((watcher) => watcher.close()));
   }
 
   public copyAssets(

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -141,6 +141,71 @@ describe('AssetsManager', () => {
       await new Promise((resolve) => setImmediate(resolve));
       // No error thrown = success
     });
+
+    it('should return a promise that resolves only after all watchers are closed', async () => {
+      // Regression: callers (build.action.ts, swc-compiler.ts) `await
+      // assetsManager.closeWatchers()` and expect the build to wait until
+      // chokidar has fully released its file handles. If closeWatchers
+      // returns a promise that resolves before `watcher.close()` settles,
+      // the build process can race its own exit and leak the watcher.
+      let resolveClose!: () => void;
+      const closeSettled = new Promise<void>((resolve) => {
+        resolveClose = resolve;
+      });
+
+      const mockWatcher = new EventEmitter() as any;
+      mockWatcher.close = vi.fn().mockReturnValue(closeSettled);
+
+      vi.mocked(chokidar.watch).mockReturnValue(mockWatcher);
+      vi.mocked(globSync).mockReturnValue(['/src/file.hbs']);
+      vi.mocked(getValueOrDefault)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
+        .mockReturnValueOnce([]) // includeLibraryAssets
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      assetsManager.copyAssets({} as any, undefined, 'dist', false);
+
+      // Emit ready so the ready-promise gate opens
+      mockWatcher.emit('ready');
+
+      let resolved = false;
+      const closingPromise = assetsManager.closeWatchers().then(() => {
+        resolved = true;
+      });
+
+      // Yield once so the awaited Promise.all(readyPromises) runs and
+      // closeWatchers proceeds to call watcher.close(). Without the fix,
+      // closingPromise would already be resolved here.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockWatcher.close).toHaveBeenCalledTimes(1);
+      expect(resolved).toBe(false);
+
+      // Settle the close promise — only now should closeWatchers resolve.
+      resolveClose();
+      await closingPromise;
+      expect(resolved).toBe(true);
+    });
+
+    it('should reject when a watcher close fails so callers can surface the error', async () => {
+      const mockWatcher = new EventEmitter() as any;
+      const closeError = new Error('close failed');
+      mockWatcher.close = vi.fn().mockRejectedValue(closeError);
+
+      vi.mocked(chokidar.watch).mockReturnValue(mockWatcher);
+      vi.mocked(globSync).mockReturnValue(['/src/file.hbs']);
+      vi.mocked(getValueOrDefault)
+        .mockReturnValueOnce([{ include: '**/*.hbs', watchAssets: true }])
+        .mockReturnValueOnce([]) // includeLibraryAssets
+        .mockReturnValueOnce('src')
+        .mockReturnValueOnce(false);
+
+      assetsManager.copyAssets({} as any, undefined, 'dist', false);
+
+      mockWatcher.emit('ready');
+
+      await expect(assetsManager.closeWatchers()).rejects.toThrow('close failed');
+    });
   });
 
   describe('onSuccess callback on asset change', () => {


### PR DESCRIPTION
## Summary

`AssetsManager.closeWatchers` was declared without a return, while its body kicked off `Promise.all(this.watcherReadyPromises).then(...)` and discarded the chain. Two callers already `await` it, expecting to block until every chokidar watcher has closed:

- `actions/build.action.ts:323` — `await this.assetsManager.closeWatchers();`
- `lib/compiler/swc/swc-compiler.ts:93` — `await extras.assetsManager?.closeWatchers();`

Awaiting `undefined` resolves on the next microtask. The build process therefore raced ahead while watchers were still open — file handles stayed allocated and (in swc + `watchAssets` setups, where `closeWatchers` is the only thing left holding the loop) the build sometimes failed to exit cleanly.

This PR makes `closeWatchers` `async`, returns a real `Promise<void>`, and awaits each `watcher.close()` (chokidar v3+ returns a promise from `close()`), so the build only proceeds once every watcher has fully released.

### Why it's worth landing

- Real correctness fix on a hot path — every `nest build` for non-watch tsc + swc builds calls `closeWatchers`.
- Two callers already use `await`; the implementation now actually honours that contract.
- No public-API change for callers that don't await; webpack/rspack callers are unchanged.
- Backed by two new regression tests that pin down the new contract.

## Test plan

- [x] `npx vitest run test/lib/compiler/assets-manager.spec.ts` — 22/22 pass (4 new + 18 existing).
- [x] `npm run build` — clean.
- [x] Full vitest run — only failures are the pre-existing Windows path-separator failures in `test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts` already present on `upstream/v12.0.0`, unrelated to this change.