### PR TITLE
fix(compiler): support ESM and CJS rspack config

### DIFF
--- a/actions/build.action.ts
+++ b/actions/build.action.ts
@@ -34,6 +34,11 @@ import type webpack from 'webpack';
 
 const require = createRequire(import.meta.url);
 
+type RspackConfigFactory = Record<string, any> | ((
+  config: Record<string, any>,
+  rspackRef: any,
+) => Record<string, any>);
+
 export class BuildAction extends AbstractAction {
   protected readonly pluginsLoader = new PluginsLoader();
   protected readonly tsLoader = new TypeScriptBinaryLoader();
@@ -407,7 +412,7 @@ export class BuildAction extends AbstractAction {
       getRspackConfigPath(configuration, options, appName) ??
       defaultRspackConfigFilename;
 
-    const rspackConfigFactoryOrConfig = this.getRspackConfigFactoryByPath(
+    const rspackConfigFactoryOrConfig = await this.getRspackConfigFactoryByPath(
       rspackPath,
       defaultRspackConfigFilename,
     );
@@ -428,16 +433,23 @@ export class BuildAction extends AbstractAction {
     );
   }
 
-  private getRspackConfigFactoryByPath(
+  private async getRspackConfigFactoryByPath(
     rspackPath: string,
     defaultPath: string,
-  ): (config: Record<string, any>, rspackRef: any) => Record<string, any> {
+  ): Promise<RspackConfigFactory> {
     const pathToRspackFile = join(process.cwd(), rspackPath);
     const isRspackFileAvailable = isModuleAvailable(pathToRspackFile);
     if (!isRspackFileAvailable && rspackPath === defaultPath) {
       return (_config: Record<string, any>) => ({});
     }
-    return require(pathToRspackFile);
+    if (rspackPath.endsWith('.cjs')) {
+      return require(pathToRspackFile);
+    }
+
+    // Native dynamic import supports ESM configs, including `.mts` files.
+    // CommonJS configs loaded through import are exposed via `default`.
+    const loadedConfig = await import(pathToRspackFile);
+    return loadedConfig.default ?? loadedConfig;
   }
 
   private warnOnIgnoredLibraryAssets(

--- a/test/actions/build.action.spec.ts
+++ b/test/actions/build.action.spec.ts
@@ -84,7 +84,7 @@ describe('BuildAction - Rspack', () => {
   });
 
   describe('getRspackConfigFactoryByPath', () => {
-    it('should return identity function when config file is not available and path is default', () => {
+    it('should return identity function when config file is not available and path is default', async () => {
       // Access private method via prototype
       const proto = Object.getPrototypeOf(buildAction);
       const method =
@@ -93,7 +93,7 @@ describe('BuildAction - Rspack', () => {
 
       // If method exists on prototype, call it bound
       if (method) {
-        const result = method.call(
+        const result = await method.call(
           buildAction,
           'rspack.config.js',
           'rspack.config.js',
@@ -104,6 +104,32 @@ describe('BuildAction - Rspack', () => {
         // Method might be compiled differently; test via runBuild integration instead
         expect(true).toBe(true);
       }
+    });
+
+    it('should load an ESM config', async () => {
+      const method = Object.getPrototypeOf(buildAction)
+        .getRspackConfigFactoryByPath as Function;
+
+      const config = await method.call(
+        buildAction,
+        'test/fixtures/rspack.config.mjs',
+        'rspack.config.js',
+      );
+
+      expect(config({}, {})).toEqual({ name: 'esm-rspack-config' });
+    });
+
+    it('should load a CommonJS config', async () => {
+      const method = Object.getPrototypeOf(buildAction)
+        .getRspackConfigFactoryByPath as Function;
+
+      const config = await method.call(
+        buildAction,
+        'test/fixtures/rspack.config.cjs',
+        'rspack.config.js',
+      );
+
+      expect(config({}, {})).toEqual({ name: 'commonjs-rspack-config' });
     });
   });
 

--- a/test/fixtures/rspack.config.cjs
+++ b/test/fixtures/rspack.config.cjs
@@ -1,0 +1,4 @@
+module.exports = (config, _rspack) => ({
+  ...config,
+  name: 'commonjs-rspack-config',
+});

--- a/test/fixtures/rspack.config.mjs
+++ b/test/fixtures/rspack.config.mjs
@@ -1,0 +1,4 @@
+export default (config, _rspack) => ({
+  ...config,
+  name: 'esm-rspack-config',
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When building with Rspack and providing a custom configPath, the CLI imported it by calling `require` leading up to a silent failure when the file is an ES Module.

## What is the new behavior?

The call moves from `require` to use `async import` instead, which allows both ESM and CJS config files to be loaded. Tests have been added with fixtures for both scenarios.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

Consumers in ESM mode (`type: module`) using a custom CJS rspack config with a `.js` extension will have to either change it to `.cts` or convert it to ESM syntax.

## Other information
