### PR TITLE
fix(package-manager): allow pnpm starter build scripts

### DIFF
--- a/lib/package-managers/pnpm.package-manager.ts
+++ b/lib/package-managers/pnpm.package-manager.ts
@@ -22,7 +22,7 @@ export class PnpmPackageManager extends AbstractPackageManager {
       remove: 'uninstall',
       saveFlag: '--save',
       saveDevFlag: '--save-dev',
-      silentFlag: '--reporter=silent',
+      silentFlag: '--reporter=silent --dangerously-allow-all-builds',
     };
   }
 }

--- a/test/lib/package-managers/pnpm.package-manager.spec.ts
+++ b/test/lib/package-managers/pnpm.package-manager.spec.ts
@@ -29,7 +29,7 @@ describe('PnpmPackageManager', () => {
       remove: 'uninstall',
       saveFlag: '--save',
       saveDevFlag: '--save-dev',
-      silentFlag: '--reporter=silent',
+      silentFlag: '--reporter=silent --dangerously-allow-all-builds',
     };
     expect(packageManager.cli).toMatchObject(expectedValues);
   });
@@ -40,7 +40,7 @@ describe('PnpmPackageManager', () => {
       const testDir = join(process.cwd(), dirName);
       packageManager.install(dirName, 'pnpm');
       expect(spy).toBeCalledWith(
-        'install --strict-peer-dependencies=false --reporter=silent',
+        'install --strict-peer-dependencies=false --reporter=silent --dangerously-allow-all-builds',
         true,
         testDir,
       );


### PR DESCRIPTION
## Issue Number

Fixes #3450

## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been reviewed and are not required for this bug fix

## Summary

PNPM 11 fails during `nest new` when generated starter dependencies contain build scripts that need approval. The CLI currently hides pnpm output with the silent reporter, so users only see a generic package installation failure.

This change lets pnpm run the generated starter app's dependency build scripts during the initial scaffold install, preserving the existing `nest new` behavior while avoiding `ERR_PNPM_IGNORED_BUILDS`.

## Test Plan

- `npx jest --config test/jest-config.json test/lib/package-managers/pnpm.package-manager.spec.ts --runInBand`
- `npm run build`
- `npx prettier --check lib/package-managers/pnpm.package-manager.ts test/lib/package-managers/pnpm.package-manager.spec.ts`
- `git diff --check`
- Manual smoke with pnpm 11.1.2: `node bin/nest.js new test-app --package-manager pnpm --skip-git --language ts`, then `pnpm run build` and `pnpm test` in the generated app

## Other information

Scoped ESLint was attempted, but this branch currently has ESLint 10 with legacy `.eslintrc.js` config, and the CLI exits before linting because no flat `eslint.config.*` file exists.
