### PR TITLE
fix(compiler): fail fast when TypeScript lacks the programmatic API (TS 7)

### DIFF
--- a/lib/compiler/typescript-loader.ts
+++ b/lib/compiler/typescript-loader.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import { CLI_ERRORS } from '../ui';
 
 export class TypeScriptBinaryLoader {
   private tsBinary?: typeof ts;
@@ -8,17 +9,28 @@ export class TypeScriptBinaryLoader {
       return this.tsBinary;
     }
 
+    let tsBinary: typeof ts;
     try {
       const tsBinaryPath = require.resolve('typescript', {
         paths: [process.cwd(), ...this.getModulePaths()],
       });
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const tsBinary = require(tsBinaryPath);
-      this.tsBinary = tsBinary;
-      return tsBinary;
+      tsBinary = require(tsBinaryPath);
     } catch {
       throw new Error(
         'TypeScript could not be found! Please, install "typescript" package.',
+      );
+    }
+
+    this.assertProgrammaticApiIsSupported(tsBinary);
+    this.tsBinary = tsBinary;
+    return tsBinary;
+  }
+
+  private assertProgrammaticApiIsSupported(tsBinary: typeof ts): void {
+    if (typeof tsBinary.getParsedCommandLineOfConfigFile !== 'function') {
+      throw new Error(
+        CLI_ERRORS.UNSUPPORTED_TYPESCRIPT_VERSION(tsBinary.version),
       );
     }
   }

--- a/lib/ui/errors.ts
+++ b/lib/ui/errors.ts
@@ -3,4 +3,6 @@ export const CLI_ERRORS = {
     `Could not find TypeScript configuration file "${path}". Please, ensure that you are running this command in the appropriate directory (inside Nest workspace).`,
   WRONG_PLUGIN: (name: string) =>
     `The "${name}" plugin is not compatible with Nest CLI. Neither "after()" nor "before()" nor "afterDeclarations()" function have been provided.`,
+  UNSUPPORTED_TYPESCRIPT_VERSION: (version: string) =>
+    `The installed TypeScript version (${version}) does not expose the programmatic compiler API that the Nest CLI requires. TypeScript 7.0 ships the "tsc" executable only; the compiler API is expected to return in 7.1. Please install TypeScript 6 (e.g. "npm i -D typescript@^6") until then.`,
 };

--- a/test/lib/compiler/typescript-loader.spec.ts
+++ b/test/lib/compiler/typescript-loader.spec.ts
@@ -1,0 +1,29 @@
+import { TypeScriptBinaryLoader } from '../../../lib/compiler/typescript-loader';
+import { CLI_ERRORS } from '../../../lib/ui';
+
+describe('TypeScriptBinaryLoader', () => {
+  it('should load the installed TypeScript that exposes the compiler API', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const tsBinary = loader.load();
+    expect(typeof tsBinary.getParsedCommandLineOfConfigFile).toBe('function');
+  });
+
+  it('should not throw for a TypeScript build exposing the programmatic API', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const supportedBinary = {
+      version: '6.0.3',
+      getParsedCommandLineOfConfigFile: () => ({}),
+    } as any;
+    expect(() =>
+      (loader as any).assertProgrammaticApiIsSupported(supportedBinary),
+    ).not.toThrow();
+  });
+
+  it('should throw an actionable error when the programmatic API is missing (TypeScript 7)', () => {
+    const loader = new TypeScriptBinaryLoader();
+    const nativeBinary = { version: '7.0.2', sys: {} } as any;
+    expect(() =>
+      (loader as any).assertProgrammaticApiIsSupported(nativeBinary),
+    ).toThrow(CLI_ERRORS.UNSUPPORTED_TYPESCRIPT_VERSION('7.0.2'));
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated (n/a — internal behavior + error message)

## What is the current behavior?

`nest build` / `nest start --watch` crash immediately with a raw `TypeError` when `typescript@7.x` is installed:

```
Error  tsBinary.getParsedCommandLineOfConfigFile is not a function
```

Root cause: TypeScript 7.0 ships the native (Go) `tsc` executable only — its Node module does **not** expose the programmatic compiler API. Per Microsoft's migration notes, that API is expected to return in TypeScript 7.1. The CLI relies on it, so it throws deep in the build with no indication of the real problem:

```js
const ts = require('typescript');
ts.version;                                 // "7.0.2"
typeof ts.getParsedCommandLineOfConfigFile; // "undefined"
typeof ts.createProgram;                    // "undefined"
```

This affects **both** builders — the default `tsc` path (`helpers/tsconfig-provider.ts`) and the SWC path (`swc/type-checker-host.ts` calls `createProgram` / `createWatchProgram` / `getPreEmitDiagnostics`, all `undefined`), so SWC is not a workaround.

Closes #3477.

## What is the new behavior?

`TypeScriptBinaryLoader.load()` — the single choke point every consumer goes through — now asserts the programmatic API is present right after resolving `typescript`, and throws an actionable error otherwise:

```
The installed TypeScript version (7.0.2) does not expose the programmatic compiler API
that the Nest CLI requires. TypeScript 7.0 ships the "tsc" executable only; the compiler
API is expected to return in 7.1. Please install TypeScript 6 (e.g. "npm i -D typescript@^6")
until then.
```

Because the guard lives in the loader, it covers every entry point (default builder, SWC type-checker host, plugin metadata generator) with one small change.

Note: I used **feature detection** (`typeof getParsedCommandLineOfConfigFile !== 'function'`) rather than a hard `major === 7` version gate on purpose — when TypeScript 7.1 restores the API, the CLI starts working again automatically with no follow-up change needed. The installed version is still surfaced in the message for the user's benefit.

Plain `tsc --noEmit` remains unaffected (only tools that `require('typescript')` and call the API break).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
