### PR TITLE
fix(compiler): validate delete out dir paths before rm

### DIFF
--- a/lib/compiler/helpers/delete-out-dir.ts
+++ b/lib/compiler/helpers/delete-out-dir.ts
@@ -1,4 +1,5 @@
 import { rm } from 'fs/promises';
+import { isAbsolute, relative, resolve } from 'path';
 import * as ts from 'typescript';
 import { Configuration } from '../../configuration';
 import { getValueOrDefault } from './get-value-or-default';
@@ -17,8 +18,34 @@ export async function deleteOutDirIfEnabled(
   if (!isDeleteEnabled) {
     return;
   }
-  await rm(dirPath, { recursive: true, force: true });
-  if (tsOptions?.tsBuildInfoFile) {
-    await rm(tsOptions.tsBuildInfoFile, { force: true });
+  const resolvedOutDir = resolvePathInsideProject(dirPath, 'outDir');
+  const resolvedTsBuildInfoFile = tsOptions?.tsBuildInfoFile
+    ? resolvePathInsideProject(tsOptions.tsBuildInfoFile, 'tsBuildInfoFile')
+    : undefined;
+
+  await rm(resolvedOutDir, {
+    recursive: true,
+    force: true,
+  });
+  if (resolvedTsBuildInfoFile) {
+    await rm(resolvedTsBuildInfoFile, {
+      force: true,
+    });
   }
+}
+
+function resolvePathInsideProject(pathToDelete: string, propertyName: string) {
+  const projectRoot = process.cwd();
+  const resolvedPath = resolve(projectRoot, pathToDelete);
+  const relativePath = relative(projectRoot, resolvedPath);
+  const isProjectRoot = relativePath === '';
+  const isOutsideProject =
+    relativePath.startsWith('..') || isAbsolute(relativePath);
+
+  if (isProjectRoot || isOutsideProject) {
+    throw new Error(
+      `Refusing to delete "${propertyName}" path outside of or equal to the project directory: ${pathToDelete}`,
+    );
+  }
+  return resolvedPath;
 }

--- a/test/lib/compiler/helpers/delete-out-dir.spec.ts
+++ b/test/lib/compiler/helpers/delete-out-dir.spec.ts
@@ -1,14 +1,14 @@
 import * as fs from 'fs/promises';
+import * as path from 'path';
 import { deleteOutDirIfEnabled } from '../../../../lib/compiler/helpers/delete-out-dir';
 import { Configuration } from '../../../../lib/configuration';
 
 jest.mock('fs/promises');
 
 const mockedRm = fs.rm as jest.MockedFunction<typeof fs.rm>;
+const resolveFromCwd = (value: string) => path.resolve(process.cwd(), value);
 
-function createConfiguration(
-  deleteOutDir: boolean,
-): Required<Configuration> {
+function createConfiguration(deleteOutDir: boolean): Required<Configuration> {
   return {
     monorepo: false,
     sourceRoot: 'src',
@@ -39,7 +39,7 @@ describe('deleteOutDirIfEnabled', () => {
   it('should delete the output directory when deleteOutDir is enabled', async () => {
     const config = createConfiguration(true);
     await deleteOutDirIfEnabled(config, undefined, 'dist');
-    expect(mockedRm).toHaveBeenCalledWith('dist', {
+    expect(mockedRm).toHaveBeenCalledWith(resolveFromCwd('dist'), {
       recursive: true,
       force: true,
     });
@@ -52,12 +52,12 @@ describe('deleteOutDirIfEnabled', () => {
     };
     await deleteOutDirIfEnabled(config, undefined, 'dist', tsOptions);
     expect(mockedRm).toHaveBeenCalledTimes(2);
-    expect(mockedRm).toHaveBeenCalledWith('dist', {
+    expect(mockedRm).toHaveBeenCalledWith(resolveFromCwd('dist'), {
       recursive: true,
       force: true,
     });
     expect(mockedRm).toHaveBeenCalledWith(
-      './node_modules/.tmp/tsconfig.tsbuildinfo',
+      resolveFromCwd('./node_modules/.tmp/tsconfig.tsbuildinfo'),
       { force: true },
     );
   });
@@ -66,7 +66,7 @@ describe('deleteOutDirIfEnabled', () => {
     const config = createConfiguration(true);
     await deleteOutDirIfEnabled(config, undefined, 'dist');
     expect(mockedRm).toHaveBeenCalledTimes(1);
-    expect(mockedRm).toHaveBeenCalledWith('dist', {
+    expect(mockedRm).toHaveBeenCalledWith(resolveFromCwd('dist'), {
       recursive: true,
       force: true,
     });
@@ -77,9 +77,57 @@ describe('deleteOutDirIfEnabled', () => {
     const tsOptions = {};
     await deleteOutDirIfEnabled(config, undefined, 'dist', tsOptions);
     expect(mockedRm).toHaveBeenCalledTimes(1);
-    expect(mockedRm).toHaveBeenCalledWith('dist', {
+    expect(mockedRm).toHaveBeenCalledWith(resolveFromCwd('dist'), {
       recursive: true,
       force: true,
     });
+  });
+
+  it('should reject deleting the project root', async () => {
+    const config = createConfiguration(true);
+
+    await expect(deleteOutDirIfEnabled(config, undefined, '.')).rejects.toThrow(
+      'Refusing to delete "outDir" path outside of or equal to the project directory: .',
+    );
+    expect(mockedRm).not.toHaveBeenCalled();
+  });
+
+  it('should reject deleting a parent directory via relative traversal', async () => {
+    const config = createConfiguration(true);
+    const outsidePath = path.join('..', 'outside-dist');
+
+    await expect(
+      deleteOutDirIfEnabled(config, undefined, outsidePath),
+    ).rejects.toThrow(
+      `Refusing to delete "outDir" path outside of or equal to the project directory: ${outsidePath}`,
+    );
+    expect(mockedRm).not.toHaveBeenCalled();
+  });
+
+  it('should reject deleting an absolute path outside the project', async () => {
+    const config = createConfiguration(true);
+    const outsidePath = path.resolve(process.cwd(), '..', 'outside-dist');
+
+    await expect(
+      deleteOutDirIfEnabled(config, undefined, outsidePath),
+    ).rejects.toThrow(
+      `Refusing to delete "outDir" path outside of or equal to the project directory: ${outsidePath}`,
+    );
+    expect(mockedRm).not.toHaveBeenCalled();
+  });
+
+  it('should reject deleting tsBuildInfoFile outside the project before deleting outDir', async () => {
+    const config = createConfiguration(true);
+    const outsidePath = path.join('..', 'tsconfig.tsbuildinfo');
+    const tsOptions = {
+      tsBuildInfoFile: outsidePath,
+    };
+
+    await expect(
+      deleteOutDirIfEnabled(config, undefined, 'dist', tsOptions),
+    ).rejects.toThrow(
+      `Refusing to delete "tsBuildInfoFile" path outside of or equal to the project directory: ${outsidePath}`,
+    );
+    expect(mockedRm).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
deleteOutDirIfEnabled() passes "outDir" and "tsBuildInfoFile" directly to "fs.rm".
If a project sets "compilerOptions.deleteOutDir" and configures either path to point
outside the project directory, "nest build" can remove files outside the workspace.

Issue Number: #3454 


## What is the new behavior?

deleteOutDirIfEnabled() now resolves both paths against the project root before
deleting anything.

The helper refuses to delete:

- the project root itself
- relative paths that escape the project directory
- absolute paths outside the project directory
- external "tsBuildInfoFile" paths

Both paths are validated before the first rm call, so an invalid "tsBuildInfoFile"
does not cause a partial deletion of "outDir".

Regression tests were added for valid internal paths and rejected external paths.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Honestly I do not know where to document this fix, or even if it should be on the docs. If any documentation is needed please tell me.