### PR TITLE
fix(cli): resolve Windows path separator bug in plugin loader

### DIFF
--- a/lib/compiler/plugins/plugins-loader.ts
+++ b/lib/compiler/plugins/plugins-loader.ts
@@ -99,7 +99,7 @@ export class PluginsLoader {
       try {
         try {
           const binaryPath = require.resolve(
-            join(item, PLUGIN_ENTRY_FILENAME),
+            `${item}/${PLUGIN_ENTRY_FILENAME}`,
             {
               paths: nodeModulePaths,
             },


### PR DESCRIPTION
## PR Checklist
- [x] Fix for Windows compatibility issue

## Description

On Windows, `path.join(item, PLUGIN_ENTRY_FILENAME)` produces backslashes (e.g. `@nestjs/graphql\plugin`), which causes `require.resolve` to fail when the NestJS CLI attempts to load GraphQL plugins from `nest-cli.json`.

Using a forward-slash path (`${item}/${PLUGIN_ENTRY_FILENAME}`) resolves correctly on all platforms including Windows.

## Steps to reproduce
1. Install `@nestjs/cli` v12 alpha on Windows
2. Add `@nestjs/graphql` to `plugins` in `nest-cli.json`
3. Run `nest build` — fails with plugin resolution error

## Related issue
Windows backslash in `path.join` breaks `require.resolve` for npm packages with scoped names (e.g. `@nestjs/graphql`).