### PR TITLE
fix(runners): remove duplicated binary in failed command message

### DIFF
--- a/lib/runners/abstract.runner.ts
+++ b/lib/runners/abstract.runner.ts
@@ -22,8 +22,8 @@ export class AbstractRunner {
       shell: true,
     };
     return new Promise<null | string>((resolve, reject) => {
-      const command = [this.binary, ...this.args, ...args].join(' ');
-      const child: ChildProcess = spawn(command, options);
+      const fullCommand = [this.binary, ...this.args, ...args].join(' ');
+      const child: ChildProcess = spawn(fullCommand, options);
       if (collect) {
         child.stdout!.on('data', (data) =>
           resolve(data.toString().replace(/\r\n|\n/, '')),
@@ -33,9 +33,7 @@ export class AbstractRunner {
         if (code === 0) {
           resolve(null);
         } else {
-          console.error(
-            red(MESSAGES.RUNNER_EXECUTION_ERROR(`${this.binary} ${command}`)),
-          );
+          console.error(red(MESSAGES.RUNNER_EXECUTION_ERROR(fullCommand)));
           reject();
         }
       });

--- a/test/lib/runners/abstract.runner.spec.ts
+++ b/test/lib/runners/abstract.runner.spec.ts
@@ -1,0 +1,48 @@
+import { EventEmitter } from 'events';
+import * as childProcess from 'child_process';
+import { AbstractRunner } from '../../../lib/runners/abstract.runner';
+import { MESSAGES } from '../../../lib/ui';
+
+jest.mock('child_process');
+
+describe('AbstractRunner', () => {
+  let fakeChild: EventEmitter & { stdout: EventEmitter };
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fakeChild = Object.assign(new EventEmitter(), {
+      stdout: new EventEmitter(),
+    });
+    jest.spyOn(childProcess, 'spawn').mockReturnValue(fakeChild as any);
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('run', () => {
+    it('should print the failed command without duplicating the binary', async () => {
+      const runner = new AbstractRunner('pnpm');
+      const runPromise = runner.run('install --strict-peer-dependencies=false');
+
+      // Simulate the spawned process exiting with a failure code.
+      fakeChild.emit('close', 1);
+
+      await expect(runPromise).rejects.toBeUndefined();
+
+      // `.trim()` drops the leading newline so the assertion is not affected
+      // by the ANSI color codes that `ansis` injects around line breaks.
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          MESSAGES.RUNNER_EXECUTION_ERROR(
+            'pnpm install --strict-peer-dependencies=false',
+          ).trim(),
+        ),
+      );
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('pnpm pnpm install'),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When a command executed through `AbstractRunner` fails, the CLI prints the failed command with the package manager binary duplicated. For example, during `nest new` with pnpm:

```
Failed to execute command: pnpm pnpm install --strict-peer-dependencies=false --reporter=silent
```

In `run()`, the inner `command` variable already contains the binary (`[this.binary, ...this.args, ...args].join(' ')`), but the failure message prepended `this.binary` once more:

```ts
console.error(red(MESSAGES.RUNNER_EXECUTION_ERROR(`${this.binary} ${command}`)));
```

This produces the duplicated `pnpm pnpm`.
The bug is package-manager agnostic (npm/yarn would print the same).

Issue Number: nestjs/nest#17135

## What is the new behavior?

The failure message now prints the command without duplicating the binary:

```
Failed to execute command: pnpm install --strict-peer-dependencies=false --reporter=silent
```

The inner variable is renamed to `fullCommand` to remove the shadowing of the outer `command` parameter, and the error message reuses it instead of prepending the binary again. A regression test for `AbstractRunner.run()` was added.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Verified locally: the new test fails against the previous code and passes with the fix, and the full test suite (`npm test`) stays green.