### PR TITLE
fix: backfill baseUrl to TsconfigPathsPlugin

### DIFF
--- a/lib/compiler/defaults/webpack-defaults.ts
+++ b/lib/compiler/defaults/webpack-defaults.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'module';
 import { join } from 'path';
+import { readFileSync } from 'fs';
 import type { TsconfigPathsPlugin as TsconfigPathsPluginType } from 'tsconfig-paths-webpack-plugin';
 import type webpack from 'webpack';
 import type nodeExternals from 'webpack-node-externals';
@@ -36,6 +37,15 @@ function loadWebpackDeps() {
         `Please install it:\n\n  npm install --save-dev webpack webpack-node-externals tsconfig-paths-webpack-plugin ts-loader fork-ts-checker-webpack-plugin\n`,
       { cause: e },
     );
+  }
+}
+
+function getBaseUrl(tsConfigFile: string) {
+  try {
+    const { compilerOptions } = JSON.parse(readFileSync(tsConfigFile, 'utf8'));
+    return compilerOptions?.baseUrl ?? '.';
+  } catch {
+    return '.';
   }
 }
 
@@ -96,6 +106,7 @@ export const webpackDefaultsFactory = (
       plugins: [
         new TsconfigPathsPlugin({
           configFile: tsConfigFile,
+          baseUrl: getBaseUrl(tsConfigFile),
         }),
       ],
     },

--- a/test/lib/compiler/defaults/webpack-defaults.spec.ts
+++ b/test/lib/compiler/defaults/webpack-defaults.spec.ts
@@ -1,4 +1,13 @@
+import * as fs from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
 
 // Hoisted module mocks. Each test resets the implementation of these
 // functions to simulate either a successful require (mock module returned)
@@ -41,6 +50,7 @@ const emptyPlugins: MultiNestCompilerPlugins = {
   beforeHooks: [],
   afterHooks: [],
   afterDeclarationsHooks: [],
+  readonlyVisitors: [],
 };
 
 // vi.fn() can be used with `new`; arrow functions cannot. Webpack and
@@ -144,6 +154,7 @@ describe('webpackDefaultsFactory', () => {
           beforeHooks: [vi.fn()],
           afterHooks: [],
           afterDeclarationsHooks: [],
+          readonlyVisitors: [],
         },
       );
 
@@ -152,6 +163,85 @@ describe('webpackDefaultsFactory', () => {
       ).not.toHaveBeenCalled();
       // IgnorePlugin only
       expect((config.plugins as any[]).length).toBe(1);
+    });
+
+    it('should pass baseUrl from tsconfig.json to TsconfigPathsPlugin', () => {
+      const mockReadFileSync = vi.mocked(fs.readFileSync);
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: './src-custom',
+          },
+        }),
+      );
+
+      webpackDefaultsFactory(
+        '/abs/src',
+        'src',
+        'main',
+        false,
+        'tsconfig.json',
+        emptyPlugins,
+      );
+
+      const { TsconfigPathsPlugin } = (
+        requireFns['tsconfig-paths-webpack-plugin'] as any
+      )();
+      expect(TsconfigPathsPlugin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: './src-custom',
+        }),
+      );
+    });
+
+    it('should default baseUrl to "." if not present in tsconfig.json', () => {
+      const mockReadFileSync = vi.mocked(fs.readFileSync);
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          compilerOptions: {},
+        }),
+      );
+
+      webpackDefaultsFactory(
+        '/abs/src',
+        'src',
+        'main',
+        false,
+        'tsconfig.json',
+        emptyPlugins,
+      );
+
+      const { TsconfigPathsPlugin } = (
+        requireFns['tsconfig-paths-webpack-plugin'] as any
+      )();
+      expect(TsconfigPathsPlugin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: '.',
+        }),
+      );
+    });
+
+    it('should default baseUrl to "." if tsconfig.json is invalid JSON', () => {
+      const mockReadFileSync = vi.mocked(fs.readFileSync);
+      mockReadFileSync.mockReturnValue('invalid json');
+
+      webpackDefaultsFactory(
+        '/abs/src',
+        'src',
+        'main',
+        false,
+        'tsconfig.json',
+        emptyPlugins,
+      );
+
+      const { TsconfigPathsPlugin } = (
+        requireFns['tsconfig-paths-webpack-plugin'] as any
+      )();
+      expect(TsconfigPathsPlugin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: '.',
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
`compilerOption.baseUrl` is deprecated with a hard notice in TypeScript v6 and dropped altogether in v7. However the `TsconfigPathsPlugin` for Webpack still uses it to rewrite the path aliases, and it won't compile correctly without it. 

Maintenance on that plugin is a bit stale so upstreaming a fix is unlikely to land. https://github.com/webpack/enhanced-resolve could replace it but it's outside the scope of this PR to assess the possible impact.

This patch simply reads the baseUrl from tsconfig if available, defaults to `.` if not, and passes it to the `TsconfigPathsPlugin`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`nest build` breaks when typescript is upgraded to v6 and `baseUrl` is removed from tsconfig

Issue Number: N/A


## What is the new behavior?

Read the baseUrl from tsconfig if available, default to `.` if not, and passes it to the `TsconfigPathsPlugin` so Webpack can resolve path aliases in TS v6+

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- See https://github.com/microsoft/TypeScript/issues/62207 for more information about the `baseUrl` deprecation