### PR TITLE
fix(compiler): support synthetic module specifiers

### DIFF
--- a/lib/compiler/hooks/tsconfig-paths.hook.ts
+++ b/lib/compiler/hooks/tsconfig-paths.hook.ts
@@ -19,16 +19,11 @@ export function tsconfigPathsBeforeHookFactory(
           (tsBinary.isExportDeclaration(node) && node.moduleSpecifier)
         ) {
           try {
-            const importPathWithQuotes =
-              node.moduleSpecifier && node.moduleSpecifier.getText();
+            const text = getModuleSpecifierText(node.moduleSpecifier, sf);
 
-            if (!importPathWithQuotes) {
+            if (!text) {
               return node;
             }
-            const text = importPathWithQuotes.substring(
-              1,
-              importPathWithQuotes.length - 1,
-            );
             const result = getNotAliasedPath(sf, matcher, text);
             if (!result) {
               return node;
@@ -70,6 +65,24 @@ export function tsconfigPathsBeforeHookFactory(
       return tsBinary.visitNode(sf, visitNode);
     };
   };
+}
+
+function getModuleSpecifierText(
+  moduleSpecifier: ts.Expression | undefined,
+  sourceFile: ts.SourceFile,
+) {
+  if (!moduleSpecifier) {
+    return;
+  }
+  if (typeof (moduleSpecifier as ts.StringLiteral).text === 'string') {
+    return (moduleSpecifier as ts.StringLiteral).text;
+  }
+
+  const importPathWithQuotes = moduleSpecifier.getText(sourceFile);
+  if (!importPathWithQuotes) {
+    return;
+  }
+  return importPathWithQuotes.substring(1, importPathWithQuotes.length - 1);
 }
 
 function getNotAliasedPath(

--- a/test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts
+++ b/test/lib/compiler/hooks/tsconfig-paths.hook.spec.ts
@@ -71,6 +71,49 @@ function createSpecWithDeclarations(
   return output;
 }
 
+function transformSyntheticImport(
+  baseUrl: string,
+  compilerOptions?: ts.CompilerOptions,
+) {
+  const options: ts.CompilerOptions = {
+    baseUrl,
+    outDir: path.join(baseUrl, 'dist'),
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.CommonJS,
+    ...compilerOptions,
+  };
+
+  const sourceFile = ts.createSourceFile(
+    path.join(baseUrl, 'src/synthetic-main.ts'),
+    'import value from "~/foo";',
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const originalImport = sourceFile.statements[0] as ts.ImportDeclaration;
+  const syntheticSpecifier = ts.factory.createStringLiteral('~/foo');
+  syntheticSpecifier.getText = () => {
+    throw new Error('getText should not be called for synthetic literals');
+  };
+  (syntheticSpecifier as any).parent = originalImport.moduleSpecifier.parent;
+
+  const updatedImport = ts.factory.updateImportDeclaration(
+    originalImport,
+    originalImport.modifiers,
+    originalImport.importClause,
+    syntheticSpecifier,
+    originalImport.assertClause,
+  );
+  const updatedSourceFile = ts.factory.updateSourceFile(sourceFile, [
+    updatedImport,
+  ]);
+  const transformer = tsconfigPathsBeforeHookFactory(options);
+  const transformed = ts.transform(updatedSourceFile, [transformer])
+    .transformed[0] as ts.SourceFile;
+
+  return (transformed.statements[0] as ts.ImportDeclaration).moduleSpecifier as ts.StringLiteral;
+}
+
 /**
  * This test is temporarily skipped because it's flaky on CI.
  * Not yet clear why but it's not a blocker.
@@ -110,6 +153,15 @@ describe.skip('tsconfig paths hooks', () => {
 });
 
 describe('tsconfig paths hooks - declaration files', () => {
+  it('should rewrite aliased synthetic module specifiers without reading getText()', () => {
+    const moduleSpecifier = transformSyntheticImport(
+      path.join(__dirname, './fixtures/aliased-imports'),
+      { paths: { '~/*': ['./src/*'] } },
+    );
+
+    expect(moduleSpecifier.text).toBe('./foo');
+  });
+
   it('should replace path aliases in .d.ts files when transformer is applied to afterDeclarations', () => {
     const output = createSpecWithDeclarations(
       path.join(__dirname, './fixtures/aliased-dts-imports'),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Typia can produce synthetic import and export string literals during TypeScript 6 transforms. The tsconfig-paths hook called getText() on the module specifier, which asserts on nodes without real source positions and stops debuggers on the caught exception.

## What is the new behavior?
Read moduleSpecifier.text when it is available, fall back to getText(sourceFile) for source-backed nodes, and cover the behavior with a regression test for synthetic literals.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
