### PR TITLE
fix(compiler): copy dotfiles when expanding a directory asset

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -237,6 +237,7 @@ export class AssetsManager {
                 if (statSync(matched).isDirectory()) {
                   return globSync(`${matched}/**/*`, {
                     ignore: item.exclude,
+                    dot: true,
                   }).filter((file) => statSync(file).isFile());
                 }
                 return matched;

--- a/test/e2e/build.command.e2e-spec.ts
+++ b/test/e2e/build.command.e2e-spec.ts
@@ -41,9 +41,7 @@ describe('Build Command (e2e)', () => {
     expect(fileExists(distDir)).toBe(true);
     expect(fileExists(path.join(distDir, 'main.js'))).toBe(true);
     expect(fileExists(path.join(distDir, 'app.module.js'))).toBe(true);
-    expect(fileExists(path.join(distDir, 'app.controller.js'))).toBe(
-      true,
-    );
+    expect(fileExists(path.join(distDir, 'app.controller.js'))).toBe(true);
     expect(fileExists(path.join(distDir, 'app.service.js'))).toBe(true);
   });
 
@@ -71,9 +69,7 @@ describe('Build Command (e2e)', () => {
       );
 
       // dist should be produced
-      expect(fileExists(path.join(appPath, 'dist', 'main.js'))).toBe(
-        true,
-      );
+      expect(fileExists(path.join(appPath, 'dist', 'main.js'))).toBe(true);
     } finally {
       proc.kill();
     }
@@ -183,6 +179,81 @@ describe('Build Command (e2e)', () => {
       expect(fileExists(path.join(distDir, 'main.js'))).toBe(true);
       // Without the flag, declaration files should NOT be present
       expect(fileExists(path.join(distDir, 'app.module.d.ts'))).toBe(false);
+    });
+  });
+
+  describe('dotfiles in a directory asset (#3522)', () => {
+    // A bare directory entry ("assets": ["config"]) is expanded by a second
+    // glob call inside the assets manager. That call used to drop dot-prefixed
+    // entries, so `nest build` copied strictly fewer files than the same
+    // config under `--watchAssets`, which uses chokidar and has no dot filter.
+    const nestCliPath = () => path.join(appPath, 'nest-cli.json');
+    const envsDir = () => path.join(appPath, 'src', 'config', 'envs');
+    let originalNestCli: string;
+
+    beforeAll(() => {
+      // The scaffolded app ships its own @nestjs/cli in node_modules, and the
+      // CLI hands off to that local copy when present — which would test the
+      // published build instead of this working tree.
+      removeLocalCli(appPath);
+
+      originalNestCli = fs.readFileSync(nestCliPath(), 'utf-8');
+      fs.mkdirSync(envsDir(), { recursive: true });
+      fs.writeFileSync(path.join(envsDir(), '.development'), 'SECRET=1');
+      fs.writeFileSync(path.join(envsDir(), 'prod.env'), 'X=1');
+    });
+
+    afterAll(() => {
+      fs.writeFileSync(nestCliPath(), originalNestCli);
+      fs.rmSync(path.join(appPath, 'src', 'config'), {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    function setAssets(assets: string[]) {
+      const config = JSON.parse(fs.readFileSync(nestCliPath(), 'utf-8'));
+      config.compilerOptions = { ...config.compilerOptions, assets };
+      fs.writeFileSync(nestCliPath(), JSON.stringify(config, null, 2));
+    }
+
+    /**
+     * Where the copied `envs` directory ends up depends on the effective
+     * rootDir (see #3387), so locate it rather than hard-coding a layout: the
+     * claim under test is that both files land in the *same* place.
+     */
+    function findCopiedEnvsDir(): string | undefined {
+      const distDir = path.join(appPath, 'dist');
+      const entries = fs.readdirSync(distDir, {
+        recursive: true,
+        encoding: 'utf-8',
+      });
+      const match = entries.find(
+        (entry) => path.basename(entry) === 'prod.env',
+      );
+      return match ? path.dirname(path.join(distDir, match)) : undefined;
+    }
+
+    it('should copy a dotfile nested under a bare directory asset', () => {
+      cleanDist();
+      setAssets(['config']);
+
+      runNest('build', appPath);
+
+      const copiedEnvs = findCopiedEnvsDir();
+      expect(copiedEnvs).toBeDefined();
+      expect(fileExists(path.join(copiedEnvs!, '.development'))).toBe(true);
+    });
+
+    it('should keep copying dotfiles for the wildcard asset form', () => {
+      cleanDist();
+      setAssets(['config/envs/*']);
+
+      runNest('build', appPath);
+
+      const copiedEnvs = findCopiedEnvsDir();
+      expect(copiedEnvs).toBeDefined();
+      expect(fileExists(path.join(copiedEnvs!, '.development'))).toBe(true);
     });
   });
 });

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -802,4 +802,69 @@ describe('AssetsManager', () => {
       );
     });
   });
+  describe('directory asset without a wildcard (#3522)', () => {
+    // A bare directory entry (e.g. "assets": ["config"]) takes the
+    // expansion branch: the outer glob resolves the directory itself, then a
+    // second glob walks it. Both must honour `dot`, otherwise a plain
+    // `nest build` silently drops dotfiles that `--watchAssets` copies.
+    const sourceRoot = join(process.cwd(), 'src').replace(/\\/g, '/');
+    const configDir = `${sourceRoot}/config`;
+    const dotfile = `${configDir}/envs/.development`;
+    const plainFile = `${configDir}/envs/prod.env`;
+
+    const arrangeDirectoryAsset = (exclude?: string) => {
+      vi.mocked(statSync).mockImplementation(
+        ((path: string) =>
+          ({
+            isFile: () => path !== configDir,
+            isDirectory: () => path === configDir,
+          }) as any) as any,
+      );
+
+      vi.mocked(globSync)
+        .mockReturnValueOnce([configDir]) // the asset entry resolves to a directory
+        .mockReturnValueOnce([dotfile, plainFile]); // its expansion
+
+      vi.mocked(getValueOrDefault)
+        .mockReturnValueOnce([
+          exclude ? { include: 'config', exclude } : 'config',
+        ] as any) // assets
+        .mockReturnValueOnce([]) // includeLibraryAssets
+        .mockReturnValueOnce('src') // sourceRoot
+        .mockReturnValueOnce(false) // compilerOptions.watchAssets
+        .mockReturnValueOnce(undefined); // compilerOptions.allowOutsidePaths
+    };
+
+    it('should expand the directory with dot enabled', () => {
+      arrangeDirectoryAsset();
+
+      assetsManager.copyAssets({} as any, undefined, 'dist', false);
+
+      expect(globSync).toHaveBeenNthCalledWith(2, `${configDir}/**/*`, {
+        ignore: undefined,
+        dot: true,
+      });
+    });
+
+    it('should copy a dotfile nested in the directory, like watch mode does', () => {
+      arrangeDirectoryAsset();
+
+      assetsManager.copyAssets({} as any, undefined, 'dist', false);
+
+      expect(copyFileSync).toHaveBeenCalledWith(dotfile, expect.any(String));
+      expect(copyFileSync).toHaveBeenCalledWith(plainFile, expect.any(String));
+    });
+
+    it('should still forward the exclude pattern when expanding', () => {
+      const exclude = 'config/**/*.env';
+      arrangeDirectoryAsset(exclude);
+
+      assetsManager.copyAssets({} as any, undefined, 'dist', false);
+
+      expect(globSync).toHaveBeenNthCalledWith(2, `${configDir}/**/*`, {
+        ignore: `${sourceRoot}/config/**/*.env`,
+        dot: true,
+      });
+    });
+  });
 });

--- a/test/lib/compiler/helpers/glob.spec.ts
+++ b/test/lib/compiler/helpers/glob.spec.ts
@@ -302,6 +302,28 @@ describe('globSync', () => {
     });
   });
 
+  describe('regression: directory expansion drops dotfiles (#3522)', () => {
+    // The exact shape `assets-manager` builds when an asset entry is a bare
+    // directory: `<dir>/**/*`. A plain `nest build` must see the same files
+    // `--watchAssets` does, which means this pattern has to honour `dot`.
+    it('includes dotfiles under the directory when dot is true', () => {
+      expect(rel(globSync(`${root}/src/assets/**/*`, { dot: true }))).toEqual([
+        '/src/assets/.dotfile.hbs',
+        '/src/assets/a.hbs',
+        '/src/assets/nested',
+        '/src/assets/nested/b.hbs',
+      ]);
+    });
+
+    it('omits them without dot, which is what caused the bug', () => {
+      expect(rel(globSync(`${root}/src/assets/**/*`))).toEqual([
+        '/src/assets/a.hbs',
+        '/src/assets/nested',
+        '/src/assets/nested/b.hbs',
+      ]);
+    });
+  });
+
   describe('regression: partial results on an unreadable subdirectory', () => {
     it('still returns matches found outside the unreadable directory', () => {
       // chmod-based permission denial has no effect when running as root.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #3522

When an `assets` entry is a **plain directory path (no trailing `*`)**, dotfiles inside that directory are copied in `--watchAssets` mode but silently skipped by a plain `nest build`.

Given `"assets": ["config"]` and `src/config/envs/.development`:

| Command | `dist/config/envs` contains |
| --- | --- |
| `nest build` | `prod.env` only — **`.development` is missing** |
| `nest build --watchAssets` | `.development`, `prod.env` |

`lib/compiler/assets-manager.ts` has three glob call sites, and only two of them pass `dot: true`:

```ts
// watch branch: has dot
const matchedPaths = globSync(item.glob, { ignore: item.exclude, dot: true });

// plain-build branch: has dot
const matchedPaths = globSync(item.glob, { ignore: item.exclude, dot: true });

const files = item.glob.endsWith('*')
  ? matchedPaths.filter((matched) => statSync(matched).isFile())
  : matchedPaths.flatMap((matched) => {
      if (statSync(matched).isDirectory()) {
        // directory expansion: NO dot  <-- bug
        return globSync(`${matched}/**/*`, {
          ignore: item.exclude,
        }).filter((file) => statSync(file).isFile());
      }
      return matched;
    });
```

Since glob does not match dotfiles unless `dot: true` is set, the expansion drops every dotfile under the matched directory. Chokidar, on the watch side, has no such default — hence the divergence.

The wildcard form (`"assets": ["config/envs/*"]`) is **not** affected: it takes the `endsWith('*')` branch, which does receive `dot: true`. Only entries that do not end in `*` and resolve to a directory hit this.

**How the fix from #2660 got lost.** Both PRs branched from the same blob of `assets-manager.ts` (`c71bef10`), and neither is an ancestor of the other:

| Date | Commit | Event |
| --- | --- | --- |
| 2024-07-19 | `3664ed06` | #2660 authored. At that time the else-branch had a **single** `sync()` call; the PR adds `dot: true` to it. |
| 2024-08-09 | `793f3193` | #2687 merged (*"copy nested files and directories when no wildcard"*). It **replaces** that one call with two — outer `matchedPaths` + inner <code>sync(\`${matched}/**/*\`)</code>. Its base predates #2660, so neither call has `dot`. |
| 2024-10-21 | `486ac60e` | Merge commit *"chore: resolve conflicts"* finally lands #2660. The resolution puts `dot: true` back on the **outer** call, but the inner expansion call — which #2660's author never saw — is left without it. |

So this is not something #2660 overlooked; it is a merge-resolution gap against a call site introduced while #2660 was open. #2653 looks fixed because its reproduction used `config/envs/*`, which takes the working path.

## What is the new behavior?

`dot: true` is passed at the third call site as well, so `nest build` and `nest build --watchAssets` copy the same set of files — the parity #2660 established.

Tests were added at three levels:

| File | What it pins |
| --- | --- |
| `test/lib/compiler/assets-manager.spec.ts` | The expansion call is made with `dot: true`, both files are copied, and `exclude` is still forwarded alongside it |
| `test/lib/compiler/helpers/glob.spec.ts` | On the real filesystem: `<dir>/**/*` includes dotfiles with `dot`, omits them without — the helper contract the fix depends on |
| `test/e2e/build.command.e2e-spec.ts` | A real `nest build` on a scaffolded app copies `.development` under a bare directory asset, and the wildcard form still does too |

With the one-line fix reverted, the bare-directory e2e test fails while the wildcard one still passes — exactly the asymmetry the issue describes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

Worth flagging even so: the fix copies **strictly more files** than before, so it is technically an observable change. Anyone who was relying on `nest build` silently skipping dotfiles under a directory asset (a stray `.DS_Store`, or a `.env` they assumed was not shipping) will see new files appear in `dist`. It restores documented-intent parity and matches what the same config already does in watch mode, so I have raised it as a `fix` — but if you would rather it rode a minor, that is your call.

## Other information

**Affected versions.** Present in `@nestjs/cli@11.0.24` (current `latest`) and on `master` at `12.0.0-alpha.5`, verified independently against `glob@13.0.6` and against the current internal `globSync` helper.

**Two unrelated things I ran into while writing the e2e tests**, neither addressed here:

1. Three pre-existing tests in `build.command.e2e-spec.ts` fail on `master` — *"default tsc compiler"*, *"custom tsconfig path using `--path`"*, and *"`--watch` mode initial compilation"*. They expect `dist/main.js`, but the scaffolded app emits to `dist/src/main.js`: the new-app template now ships root-level `vitest.config.ts` / `vitest.config.e2e.ts`, which widen the computed rootDir to the project root. I confirmed these fail without my changes applied. Either the template or those expectations needs updating — happy to open a separate issue.

2. The scaffolded app carries its own published `@nestjs/cli` in `node_modules`, and the CLI hands off to that local copy, so an e2e test can silently exercise the released build instead of the working tree. `library-assets.e2e-spec.ts` already calls `removeLocalCli` for this reason; the new block here does too.

Because of (1), the new e2e assertions *locate* the copied `prod.env` under `dist` and check that `.development` sits beside it, rather than hard-coding an output layout that is currently in question.

---

Thanks to Claude Opus 5