### PR TITLE
fix(assets): don't corrupt outdir for includes outside sourceroot

### DIFF
--- a/lib/compiler/assets-manager.ts
+++ b/lib/compiler/assets-manager.ts
@@ -1,6 +1,6 @@
 import * as chokidar from 'chokidar';
 import { copyFileSync, mkdirSync, rmSync, statSync } from 'fs';
-import { dirname, join, sep } from 'path';
+import { basename, dirname, join, resolve, sep } from 'path';
 import {
   ActionOnFile,
   Asset,
@@ -343,11 +343,29 @@ export class AssetsManager {
     // Set path value to true for watching the first time
     this.watchAssetsKeyValue[assetCheckKey] = true;
 
-    let dest = copyPathResolve(
-      path,
-      item.outDir!,
-      sourceRoot.split(sep).length,
-    );
+    // "flat" bypasses the sourceRoot-relative stripping entirely and copies
+    // the file to "outDir" by its basename. This is the only way to target an
+    // "include" path that lives outside "sourceRoot" (e.g. the project's own
+    // package.json, needed one directory up for Node's subpath imports to
+    // resolve against the compiled output) without hitting the stripping
+    // logic below, which assumes the file is somewhere under "sourceRoot".
+    let dest = item.flat
+      ? join(item.outDir!, basename(path))
+      : copyPathResolve(path, item.outDir!, sourceRoot.split(sep).length);
+
+    // When "include" resolves outside "sourceRoot" (and "flat" isn't set),
+    // stripping sourceRoot's segment count from the file's path can consume
+    // the filename itself, collapsing the destination to "outDir" — silently
+    // overwriting the output directory with the asset's contents before the
+    // compiler even runs. Fail loudly instead.
+    if (!item.flat && resolve(dest) === resolve(item.outDir!)) {
+      throw new Error(
+        `Refusing to copy "${path}" to "${item.outDir}": the "include" path is not deep enough under ` +
+          `"sourceRoot" for any path segment to survive stripping, so the file would overwrite the ` +
+          `"outDir" directory itself. Move the file inside "sourceRoot", or set "flat": true on this ` +
+          `"assets" entry to copy it into "${item.outDir}" by its basename instead.`,
+      );
+    }
 
     // The destination is re-checked per file: the configured "outDir" is
     // validated up front, but a symlinked directory *inside* it would still

--- a/test/lib/compiler/assets-manager.spec.ts
+++ b/test/lib/compiler/assets-manager.spec.ts
@@ -727,6 +727,91 @@ describe('AssetsManager', () => {
     });
   });
 
+  describe('outDir collapse guard', () => {
+    it('throws instead of overwriting outDir when stripping consumes the whole path', () => {
+      // "../package.json" resolves outside "sourceRoot" (src/); stripping
+      // sourceRoot's segment count from it consumes the filename too, so
+      // copyPathResolve would otherwise return "dist" itself.
+      vi.mocked(globSync).mockReturnValue(['/cwd/package.json']);
+      vi.mocked(copyPathResolve).mockReturnValue('dist');
+      vi.mocked(getValueOrDefault)
+        .mockReturnValueOnce([{ include: '../package.json' }]) // assets
+        .mockReturnValueOnce([]) // includeLibraryAssets
+        .mockReturnValueOnce('src') // sourceRoot
+        .mockReturnValueOnce(false) // compilerOptions.watchAssets
+        .mockReturnValueOnce(undefined); // compilerOptions.allowOutsidePaths
+
+      expect(() =>
+        assetsManager.copyAssets({} as any, undefined, 'dist', false),
+      ).toThrow(/would overwrite the "outDir" directory itself/);
+
+      expect(copyFileSync).not.toHaveBeenCalled();
+
+      vi.mocked(copyPathResolve).mockReturnValue(
+        `${process.cwd()}/dist/file.txt`,
+      );
+    });
+
+    it('does not throw when flat is set, even for a path outside sourceRoot', () => {
+      vi.mocked(globSync).mockReturnValue(['/cwd/package.json']);
+      vi.mocked(copyPathResolve).mockReturnValue('dist');
+      vi.mocked(getValueOrDefault)
+        .mockReturnValueOnce([{ include: '../package.json', flat: true }]) // assets
+        .mockReturnValueOnce([]) // includeLibraryAssets
+        .mockReturnValueOnce('src') // sourceRoot
+        .mockReturnValueOnce(false) // compilerOptions.watchAssets
+        .mockReturnValueOnce(undefined); // compilerOptions.allowOutsidePaths
+
+      expect(() =>
+        assetsManager.copyAssets({} as any, undefined, 'dist', false),
+      ).not.toThrow();
+
+      expect(copyFileSync).toHaveBeenCalled();
+
+      vi.mocked(copyPathResolve).mockReturnValue(
+        `${process.cwd()}/dist/file.txt`,
+      );
+    });
+  });
+
+  describe('flat option', () => {
+    it('copies to outDir by basename, bypassing sourceRoot-relative stripping', () => {
+      vi.mocked(globSync).mockReturnValue(['/cwd/package.json']);
+      vi.mocked(getValueOrDefault)
+        .mockReturnValueOnce([{ include: '../package.json', flat: true }]) // assets
+        .mockReturnValueOnce([]) // includeLibraryAssets
+        .mockReturnValueOnce('src') // sourceRoot
+        .mockReturnValueOnce(false) // compilerOptions.watchAssets
+        .mockReturnValueOnce(undefined); // compilerOptions.allowOutsidePaths
+
+      assetsManager.copyAssets({} as any, undefined, 'dist', false);
+
+      // copyPathResolve's sourceRoot-relative stripping is skipped entirely.
+      expect(copyPathResolve).not.toHaveBeenCalled();
+      expect(copyFileSync).toHaveBeenCalledWith(
+        '/cwd/package.json',
+        join(process.cwd(), 'dist', 'package.json'),
+      );
+    });
+
+    it('still confines a flat destination to the project directory', () => {
+      vi.mocked(globSync).mockReturnValue(['/cwd/package.json']);
+      vi.mocked(getValueOrDefault)
+        .mockReturnValueOnce([
+          { include: '../package.json', outDir: '../../etc', flat: true },
+        ]) // assets
+        .mockReturnValueOnce([]) // includeLibraryAssets
+        .mockReturnValueOnce('src') // sourceRoot
+        .mockReturnValueOnce(false) // compilerOptions.watchAssets
+        .mockReturnValueOnce(undefined); // compilerOptions.allowOutsidePaths
+
+      expect(() =>
+        assetsManager.copyAssets({} as any, undefined, 'dist', false),
+      ).toThrow(/outside of or equal to the project directory/);
+      expect(copyFileSync).not.toHaveBeenCalled();
+    });
+  });
+
   describe('path confinement', () => {
     it('should reject an asset outDir outside the project before watching', () => {
       const mockWatcher = new EventEmitter() as any;


### PR DESCRIPTION
### What

Two related fixes in `AssetsManager`/`actionOnFile`:

1. When an `assets[].include` path resolves outside `sourceRoot` (e.g. the project's own `package.json`, one directory above `src/`), the sourceRoot-relative segment stripping can consume the filename itself, collapsing the destination to `outDir`. This silently overwrote `outDir` with the asset's contents before the compiler ran, corrupting the entire build. Now throws a clear error instead.
2. `assets[].flat` was declared in `configuration.d.ts` and threaded through `filesToCopy`/`collectLibraryAssets`, but never actually consulted when resolving the destination — setting it had no effect. It's now honored: `join(outDir, basename(path))`, bypassing the sourceRoot-relative stripping entirely. This is the escape hatch that makes (1) actionable instead of just diagnostic.

### Why

Copying a project's own `package.json` into `dist/` is needed to support Node's native [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) (`imports` field, `#specifier`) in an ESM (`"type": "module"`) project: Node resolves `#specifier` against the nearest `package.json` walking up from the *compiled* file doing the import, and `dist/` doesn't have one on its own. `package.json` always lives outside `sourceRoot`, which made this fail — see minimal repro: https://github.com/Roman991/nest-subpath-imports-repro

### Before / after (repro's `nest-cli.json`)

```json
{ "sourceRoot": "src", "compilerOptions": { "assets": [{ "include": "../package.json", "outDir": "dist" }] } }
```

```
# before
$ rm -rf dist && npx nest build
error TS5033: Could not write file '.../dist/main.js': ENOENT: no such file or directory, ...
$ file dist
dist: JSON text data          # outDir is now a *file*

# after
$ rm -rf dist && npx nest build
error  An error occurred during the assets copying process. Refusing to copy ".../package.json" to "dist": the "include" path is not deep enough under "sourceRoot" for any path segment to survive stripping, so the file would overwrite the "outDir" directory itself. Move the file inside "sourceRoot", or set "flat": true on this "assets" entry to copy it into "dist" by its basename instead.
```

With `"flat": true` added to the same entry:

```
$ rm -rf dist && npx nest build   # exit 0
$ find dist -type f
dist/app.module.js
dist/lib/hello.service.js
dist/main.js
dist/package.json
```

Verified end-to-end against the linked repro (with `rootDir: "."` added there so `dist/`he same `package.json` works unmodified for both the source tree and the compiled output — no custom `postbuild` script needed): `nest build` + `node dist/src/main.js`, `nest start`, and `nest start --watch` all correctly resolve the `#lib/*` subpath import.

### Backward compatibility

`copyPathResolve` itself is untouched — the existing unit test asserting it returns `outDir` when all segments are stripped (`copy-path-resolve.spec.ts`) still passes unchanged. The new behavior is a guard
at the call site in `actionOnFile`, which is where that return value was actually being

### Tests

Added to `test/lib/compiler/assets-manager.spec.ts`: throws instead of overwriting `outDir` when stripping consumes the whole path; does not throw when `flat` is set for the same case; `flat` copies to `outDir` by basename, bypassing `copyPathResolve` entirely; a `flat` destination is still confined to the project directory (`allowOutsidePaths` respected).

`npx vitest run` — 989 passing; the 3 pre-existing failures (`tsconfig-provider.spec.ts`s`) are present identically on `master` before this change and unrelated to`assets-manager`/`copy-path-resolve`.