### PR TITLE
fix(schematics): resolve built-in collection by path

### DIFF
--- a/lib/schematics/nest.collection.ts
+++ b/lib/schematics/nest.collection.ts
@@ -1,6 +1,7 @@
 import { AbstractRunner } from '../runners';
 import { AbstractCollection } from './abstract.collection';
 import { SchematicOption } from './schematic.option';
+import * as path from 'path';
 
 export interface Schematic {
   name: string;
@@ -113,12 +114,17 @@ export class NestCollection extends AbstractCollection {
   ];
 
   constructor(runner: AbstractRunner) {
-    super('@nestjs/schematics', runner);
+    super(NestCollection.getCollectionPath(), runner);
   }
 
   public async execute(name: string, options: SchematicOption[]) {
     const schematic: string = this.validate(name);
-    await super.execute(schematic, options);
+    await super.execute(schematic, [
+      ...options,
+      // Absolute collection paths are treated as local collections by
+      // schematics-cli, which enables debug/dry-run defaults unless disabled.
+      new SchematicOption('debug', false),
+    ]);
   }
 
   public getSchematics(): Schematic[] {
@@ -138,5 +144,19 @@ export class NestCollection extends AbstractCollection {
       );
     }
     return schematic.name;
+  }
+
+  private static getCollectionPath(): string {
+    const packageJsonPath = require.resolve('@nestjs/schematics/package.json');
+    const packageJson = require(packageJsonPath);
+    const collectionPath = path.resolve(
+      path.dirname(packageJsonPath),
+      packageJson.schematics,
+    );
+
+    if (process.platform === 'win32') {
+      return `"${collectionPath.replace(/"/g, '\\"')}"`;
+    }
+    return `'${collectionPath.replace(/'/g, `'\\''`)}'`;
   }
 }

--- a/test/lib/schematics/nest.collection.spec.ts
+++ b/test/lib/schematics/nest.collection.spec.ts
@@ -1,5 +1,23 @@
 import { AbstractRunner } from '../../../lib/runners';
 import { NestCollection } from '../../../lib/schematics/nest.collection';
+import * as path from 'path';
+
+const getResolvedNestCollectionPath = () => {
+  const packageJsonPath = require.resolve('@nestjs/schematics/package.json');
+  const packageJson = require(packageJsonPath);
+
+  return path.resolve(path.dirname(packageJsonPath), packageJson.schematics);
+};
+
+const quoteCollectionPath = (collectionPath: string) => {
+  if (process.platform === 'win32') {
+    return `"${collectionPath.replace(/"/g, '\\"')}"`;
+  }
+  return `'${collectionPath.replace(/'/g, `'\\''`)}'`;
+};
+
+const getExpectedNestCollectionCommand = (schematic: string) =>
+  `${quoteCollectionPath(getResolvedNestCollectionPath())}:${schematic} --no-debug`;
 
 describe('Nest Collection', () => {
   [
@@ -35,7 +53,7 @@ describe('Nest Collection', () => {
       const collection = new NestCollection(mockedRunner as AbstractRunner);
       await collection.execute(schematic, []);
       expect(mockedRunner.run).toHaveBeenCalledWith(
-        `@nestjs/schematics:${schematic}`,
+        getExpectedNestCollectionCommand(schematic),
       );
     });
   });
@@ -72,7 +90,7 @@ describe('Nest Collection', () => {
       const collection = new NestCollection(mockedRunner as AbstractRunner);
       await collection.execute(schematic.alias, []);
       expect(mockedRunner.run).toHaveBeenCalledWith(
-        `@nestjs/schematics:${schematic.name}`,
+        getExpectedNestCollectionCommand(schematic.name),
       );
     });
   });
@@ -92,6 +110,39 @@ describe('Nest Collection', () => {
       expect(error.message).toEqual(
         'Invalid schematic "name". Please, ensure that "name" exists in this collection.',
       );
+    }
+  });
+
+  it('should quote collection paths that contain shell special characters', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const packageJsonPath = require.resolve('@nestjs/schematics/package.json');
+    const originalDirname = path.dirname;
+    const dirname = jest.spyOn(path, 'dirname').mockImplementation((value) => {
+      if (value === packageJsonPath) {
+        return "/tmp/nest $(echo unsafe) path's";
+      }
+      return originalDirname(value);
+    });
+
+    const mockedRunner = {
+      run: jest.fn().mockImplementation(() => Promise.resolve()),
+    };
+
+    try {
+      const collection = new NestCollection(
+        mockedRunner as unknown as AbstractRunner,
+      );
+
+      await collection.execute('application', []);
+
+      expect(mockedRunner.run).toHaveBeenCalledWith(
+        "'/tmp/nest $(echo unsafe) path'\\''s/dist/collection.json':application --no-debug",
+      );
+    } finally {
+      dirname.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When `@nestjs/cli` is installed globally with pnpm 11, `nest new` can fail before scaffolding because the spawned Angular schematics CLI cannot resolve the built-in `@nestjs/schematics` collection from pnpm's global store layout.

Issue Number: Fixes #3471


## What is the new behavior?
`NestCollection` resolves the installed `@nestjs/schematics` package metadata and invokes schematics through the package's concrete collection file path. The collection path is quoted so installs under paths containing spaces still work.

Because schematics-cli treats collection file paths as local collections, the CLI also passes `--no-debug` to avoid enabling debug/dry-run defaults for normal `nest new` and `nest generate` commands.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Local validation:

```bash
npm test -- --runTestsByPath test/lib/schematics/nest.collection.spec.ts
npm run build
npm exec -- prettier --check lib/schematics/nest.collection.ts test/lib/schematics/nest.collection.spec.ts
git diff --check
npm pack --pack-destination /tmp/nest-3471-pr-pack
# Install the packed CLI with pnpm 11 in an isolated global home, then:
nest new pr-example --skip-install --skip-git -p pnpm
```
