### PR TITLE
refactor(compiler): replace glob with an internal fs-based helper

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -1,6 +1,5 @@
 import * as chokidar from 'chokidar';
 import { copyFileSync, mkdirSync, rmSync, statSync } from 'fs';
-import { sync } from 'glob';
 import { dirname, join, sep } from 'path';
 import {
   ActionOnFile,
@@ -10,6 +9,7 @@ import {
 } from '../configuration/index.js';
 import { ERROR_PREFIX } from '../ui/index.js';
 import { copyPathResolve } from './helpers/copy-path-resolve.js';
+import { globSync } from './helpers/glob.js';
 import { getValueOrDefault } from './helpers/get-value-or-default.js';
 import {
   areOutsidePathsAllowed,
@@ -162,7 +162,7 @@ export class AssetsManager {
         };
 
         if (isWatchEnabled || item.watchAssets) {
-          const matchedPaths = sync(item.glob, {
+          const matchedPaths = globSync(item.glob, {
             ignore: item.exclude,
             dot: true,
           });
@@ -227,7 +227,7 @@ export class AssetsManager {
           this.watchers.push(watcher);
           this.watcherReadyPromises.push(settled);
         } else {
-          const matchedPaths = sync(item.glob, {
+          const matchedPaths = globSync(item.glob, {
             ignore: item.exclude,
             dot: true,
           });
@@ -235,7 +235,7 @@ export class AssetsManager {
             ? matchedPaths.filter((matched) => statSync(matched).isFile())
             : matchedPaths.flatMap((matched) => {
                 if (statSync(matched).isDirectory()) {
-                  return sync(`${matched}/**/*`, {
+                  return globSync(`${matched}/**/*`, {
                     ignore: item.exclude,
                   }).filter((file) => statSync(file).isFile());
                 }

--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -273,8 +273,7 @@ export class AssetsManager {
       }
 
       const libAssets = libProject.compilerOptions?.assets as
-        | Asset[]
-        | undefined;
+        Asset[] | undefined;
       if (!libAssets || libAssets.length <= 0) {
         continue;
       }

--- a/lib/compiler/helpers/glob.ts
+++ b/lib/compiler/helpers/glob.ts
@@ -1,3 +1,15 @@
+/**
+ * A minimal synchronous glob over `fs` + `minimatch`, covering just the
+ * surface `assets-manager` needs: one pattern, one optional `ignore`
+ * pattern, and `dot`.
+ *
+ * This replaced the `glob` package (see nestjs/nest-cli#3520), and asset
+ * copying is expected to behave exactly as it did before that swap. Several
+ * rules below therefore look arbitrary in isolation — zero-segment trailing
+ * globstars, the symlink depth budget — but each one preserves a documented
+ * behavior that build configurations already depend on. The tests in
+ * `test/lib/compiler/helpers/glob.spec.ts` pin them.
+ */
 import { Dirent, readdirSync, statSync } from 'fs';
 import { minimatch } from 'minimatch';
 
@@ -48,10 +60,10 @@ function splitPattern(pattern: string): { base: string; rest: string[] } {
 }
 
 /**
- * `minimatch` does not match `a/**` against `a`, but `glob` does — a trailing
- * globstar matches zero segments. Expanding the suffix restores that for the
- * include pattern, and for `ignore` it reproduces glob's behavior of pruning
- * the ignored directory itself rather than only its contents.
+ * A trailing globstar matches zero segments, so `a/**` must match `a`
+ * itself; `minimatch` alone does not. Expanding the suffix restores that for
+ * the include pattern, and for `ignore` it prunes the ignored directory
+ * itself rather than only its contents.
  */
 function expandGlobstarSuffix(pattern: string): string[] {
   return pattern.endsWith('/**') ? [pattern, pattern.slice(0, -3)] : [pattern];
@@ -64,17 +76,46 @@ interface WalkedEntry {
 }
 
 /**
+ * How far below a symlinked directory a pattern can still reach.
+ *
+ * A globstar never recurses *through* a symlinked directory, but the
+ * explicit segments that follow the last one keep matching normally once
+ * there. So a pattern ending in a bare globstar stops at the symlink itself
+ * and gets a budget of 0; adding one more segment after it reaches a single
+ * level inside (budget 1), and two segments reach two levels (budget 2). A
+ * pattern with no globstar at all does no recursion of this kind, so its own
+ * depth is the only bound.
+ *
+ * Returning a finite number also bounds the walk: symlink cycles terminate
+ * because each crossing costs depth we can never regain.
+ */
+function symlinkDepthBudget(rest: string[]): number {
+  for (let index = rest.length - 1; index >= 0; index--) {
+    if (rest[index].includes('**')) {
+      return rest.length - index - 1;
+    }
+  }
+  return rest.length;
+}
+
+/**
  * Walks the directory tree rooted at `dir`, without using `fs`'s own
  * `recursive` option so we can:
  *
- * - Skip an unreadable directory instead of failing the whole walk (`glob`
- *   returns whatever it found before the error, not nothing).
- * - Never follow a symlinked directory into further recursion, matching
- *   `glob`'s `follow: false` default and avoiding symlink cycles. A
- *   symlinked directory's immediate children are still listed (so a pattern
- *   can match one level in), just not walked any deeper.
+ * - Skip an unreadable directory instead of failing the whole walk: one
+ *   `EACCES` deep in an asset tree must not silently empty the result.
+ * - Stop descending once we are `budget` levels past a symlinked directory
+ *   (see `symlinkDepthBudget`), which also makes symlink cycles terminate.
+ *
+ * `depth` is how many levels below the nearest symlinked ancestor an entry
+ * sits; 0 means it was reached without crossing one.
  */
-function walk(dir: string, recursive: boolean): WalkedEntry[] {
+function walk(
+  dir: string,
+  recursive: boolean,
+  budget: number,
+  depth = 0,
+): WalkedEntry[] {
   let entries: Dirent[];
   try {
     entries = readdirSync(dir, { withFileTypes: true });
@@ -84,7 +125,10 @@ function walk(dir: string, recursive: boolean): WalkedEntry[] {
     return [];
   }
 
-  const results: WalkedEntry[] = entries.map((entry) => ({ parent: dir, entry }));
+  const results: WalkedEntry[] = entries.map((entry) => ({
+    parent: dir,
+    entry,
+  }));
 
   if (!recursive) {
     return results;
@@ -93,12 +137,19 @@ function walk(dir: string, recursive: boolean): WalkedEntry[] {
   for (const entry of entries) {
     const full = `${dir}/${entry.name}`;
 
+    // Below a symlink every further level costs budget; above one, plain
+    // directory recursion is unbounded.
     if (entry.isDirectory()) {
-      results.push(...walk(full, true));
+      const childDepth = depth === 0 ? 0 : depth + 1;
+      if (childDepth <= budget) {
+        results.push(...walk(full, true, budget, childDepth));
+      }
       continue;
     }
 
-    if (entry.isSymbolicLink()) {
+    // `Dirent.isDirectory()` is false for a symlink (it reports on the link
+    // itself), so a symlinked directory only ever reaches this branch.
+    if (entry.isSymbolicLink() && depth + 1 <= budget) {
       let stats;
       try {
         stats = statSync(full);
@@ -106,8 +157,7 @@ function walk(dir: string, recursive: boolean): WalkedEntry[] {
         continue;
       }
       if (stats.isDirectory()) {
-        // One level, not recursive: list children but don't descend further.
-        results.push(...walk(full, false));
+        results.push(...walk(full, true, budget, depth + 1));
       }
     }
   }
@@ -116,9 +166,8 @@ function walk(dir: string, recursive: boolean): WalkedEntry[] {
 }
 
 /**
- * Minimal synchronous glob over `fs` + `minimatch`, replacing the `glob`
- * package. Supports only the surface `assets-manager` needs: one pattern, one
- * optional `ignore` pattern, and `dot`.
+ * Expands `pattern` to every matching path, with the type of each entry.
+ * See the file header for the compatibility rules this preserves.
  */
 export function globEntriesSync(
   pattern: string,
@@ -158,7 +207,7 @@ export function globEntriesSync(
   // An asset may be configured for a directory that does not exist, or one
   // that turns out to be unreadable; `walk` reports no matches for it (and
   // any nested directories that fail) rather than failing the whole build.
-  const walked = walk(base, recursive);
+  const walked = walk(base, recursive, symlinkDepthBudget(rest));
 
   const matches: GlobEntry[] = [];
 
@@ -181,7 +230,7 @@ export function globEntriesSync(
   return matches;
 }
 
-/** Drop-in replacement for `glob`'s `sync` export. */
+/** Expands `pattern` to every matching path. */
 export function globSync(
   pattern: string,
   options: GlobSyncOptions = {},

--- a/lib/compiler/helpers/glob.ts
+++ b/lib/compiler/helpers/glob.ts
@@ -16,13 +16,18 @@ export interface GlobEntry {
 }
 
 /**
- * Characters that make a path segment a pattern rather than a literal.
+ * Characters that make a path segment a pattern rather than a literal, under
+ * minimatch's default options (no extglob).
  *
- * Deliberately over-inclusive: misreading a literal as a pattern only widens
- * the directory we walk (still correct, marginally slower), whereas the
- * reverse would have us stat a path that can never exist.
+ * Matches the literal chars `*`, `?`, `[`, `{` anywhere, plus `!`, `+`, `@`,
+ * `?`, or `*` immediately followed by `(` (an extglob-looking prefix, which
+ * minimatch still treats specially even without extglob enabled). Chars like
+ * `@`, `(`, `)`, `]`, `}` on their own are NOT magic here: treating them as
+ * such previously collapsed the literal base far above the real directory
+ * (e.g. an `@` in a username segment), causing `readdir` to walk huge trees
+ * and silently return no matches on the first unreadable subdirectory.
  */
-const MAGIC_CHARS = /[*?[\]{}()!+@]/;
+const MAGIC_CHARS = /[*?[{]|[!+@?*]\(/;
 
 const toPosix = (value: string): string => value.replace(/\\/g, '/');
 
@@ -50,6 +55,64 @@ function splitPattern(pattern: string): { base: string; rest: string[] } {
  */
 function expandGlobstarSuffix(pattern: string): string[] {
   return pattern.endsWith('/**') ? [pattern, pattern.slice(0, -3)] : [pattern];
+}
+
+interface WalkedEntry {
+  /** Always `/`-separated. */
+  parent: string;
+  entry: Dirent;
+}
+
+/**
+ * Walks the directory tree rooted at `dir`, without using `fs`'s own
+ * `recursive` option so we can:
+ *
+ * - Skip an unreadable directory instead of failing the whole walk (`glob`
+ *   returns whatever it found before the error, not nothing).
+ * - Never follow a symlinked directory into further recursion, matching
+ *   `glob`'s `follow: false` default and avoiding symlink cycles. A
+ *   symlinked directory's immediate children are still listed (so a pattern
+ *   can match one level in), just not walked any deeper.
+ */
+function walk(dir: string, recursive: boolean): WalkedEntry[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    // Unreadable or missing directory: contribute nothing here, but let
+    // sibling directories elsewhere in the walk still report their matches.
+    return [];
+  }
+
+  const results: WalkedEntry[] = entries.map((entry) => ({ parent: dir, entry }));
+
+  if (!recursive) {
+    return results;
+  }
+
+  for (const entry of entries) {
+    const full = `${dir}/${entry.name}`;
+
+    if (entry.isDirectory()) {
+      results.push(...walk(full, true));
+      continue;
+    }
+
+    if (entry.isSymbolicLink()) {
+      let stats;
+      try {
+        stats = statSync(full);
+      } catch {
+        continue;
+      }
+      if (stats.isDirectory()) {
+        // One level, not recursive: list children but don't descend further.
+        results.push(...walk(full, false));
+      }
+    }
+  }
+
+  return results;
 }
 
 /**
@@ -92,14 +155,10 @@ export function globEntriesSync(
   const recursive =
     rest.length > 1 || rest.some((segment) => segment.includes('**'));
 
-  let entries: Dirent[];
-  try {
-    entries = readdirSync(base, { recursive, withFileTypes: true });
-  } catch {
-    // An asset may be configured for a directory that does not exist; `glob`
-    // reports no matches rather than failing the build, so we do too.
-    return [];
-  }
+  // An asset may be configured for a directory that does not exist, or one
+  // that turns out to be unreadable; `walk` reports no matches for it (and
+  // any nested directories that fail) rather than failing the whole build.
+  const walked = walk(base, recursive);
 
   const matches: GlobEntry[] = [];
 
@@ -108,14 +167,8 @@ export function globEntriesSync(
     matches.push({ path: base, isFile: false, isDirectory: true });
   }
 
-  for (const entry of entries) {
-    // `parentPath` replaced the deprecated `path` in Node 20.12; keep the
-    // fallback while `engines.node` still allows 20.11. The double cast is
-    // required because @types/node@25 has already dropped `Dirent.path`.
-    const parent = toPosix(
-      entry.parentPath ?? (entry as unknown as { path: string }).path,
-    );
-    const full = `${parent}/${entry.name}`;
+  for (const { parent, entry } of walked) {
+    const full = `${toPosix(parent)}/${entry.name}`;
     if (accept(full)) {
       matches.push({
         path: full,

--- a/lib/compiler/helpers/glob.ts
+++ b/lib/compiler/helpers/glob.ts
@@ -1,0 +1,137 @@
+import { Dirent, readdirSync, statSync } from 'fs';
+import { minimatch } from 'minimatch';
+
+export interface GlobSyncOptions {
+  /** A single glob pattern; every path matching it is removed from the result. */
+  ignore?: string;
+  /** When true, `*` and `**` also match entries whose name starts with a dot. */
+  dot?: boolean;
+}
+
+export interface GlobEntry {
+  /** Absolute path, always `/`-separated regardless of platform. */
+  path: string;
+  isFile: boolean;
+  isDirectory: boolean;
+}
+
+/**
+ * Characters that make a path segment a pattern rather than a literal.
+ *
+ * Deliberately over-inclusive: misreading a literal as a pattern only widens
+ * the directory we walk (still correct, marginally slower), whereas the
+ * reverse would have us stat a path that can never exist.
+ */
+const MAGIC_CHARS = /[*?[\]{}()!+@]/;
+
+const toPosix = (value: string): string => value.replace(/\\/g, '/');
+
+/**
+ * Splits a pattern into the literal prefix we can hand to `readdir` and the
+ * trailing segments that still need matching: `/src/a/*.hbs` -> `/src/a`.
+ */
+function splitPattern(pattern: string): { base: string; rest: string[] } {
+  const segments = pattern.split('/');
+  const magicIndex = segments.findIndex((segment) => MAGIC_CHARS.test(segment));
+  if (magicIndex === -1) {
+    return { base: pattern, rest: [] };
+  }
+  return {
+    base: segments.slice(0, magicIndex).join('/') || '/',
+    rest: segments.slice(magicIndex),
+  };
+}
+
+/**
+ * `minimatch` does not match `a/**` against `a`, but `glob` does — a trailing
+ * globstar matches zero segments. Expanding the suffix restores that for the
+ * include pattern, and for `ignore` it reproduces glob's behavior of pruning
+ * the ignored directory itself rather than only its contents.
+ */
+function expandGlobstarSuffix(pattern: string): string[] {
+  return pattern.endsWith('/**') ? [pattern, pattern.slice(0, -3)] : [pattern];
+}
+
+/**
+ * Minimal synchronous glob over `fs` + `minimatch`, replacing the `glob`
+ * package. Supports only the surface `assets-manager` needs: one pattern, one
+ * optional `ignore` pattern, and `dot`.
+ */
+export function globEntriesSync(
+  pattern: string,
+  options: GlobSyncOptions = {},
+): GlobEntry[] {
+  const { ignore, dot = false } = options;
+  const normalized = toPosix(pattern);
+  const { base, rest } = splitPattern(normalized);
+
+  const includeMatchers = expandGlobstarSuffix(normalized);
+  const ignoreMatchers = ignore ? expandGlobstarSuffix(toPosix(ignore)) : [];
+
+  const accept = (candidate: string): boolean =>
+    includeMatchers.some((matcher) => minimatch(candidate, matcher, { dot })) &&
+    !ignoreMatchers.some((matcher) => minimatch(candidate, matcher, { dot }));
+
+  // No wildcard anywhere: the pattern names one concrete path.
+  if (rest.length === 0) {
+    const stats = statSync(normalized, { throwIfNoEntry: false });
+    if (!stats || !accept(normalized)) {
+      return [];
+    }
+    return [
+      {
+        path: normalized,
+        isFile: stats.isFile(),
+        isDirectory: stats.isDirectory(),
+      },
+    ];
+  }
+
+  // Only the immediate children of `base` can match a single trailing
+  // wildcard segment, so skip the deep walk in that (common) case.
+  const recursive =
+    rest.length > 1 || rest.some((segment) => segment.includes('**'));
+
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(base, { recursive, withFileTypes: true });
+  } catch {
+    // An asset may be configured for a directory that does not exist; `glob`
+    // reports no matches rather than failing the build, so we do too.
+    return [];
+  }
+
+  const matches: GlobEntry[] = [];
+
+  // A trailing `**` matches zero segments, so `base` itself can be a result.
+  if (accept(base)) {
+    matches.push({ path: base, isFile: false, isDirectory: true });
+  }
+
+  for (const entry of entries) {
+    // `parentPath` replaced the deprecated `path` in Node 20.12; keep the
+    // fallback while `engines.node` still allows 20.11. The double cast is
+    // required because @types/node@25 has already dropped `Dirent.path`.
+    const parent = toPosix(
+      entry.parentPath ?? (entry as unknown as { path: string }).path,
+    );
+    const full = `${parent}/${entry.name}`;
+    if (accept(full)) {
+      matches.push({
+        path: full,
+        isFile: entry.isFile(),
+        isDirectory: entry.isDirectory(),
+      });
+    }
+  }
+
+  return matches;
+}
+
+/** Drop-in replacement for `glob`'s `sync` export. */
+export function globSync(
+  pattern: string,
+  options: GlobSyncOptions = {},
+): string[] {
+  return globEntriesSync(pattern, options).map((entry) => entry.path);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "chokidar": "5.0.0",
         "cli-table3": "0.6.5",
         "commander": "15.0.0",
-        "glob": "13.0.6",
         "minimatch": "10.2.6",
         "node-emoji": "2.2.0",
         "ora": "9.4.1",
@@ -2130,72 +2129,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@module-federation/error-codes": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.8.2.tgz",
-      "integrity": "sha512-8inlDv48QOjA//CLQ3epjoHEiMQGsz1Pmtu2N+s7gQVggn6AYHpjnMe8AsyGxtpaPg3wbX0HmBZtRFggpXUB9A==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@module-federation/runtime": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.8.2.tgz",
-      "integrity": "sha512-SUoP+PD5EjSPSi6FxEPGIZoRkFifxdeYcVQbJE9mO0VEjF51gAk3/TgX8k0vzUryOBPmXekLr9SfQXU6DqUtvA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@module-federation/error-codes": "2.8.2",
-        "@module-federation/runtime-core": "2.8.2",
-        "@module-federation/sdk": "2.8.2"
-      }
-    },
-    "node_modules/@module-federation/runtime-core": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.8.2.tgz",
-      "integrity": "sha512-PEkkK9MUp+nUCeQMS4ox3QGZfwwxgfjGA7P4umEnr5c3y8DLNDR+26tyHf/Gkjen2VsjlcyL+mEAQo1Zi4IE3g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@module-federation/error-codes": "2.8.2",
-        "@module-federation/sdk": "2.8.2"
-      }
-    },
-    "node_modules/@module-federation/runtime-tools": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.8.2.tgz",
-      "integrity": "sha512-eW/yPvZB2LbpbyPXPTnOeF1ieWl165D9QcPV0y5Bj1QYGDjL2cb+dnzrBp0fmFtJhCYqmAdsVNoYItVa3yuJ3g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@module-federation/runtime": "2.8.2",
-        "@module-federation/webpack-bundler-runtime": "2.8.2"
-      }
-    },
-    "node_modules/@module-federation/sdk": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.8.2.tgz",
-      "integrity": "sha512-OPS/lbQjraLXoWniQpCwQ/vqgURHTrhsackSNcOPmcJHM3LyR+DabxUc0pl8jAqExsW2l+uepQq7+/Gkei871w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.8.2.tgz",
-      "integrity": "sha512-g4xQgfgMMCKgJjVMBh7nIYGjLGNDYwSZ4lfpTdkVyWDnxmR3SL6VPQTJEZHRYPyqvrTtZE1zdDhDd++yNRvLdA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@module-federation/error-codes": "2.8.2",
-        "@module-federation/runtime": "2.8.2",
-        "@module-federation/sdk": "2.8.2"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -3903,7 +3836,7 @@
       "version": "25.9.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
       "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -6665,22 +6598,6 @@
         "git-up": "^8.1.0"
       }
     },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -7802,14 +7719,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
-      "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/macos-release": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.5.1.tgz",
@@ -8115,14 +8024,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -8788,21 +8689,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-starts-with": {
@@ -10321,7 +10207,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",
@@ -12012,8 +11898,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12058,8 +11943,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12105,8 +11989,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12151,8 +12034,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12206,8 +12088,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12252,8 +12133,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12299,8 +12179,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12362,8 +12241,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12409,8 +12287,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12457,8 +12334,7 @@
         "@inquirer/type": {
           "version": "4.0.7",
           "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
-          "requires": {}
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g=="
         },
         "mute-stream": {
           "version": "3.0.0",
@@ -12520,72 +12396,6 @@
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true
-    },
-    "@module-federation/error-codes": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.8.2.tgz",
-      "integrity": "sha512-8inlDv48QOjA//CLQ3epjoHEiMQGsz1Pmtu2N+s7gQVggn6AYHpjnMe8AsyGxtpaPg3wbX0HmBZtRFggpXUB9A==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "@module-federation/runtime": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.8.2.tgz",
-      "integrity": "sha512-SUoP+PD5EjSPSi6FxEPGIZoRkFifxdeYcVQbJE9mO0VEjF51gAk3/TgX8k0vzUryOBPmXekLr9SfQXU6DqUtvA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@module-federation/error-codes": "2.8.2",
-        "@module-federation/runtime-core": "2.8.2",
-        "@module-federation/sdk": "2.8.2"
-      }
-    },
-    "@module-federation/runtime-core": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.8.2.tgz",
-      "integrity": "sha512-PEkkK9MUp+nUCeQMS4ox3QGZfwwxgfjGA7P4umEnr5c3y8DLNDR+26tyHf/Gkjen2VsjlcyL+mEAQo1Zi4IE3g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@module-federation/error-codes": "2.8.2",
-        "@module-federation/sdk": "2.8.2"
-      }
-    },
-    "@module-federation/runtime-tools": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.8.2.tgz",
-      "integrity": "sha512-eW/yPvZB2LbpbyPXPTnOeF1ieWl165D9QcPV0y5Bj1QYGDjL2cb+dnzrBp0fmFtJhCYqmAdsVNoYItVa3yuJ3g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@module-federation/runtime": "2.8.2",
-        "@module-federation/webpack-bundler-runtime": "2.8.2"
-      }
-    },
-    "@module-federation/sdk": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.8.2.tgz",
-      "integrity": "sha512-OPS/lbQjraLXoWniQpCwQ/vqgURHTrhsackSNcOPmcJHM3LyR+DabxUc0pl8jAqExsW2l+uepQq7+/Gkei871w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "@module-federation/webpack-bundler-runtime": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.8.2.tgz",
-      "integrity": "sha512-g4xQgfgMMCKgJjVMBh7nIYGjLGNDYwSZ4lfpTdkVyWDnxmR3SL6VPQTJEZHRYPyqvrTtZE1zdDhDd++yNRvLdA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@module-federation/error-codes": "2.8.2",
-        "@module-federation/runtime": "2.8.2",
-        "@module-federation/sdk": "2.8.2"
-      }
     },
     "@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -12765,8 +12575,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
       "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "17.0.0",
@@ -13541,7 +13350,7 @@
       "version": "25.9.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
       "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -13970,8 +13779,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -14129,8 +13937,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "bach": {
       "version": "2.0.1",
@@ -15208,8 +15015,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "figures": {
       "version": "6.1.0",
@@ -15489,16 +15295,6 @@
       "dev": true,
       "requires": {
         "git-up": "^8.1.0"
-      }
-    },
-    "glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "requires": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
       }
     },
     "glob-parent": {
@@ -16307,11 +16103,6 @@
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true
     },
-    "lru-cache": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
-      "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA=="
-    },
     "macos-release": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.5.1.tgz",
@@ -16482,11 +16273,6 @@
           }
         }
       }
-    },
-    "minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
     },
     "ms": {
       "version": "2.1.3",
@@ -16929,15 +16715,6 @@
       "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
       "dev": true
     },
-    "path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "requires": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      }
-    },
     "path-starts-with": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-starts-with/-/path-starts-with-2.0.0.tgz",
@@ -17128,8 +16905,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
       "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "proxy-from-env": {
       "version": "2.1.0",
@@ -18018,7 +17794,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "devOptional": true
+      "dev": true
     },
     "unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "chokidar": "5.0.0",
     "cli-table3": "0.6.5",
     "commander": "15.0.0",
-    "glob": "13.0.6",
     "minimatch": "10.2.6",
     "node-emoji": "2.2.0",
     "ora": "9.4.1",

--- a/test/actions/start.action.spec.ts
+++ b/test/actions/start.action.spec.ts
@@ -13,11 +13,6 @@ vi.mock('fs', () => ({
   readFileSync: vi.fn(),
 }));
 
-vi.mock('glob', () => ({
-  glob: vi.fn(),
-  globSync: vi.fn(() => []),
-}));
-
 vi.mock('../../lib/compiler/assets-manager.js', () => ({
   AssetsManager: vi.fn(
     class {

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -1,7 +1,7 @@
 import * as chokidar from 'chokidar';
 import { EventEmitter } from 'events';
 import { copyFileSync, statSync } from 'fs';
-import { sync as globSync } from 'glob';
+import { globSync } from '../../../lib/compiler/helpers/glob.js';
 import { join, sep } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AssetsManager } from '../../../lib/compiler/assets-manager.js';
@@ -12,8 +12,9 @@ vi.mock('chokidar', () => ({
   watch: vi.fn(),
 }));
 
-vi.mock('glob', () => ({
-  sync: vi.fn(),
+vi.mock('../../../lib/compiler/helpers/glob.js', () => ({
+  globSync: vi.fn(),
+  globEntriesSync: vi.fn(),
 }));
 
 vi.mock('fs', () => ({

--- a/test/lib/compiler/helpers/glob.spec.ts
+++ b/test/lib/compiler/helpers/glob.spec.ts
@@ -1,0 +1,189 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  globEntriesSync,
+  globSync,
+} from '../../../../lib/compiler/helpers/glob.js';
+
+describe('globSync', () => {
+  let root: string;
+  const rel = (paths: string[]) => paths.map((p) => p.replace(root, '')).sort();
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'nest-glob-')).replace(/\\/g, '/');
+    mkdirSync(join(root, 'src/assets/nested'), { recursive: true });
+    mkdirSync(join(root, 'src/.hidden'), { recursive: true });
+    mkdirSync(join(root, 'src/emptydir'), { recursive: true });
+    writeFileSync(join(root, 'src/top.hbs'), 'top');
+    writeFileSync(join(root, 'src/assets/a.hbs'), 'a');
+    writeFileSync(join(root, 'src/assets/.dotfile.hbs'), 'dot');
+    writeFileSync(join(root, 'src/assets/nested/b.hbs'), 'b');
+    writeFileSync(join(root, 'src/.hidden/d.hbs'), 'd');
+  });
+
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  describe('dot handling', () => {
+    it('includes dotfiles for a wildcard when dot is true', () => {
+      expect(rel(globSync(`${root}/src/assets/*`, { dot: true }))).toEqual([
+        '/src/assets/.dotfile.hbs',
+        '/src/assets/a.hbs',
+        '/src/assets/nested',
+      ]);
+    });
+
+    it('excludes dotfiles for a wildcard when dot is false', () => {
+      expect(rel(globSync(`${root}/src/assets/*`, { dot: false }))).toEqual([
+        '/src/assets/a.hbs',
+        '/src/assets/nested',
+      ]);
+    });
+
+    it('defaults dot to false when omitted', () => {
+      expect(rel(globSync(`${root}/src/assets/*`))).toEqual([
+        '/src/assets/a.hbs',
+        '/src/assets/nested',
+      ]);
+    });
+
+    it('matches dot entries through a globstar when dot is true', () => {
+      expect(rel(globSync(`${root}/src/**/*.hbs`, { dot: true }))).toEqual([
+        '/src/.hidden/d.hbs',
+        '/src/assets/.dotfile.hbs',
+        '/src/assets/a.hbs',
+        '/src/assets/nested/b.hbs',
+        '/src/top.hbs',
+      ]);
+    });
+
+    it('matches an explicit dot pattern regardless of the dot option', () => {
+      expect(rel(globSync(`${root}/src/assets/.*`, { dot: false }))).toEqual([
+        '/src/assets/.dotfile.hbs',
+      ]);
+    });
+  });
+
+  describe('pattern forms', () => {
+    it('returns a literal directory path unchanged', () => {
+      expect(rel(globSync(`${root}/src/assets`, { dot: true }))).toEqual([
+        '/src/assets',
+      ]);
+    });
+
+    it('returns a literal file path unchanged', () => {
+      expect(rel(globSync(`${root}/src/top.hbs`, { dot: true }))).toEqual([
+        '/src/top.hbs',
+      ]);
+    });
+
+    it('matches the base itself for a trailing globstar', () => {
+      expect(rel(globSync(`${root}/src/assets/**`, { dot: true }))).toEqual([
+        '/src/assets',
+        '/src/assets/.dotfile.hbs',
+        '/src/assets/a.hbs',
+        '/src/assets/nested',
+        '/src/assets/nested/b.hbs',
+      ]);
+    });
+
+    it('supports brace expansion', () => {
+      expect(
+        rel(globSync(`${root}/src/{assets,emptydir}/*`, { dot: false })),
+      ).toEqual(['/src/assets/a.hbs', '/src/assets/nested']);
+    });
+
+    it('supports a single-segment wildcard between literals', () => {
+      expect(rel(globSync(`${root}/src/*/*.hbs`, { dot: false }))).toEqual([
+        '/src/assets/a.hbs',
+      ]);
+    });
+
+    it('returns directories as well as files', () => {
+      expect(rel(globSync(`${root}/src/*`, { dot: false }))).toEqual([
+        '/src/assets',
+        '/src/emptydir',
+        '/src/top.hbs',
+      ]);
+    });
+  });
+
+  describe('ignore handling', () => {
+    it('drops matches under an ignored globstar', () => {
+      expect(
+        rel(
+          globSync(`${root}/src/**/*.hbs`, {
+            dot: true,
+            ignore: `${root}/src/assets/**`,
+          }),
+        ),
+      ).toEqual(['/src/.hidden/d.hbs', '/src/top.hbs']);
+    });
+
+    it('prunes the ignored directory itself, not only its contents', () => {
+      expect(
+        rel(
+          globSync(`${root}/src/assets/**/*`, {
+            dot: true,
+            ignore: `${root}/src/assets/nested/**`,
+          }),
+        ),
+      ).toEqual(['/src/assets/.dotfile.hbs', '/src/assets/a.hbs']);
+    });
+
+    it('drops an exact literal ignore match', () => {
+      expect(
+        rel(
+          globSync(`${root}/src/*`, {
+            dot: true,
+            ignore: `${root}/src/.hidden`,
+          }),
+        ),
+      ).toEqual(['/src/assets', '/src/emptydir', '/src/top.hbs']);
+    });
+  });
+
+  describe('missing paths', () => {
+    it('returns an empty array when the base directory does not exist', () => {
+      expect(globSync(`${root}/src/nonexistent/**/*`, { dot: true })).toEqual(
+        [],
+      );
+    });
+
+    it('returns an empty array for a literal path that does not exist', () => {
+      expect(globSync(`${root}/src/nonexistent.txt`, { dot: true })).toEqual(
+        [],
+      );
+    });
+
+    it('returns an empty array for an empty directory', () => {
+      expect(globSync(`${root}/src/emptydir/*`, { dot: true })).toEqual([]);
+    });
+  });
+
+  describe('globEntriesSync', () => {
+    it('reports the type of each match', () => {
+      const entries = globEntriesSync(`${root}/src/*`, { dot: false }).sort(
+        (a, b) => a.path.localeCompare(b.path),
+      );
+      expect(
+        entries.map((e) => ({
+          path: e.path.replace(root, ''),
+          isFile: e.isFile,
+          isDirectory: e.isDirectory,
+        })),
+      ).toEqual([
+        { path: '/src/assets', isFile: false, isDirectory: true },
+        { path: '/src/emptydir', isFile: false, isDirectory: true },
+        { path: '/src/top.hbs', isFile: true, isDirectory: false },
+      ]);
+    });
+
+    it('reports a literal directory as a directory', () => {
+      expect(globEntriesSync(`${root}/src/assets`, { dot: true })).toEqual([
+        { path: `${root}/src/assets`, isFile: false, isDirectory: true },
+      ]);
+    });
+  });
+});

--- a/test/lib/compiler/helpers/glob.spec.ts
+++ b/test/lib/compiler/helpers/glob.spec.ts
@@ -252,6 +252,56 @@ describe('globSync', () => {
     });
   });
 
+  describe('regression: how far a pattern reaches past a symlink', () => {
+    let linkRoot: string;
+    let supported = true;
+
+    beforeAll(() => {
+      linkRoot = join(root, 'linktree');
+      mkdirSync(join(linkRoot, 'real'), { recursive: true });
+      mkdirSync(join(linkRoot, 'assets'), { recursive: true });
+      writeFileSync(join(linkRoot, 'real/x.hbs'), 'x');
+      writeFileSync(join(linkRoot, 'assets/y.hbs'), 'y');
+
+      try {
+        symlinkSync(
+          join(linkRoot, 'real'),
+          join(linkRoot, 'assets/link'),
+          'dir',
+        );
+      } catch {
+        supported = false;
+      }
+    });
+
+    // A globstar stops AT a symlinked directory, but the explicit segments
+    // after it keep matching normally — so `assets/**` must not reach through
+    // `link`, while `assets/**/*` reaches exactly one level in.
+    it('a trailing globstar stops at the symlink itself', () => {
+      if (platform() === 'win32' || !supported) {
+        return;
+      }
+
+      expect(rel(globSync(`${linkRoot}/assets/**`, { dot: true }))).toEqual([
+        '/linktree/assets',
+        '/linktree/assets/link',
+        '/linktree/assets/y.hbs',
+      ]);
+    });
+
+    it('an explicit segment after the globstar reaches one level in', () => {
+      if (platform() === 'win32' || !supported) {
+        return;
+      }
+
+      expect(rel(globSync(`${linkRoot}/assets/**/*`, { dot: true }))).toEqual([
+        '/linktree/assets/link',
+        '/linktree/assets/link/x.hbs',
+        '/linktree/assets/y.hbs',
+      ]);
+    });
+  });
+
   describe('regression: partial results on an unreadable subdirectory', () => {
     it('still returns matches found outside the unreadable directory', () => {
       // chmod-based permission denial has no effect when running as root.

--- a/test/lib/compiler/helpers/glob.spec.ts
+++ b/test/lib/compiler/helpers/glob.spec.ts
@@ -1,5 +1,12 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { platform, tmpdir } from 'os';
 import { join } from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
@@ -184,6 +191,90 @@ describe('globSync', () => {
       expect(globEntriesSync(`${root}/src/assets`, { dot: true })).toEqual([
         { path: `${root}/src/assets`, isFile: false, isDirectory: true },
       ]);
+    });
+  });
+
+  describe('regression: narrow MAGIC_CHARS', () => {
+    it('finds files under a path segment containing "@"', () => {
+      mkdirSync(join(root, 'users/user@latam.com/src'), { recursive: true });
+      writeFileSync(join(root, 'users/user@latam.com/src/app.hbs'), 'app');
+
+      expect(
+        rel(globSync(`${root}/users/user@latam.com/src/**/*.hbs`)),
+      ).toEqual(['/users/user@latam.com/src/app.hbs']);
+    });
+
+    it('finds files under a path segment containing "(x86)"', () => {
+      mkdirSync(join(root, 'Program Files (x86)/@scope/src'), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(root, 'Program Files (x86)/@scope/src/app.hbs'),
+        'app',
+      );
+
+      expect(
+        rel(globSync(`${root}/Program Files (x86)/@scope/src/**/*.hbs`)),
+      ).toEqual(['/Program Files (x86)/@scope/src/app.hbs']);
+    });
+  });
+
+  describe('regression: symlinked directories are not followed', () => {
+    let symlinkRoot: string;
+
+    beforeAll(() => {
+      symlinkRoot = join(root, 'symtree');
+      mkdirSync(join(symlinkRoot, 'real'), { recursive: true });
+      writeFileSync(join(symlinkRoot, 'real/leaf.hbs'), 'leaf');
+
+      // A symlinked directory that cycles back to its own parent. Following
+      // it would recurse forever; the fix must list it as an entry without
+      // ever descending into `loop/real` or `loop/loop`.
+      try {
+        symlinkSync(symlinkRoot, join(symlinkRoot, 'loop'), 'dir');
+      } catch {
+        // Creating symlinks can require elevated privileges on Windows;
+        // skip silently there rather than failing the whole run.
+      }
+    });
+
+    it('does not follow a symlinked directory (no infinite loop, no double count)', () => {
+      if (platform() === 'win32') {
+        return;
+      }
+
+      const matches = rel(globSync(`${symlinkRoot}/**/*.hbs`));
+
+      // Only the real file is matched; nothing is found through `loop`,
+      // because the walk lists `loop`'s immediate children but never
+      // descends into `loop/real` or `loop/loop`.
+      expect(matches).toEqual(['/symtree/real/leaf.hbs']);
+    });
+  });
+
+  describe('regression: partial results on an unreadable subdirectory', () => {
+    it('still returns matches found outside the unreadable directory', () => {
+      // chmod-based permission denial has no effect when running as root.
+      if (platform() === 'win32' || process.getuid?.() === 0) {
+        return;
+      }
+
+      const unreadableRoot = join(root, 'partial');
+      mkdirSync(join(unreadableRoot, 'ok'), { recursive: true });
+      mkdirSync(join(unreadableRoot, 'blocked'), { recursive: true });
+      writeFileSync(join(unreadableRoot, 'ok/keep.hbs'), 'keep');
+      writeFileSync(join(unreadableRoot, 'blocked/hidden.hbs'), 'hidden');
+
+      chmodSync(join(unreadableRoot, 'blocked'), 0o000);
+
+      try {
+        expect(rel(globSync(`${unreadableRoot}/**/*.hbs`))).toEqual([
+          '/partial/ok/keep.hbs',
+        ]);
+      } finally {
+        // Restore permissions so `afterAll`'s recursive rmSync can clean up.
+        chmodSync(join(unreadableRoot, 'blocked'), 0o755);
+      }
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`glob` is a runtime dependency used in exactly one place — `lib/compiler/assets-manager.ts`, at three call sites — for a narrow slice of its feature set: one pattern, one optional `ignore` pattern, and `dot`.

It pulls in `path-scurry`, `lru-cache` and `minipass` as exclusive transitives, roughly 3.4 MB installed, for that one usage.

Issue Number: closes #3520

## What is the new behavior?

`glob` is removed and replaced by a small internal helper (`lib/compiler/helpers/glob.ts`) built on `fs.readdirSync` and `minimatch`. `minimatch` was already a direct dependency, used by `lib/compiler/swc/swc-compiler.ts`, so nothing new is added.

**Why not `fs.globSync`?** The issue suggests Node's built-in, but it has no `dot` option and silently ignores one if passed. `dot: true` is load-bearing here — it was added in 3664ed06 to unify watched and non-watched asset copying, so dropping it would stop dotfile assets being copied. `fs.globSync` also requires Node 22, while `engines.node` is `>= 20.11`, so it would have forced an engine bump regardless.

The helper is a drop-in for `glob`'s `sync` export. The non-obvious behaviours it preserves, each pinned by a test:

- **A trailing globstar matches zero segments** — `a/**` matches `a` itself. `minimatch` alone does not do this.
- **`ignore` prunes the ignored directory itself**, not only its contents.
- **A globstar does not recurse *through* a symlinked directory**, but the explicit segments after it keep matching normally — `assets/**` stops at the symlink, `assets/**/*` reaches one level in. This is derived as a depth budget from the pattern, which also makes symlink cycles terminate.
- **An unreadable subdirectory is skipped**, not fatal — one `EACCES` deep in an asset tree must not silently empty the result.
- **Only real glob metacharacters split the pattern.** An earlier revision of this branch also treated `@ ( ) [ ] { } ! +` as metacharacters, which collapsed the scan base to a distant ancestor on any project path containing them — `user@company.com`, `Program Files (x86)`, `node_modules/@scope/` — producing a **silent zero-asset build**. There are regression tests for both shapes.

Parity was verified differentially against `glob@13` on fixtures containing `@` and `(x86)` in the path, a symlink cycle, and an unreadable subdirectory.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

Asset copying is intended to behave exactly as before. No public API changes, and no change to `engines.node`.


## Other information

**Docs checkbox** is unchecked because this is an internal refactor with no user-facing surface — there is nothing in the docs describing how asset globbing is implemented. Happy to add something if you disagree.

**A weak existing test, worth flagging.** `test/e2e/library-assets.e2e-spec.ts` configures `assets: ['templates/**/*.hbs']` but only asserts that `main.js` files exist — it never asserts the `.hbs` file reached `dist`, so it passes even when zero assets are copied. It did not catch the metacharacter bug described above. Happy to tighten it here or in a follow-up.

**Lockfile note.** Regenerating `package-lock.json` also drops six `@module-federation/*` entries. These are unrelated to this change — an optional-peer closure npm stopped materialising after the `@rspack/core` v1 → v2 bump in 54d429df, which `npm install` drops deterministically on the current lockfile regardless of this PR. Restoring them by hand would produce a lockfile npm did not generate. Happy to split them out if you'd prefer.

**Follow-ups, deliberately not included here:**

- `assets-manager.ts` passes `dot: true` at two call sites but not at the directory-expansion one, so a dotfile inside a matched directory is copied in watch mode but not in a plain build. Preserved verbatim to keep this change behaviour-neutral, but it looks like a genuine latent bug and deserves its own issue.
- `globEntriesSync` exposes entry types, so the per-path `statSync` calls in `assets-manager` could be dropped. Left out to keep this diff reviewable. Note for whoever picks it up: that helper's `isFile`/`isDirectory` flags follow symlinks in the literal-path branch but not in the walk branch, so a naive swap would stop copying symlinked asset files.

---

Thanks to Claude Opus 5