### PR TITLE
fix(compiler): validate asset output paths

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -1,7 +1,7 @@
 import * as chokidar from 'chokidar';
 import { copyFileSync, mkdirSync, rmSync, statSync } from 'fs';
 import { sync } from 'glob';
-import { dirname, join, sep } from 'path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import {
   ActionOnFile,
   Asset,
@@ -136,6 +136,7 @@ export class AssetsManager {
   private actionOnFile(option: ActionOnFile) {
     const { action, item, path, sourceRoot, watchAssetsMode } = option;
     const isWatchEnabled = watchAssetsMode || item.watchAssets;
+    const dest = this.resolveAssetDestination(path, item.outDir!, sourceRoot);
 
     const assetCheckKey = path + (item.outDir ?? '');
     // Allow to do action for the first time before check watchMode
@@ -147,12 +148,6 @@ export class AssetsManager {
     // Set action to true to avoid watches getting cutoff
     this.actionInProgress = true;
 
-    const dest = copyPathResolve(
-      path,
-      item.outDir!,
-      sourceRoot.split(sep).length,
-    );
-
     // Copy to output dir if file is changed or added
     if (action === 'change') {
       mkdirSync(dirname(dest), { recursive: true });
@@ -161,5 +156,32 @@ export class AssetsManager {
       // Remove from output dir if file is deleted
       rmSync(dest, { force: true });
     }
+  }
+
+  private resolveAssetDestination(
+    filePath: string,
+    outDir: string,
+    sourceRoot: string,
+  ) {
+    const dest = copyPathResolve(
+      filePath,
+      outDir,
+      sourceRoot.split(sep).length,
+    );
+    const projectRoot = process.cwd();
+    const resolvedDest = resolve(projectRoot, dest);
+    const relativeDest = relative(projectRoot, resolvedDest);
+    const isProjectRoot = relativeDest === '';
+    const isOutsideProject =
+      relativeDest === '..' ||
+      relativeDest.startsWith(`..${sep}`) ||
+      isAbsolute(relativeDest);
+
+    if (isProjectRoot || isOutsideProject) {
+      throw new Error(
+        `Refusing to process asset outside of or equal to the project directory: ${dest}`,
+      );
+    }
+    return resolvedDest;
   }
 }

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -1,0 +1,180 @@
+import { copyFileSync, mkdirSync, rmSync, statSync } from 'fs';
+import { sync } from 'glob';
+import * as path from 'path';
+import { AssetsManager } from '../../../lib/compiler/assets-manager';
+import { Configuration } from '../../../lib/configuration';
+
+jest.mock('fs', () => ({
+  copyFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  rmSync: jest.fn(),
+  statSync: jest.fn(),
+}));
+
+jest.mock('glob', () => ({
+  sync: jest.fn(),
+}));
+
+jest.mock('chokidar', () => ({
+  watch: jest.fn(() => ({
+    close: jest.fn(),
+    on: jest.fn().mockReturnThis(),
+  })),
+}));
+
+const copyFileSyncMock = copyFileSync as jest.MockedFunction<
+  typeof copyFileSync
+>;
+const mkdirSyncMock = mkdirSync as jest.MockedFunction<typeof mkdirSync>;
+const rmSyncMock = rmSync as jest.MockedFunction<typeof rmSync>;
+const statSyncMock = statSync as jest.MockedFunction<typeof statSync>;
+const globSyncMock = sync as jest.MockedFunction<typeof sync>;
+
+function createConfiguration(
+  assets: Required<Configuration>['compilerOptions']['assets'],
+): Required<Configuration> {
+  return {
+    monorepo: false,
+    sourceRoot: 'src',
+    entryFile: 'main',
+    exec: '',
+    projects: {},
+    language: 'ts',
+    collection: '@nestjs/schematics',
+    compilerOptions: {
+      assets,
+    },
+    generateOptions: {},
+  };
+}
+
+describe('AssetsManager', () => {
+  const sourceRoot = path.join(process.cwd(), 'src');
+  const sourceFile = path.join(sourceRoot, 'asset.txt');
+
+  beforeEach(() => {
+    copyFileSyncMock.mockReset();
+    mkdirSyncMock.mockReset();
+    rmSyncMock.mockReset();
+    statSyncMock.mockReset();
+    globSyncMock.mockReset();
+
+    statSyncMock.mockReturnValue({
+      isDirectory: () => false,
+      isFile: () => true,
+    } as any);
+    globSyncMock.mockReturnValue([sourceFile] as any);
+  });
+
+  it('should copy assets to an output directory inside the project', () => {
+    const assetsManager = new AssetsManager();
+    const configuration = createConfiguration(['**/*.txt']);
+    const dest = path.resolve(process.cwd(), 'dist', 'asset.txt');
+
+    assetsManager.copyAssets(configuration, undefined, 'dist', false);
+
+    expect(mkdirSyncMock).toHaveBeenCalledWith(path.dirname(dest), {
+      recursive: true,
+    });
+    expect(copyFileSyncMock).toHaveBeenCalledWith(sourceFile, dest);
+  });
+
+  it('should copy assets to an absolute output directory inside the project', () => {
+    const assetsManager = new AssetsManager();
+    const outDir = path.resolve(process.cwd(), 'build-assets');
+    const configuration = createConfiguration([
+      {
+        glob: '**/*.txt',
+        include: '**/*.txt',
+        outDir,
+      },
+    ]);
+    const dest = path.join(outDir, 'asset.txt');
+
+    assetsManager.copyAssets(configuration, undefined, 'dist', false);
+
+    expect(mkdirSyncMock).toHaveBeenCalledWith(path.dirname(dest), {
+      recursive: true,
+    });
+    expect(copyFileSyncMock).toHaveBeenCalledWith(sourceFile, dest);
+  });
+
+  it('should reject a relative output directory outside the project', () => {
+    const assetsManager = new AssetsManager();
+    const outDir = path.join('..', 'outside-assets');
+    const configuration = createConfiguration([
+      {
+        glob: '**/*.txt',
+        include: '**/*.txt',
+        outDir,
+      },
+    ]);
+
+    expect(() =>
+      assetsManager.copyAssets(configuration, undefined, 'dist', false),
+    ).toThrow(
+      'An error occurred during the assets copying process. Refusing to process asset outside of or equal to the project directory:',
+    );
+    expect(mkdirSyncMock).not.toHaveBeenCalled();
+    expect(copyFileSyncMock).not.toHaveBeenCalled();
+    expect(rmSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject an absolute output directory outside the project', () => {
+    const assetsManager = new AssetsManager();
+    const outDir = path.resolve(process.cwd(), '..', 'outside-assets');
+    const configuration = createConfiguration([
+      {
+        glob: '**/*.txt',
+        include: '**/*.txt',
+        outDir,
+      },
+    ]);
+
+    expect(() =>
+      assetsManager.copyAssets(configuration, undefined, 'dist', false),
+    ).toThrow(
+      'An error occurred during the assets copying process. Refusing to process asset outside of or equal to the project directory:',
+    );
+    expect(mkdirSyncMock).not.toHaveBeenCalled();
+    expect(copyFileSyncMock).not.toHaveBeenCalled();
+    expect(rmSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('should remove watched assets from an output directory inside the project', () => {
+    const assetsManager = new AssetsManager();
+    const dest = path.resolve(process.cwd(), 'dist', 'asset.txt');
+
+    (assetsManager as any).actionOnFile({
+      action: 'unlink',
+      item: {
+        outDir: 'dist',
+      },
+      path: sourceFile,
+      sourceRoot,
+      watchAssetsMode: true,
+    });
+
+    expect(rmSyncMock).toHaveBeenCalledWith(dest, { force: true });
+  });
+
+  it('should reject removing watched assets outside the project', () => {
+    const assetsManager = new AssetsManager();
+    const outDir = path.join('..', 'outside-assets');
+
+    expect(() =>
+      (assetsManager as any).actionOnFile({
+        action: 'unlink',
+        item: {
+          outDir,
+        },
+        path: sourceFile,
+        sourceRoot,
+        watchAssetsMode: true,
+      }),
+    ).toThrow(
+      'Refusing to process asset outside of or equal to the project directory:',
+    );
+    expect(rmSyncMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The assets pipeline computes copy and unlink destinations from
"compilerOptions.assets[].outDir" without checking whether the final resolved
path remains inside the project directory.

As a result, a project configuration can point asset output to a parent or
absolute external directory. `nest build` may then copy files outside the
workspace, and watch mode may remove the corresponding external destination on
asset unlink.

Issue Number: #3456


## What is the new behavior?

AssetsManager now resolves the final asset destination against the project
root before any filesystem write or unlink is performed.

The helper refuses to process asset destinations that are:

- equal to the project root
- relative paths that escape the project directory
- absolute paths outside the project directory

This validation is used for both asset copy operations and watch-mode unlink
operations.

Regression tests were added for valid internal destinations and rejected
external destinations.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```