### PR TITLE
feat(cli): pass skip testing flag to application schematic

### DIFF
--- a/actions/new.action.ts
+++ b/actions/new.action.ts
@@ -88,13 +88,13 @@ const mapContextToSchematicOptions = (
   if (context.directory !== undefined)
     options.push(new SchematicOption('directory', context.directory));
 
-  if (context.dryRun)
-    options.push(new SchematicOption('dry-run', true));
+  if (context.dryRun) options.push(new SchematicOption('dry-run', true));
   options.push(new SchematicOption('skip-git', context.skipGit));
   options.push(new SchematicOption('strict', context.strict));
 
   if (context.skipTests) {
     options.push(new SchematicOption('spec', false));
+    options.push(new SchematicOption('skipTesting', true));
   }
 
   if (context.packageManager !== undefined)

--- a/test/actions/new.action.spec.ts
+++ b/test/actions/new.action.spec.ts
@@ -72,7 +72,9 @@ describe('NewAction', () => {
     process.exit = originalExit;
   });
 
-  const baseContext = (overrides: Partial<NewCommandContext> = {}): NewCommandContext => ({
+  const baseContext = (
+    overrides: Partial<NewCommandContext> = {},
+  ): NewCommandContext => ({
     name: 'test-project',
     directory: undefined,
     dryRun: false,
@@ -102,6 +104,19 @@ describe('NewAction', () => {
       expect(specOption).toBeDefined();
     });
 
+    it('should pass --skipTesting=true to schematics when --skip-tests is true', async () => {
+      const context = baseContext({ skipTests: true });
+      await action.handle(context);
+
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      const [, schematicOptions] = mockExecute.mock.calls[0];
+
+      const skipTestingOption = schematicOptions.find(
+        (opt: SchematicOption) => opt.toCommandString() === '--skip-testing',
+      );
+      expect(skipTestingOption).toBeDefined();
+    });
+
     it('should not pass spec option to schematics when --skip-tests is false', async () => {
       const context = baseContext({ skipTests: false });
       await action.handle(context);
@@ -123,9 +138,8 @@ describe('NewAction', () => {
 
       const [, schematicOptions] = mockExecute.mock.calls[0];
 
-      const skipTestsOption = schematicOptions.find(
-        (opt: SchematicOption) =>
-          opt.toCommandString().includes('skip-tests'),
+      const skipTestsOption = schematicOptions.find((opt: SchematicOption) =>
+        opt.toCommandString().includes('skip-tests'),
       );
       expect(skipTestsOption).toBeUndefined();
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The v12 `nest new --skip-tests` flag passes `spec: false` to the application schematic. That skips spec files, but it does not give the schematic enough information to skip the full testing scaffold.

Issue Number: Refs #2575


## What is the new behavior?
When `--skip-tests` is enabled, the new command now passes both `spec: false` and `skipTesting: true` to the application schematic. This preserves the existing spec-file behavior while allowing the schematic to omit test files, Jest configuration, testing scripts, and testing-related dependencies.

This pairs with nestjs/schematics#2354.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Validated with:

```bash
npm test -- test/actions/new.action.spec.ts
npm run build
npm run lint
npm exec -- prettier --check actions/new.action.ts test/actions/new.action.spec.ts
git diff --check
```

`npm run lint` completed with one existing warning in `lib/runners/runner.factory.ts` and no errors.
