### PR TITLE
fix(compiler): resolve tsconfig absolute path

### DIFF
--- a/lib/compiler/rspack-compiler.ts
+++ b/lib/compiler/rspack-compiler.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { createRequire } from 'module';
-import { join } from 'path';
+import { resolve } from 'path';
 import type * as ts from 'typescript';
 import { Configuration } from '../configuration/index.js';
 import { ERROR_PREFIX, INFO_PREFIX } from '../ui/index.js';
@@ -44,7 +44,7 @@ export class RspackCompiler extends BaseCompiler<RspackCompilerExtras> {
     onSuccess?: () => void,
   ) {
     const cwd = process.cwd();
-    const configPath = join(cwd, tsConfigPath!);
+    const configPath = resolve(cwd, tsConfigPath!);
     if (!existsSync(configPath)) {
       throw new Error(
         `Could not find TypeScript configuration file "${tsConfigPath!}".`,
@@ -72,7 +72,7 @@ export class RspackCompiler extends BaseCompiler<RspackCompilerExtras> {
       entryFileRoot,
       entryFile,
       extras.debug ?? false,
-      tsConfigPath,
+      configPath,
       plugins,
       isEsmProject(),
       extras.tsOptions,

--- a/test/lib/compiler/rspack/rspack-compiler.spec.ts
+++ b/test/lib/compiler/rspack/rspack-compiler.spec.ts
@@ -11,6 +11,7 @@ import { PluginsLoader } from '../../../../lib/compiler/plugins/plugins-loader.j
 import { RspackCompiler } from '../../../../lib/compiler/rspack-compiler.js';
 
 import { existsSync } from 'fs';
+import { resolve } from 'path';
 import { rspackDefaultsFactory } from '../../../../lib/compiler/defaults/rspack-defaults.js';
 import { getValueOrDefault } from '../../../../lib/compiler/helpers/get-value-or-default.js';
 import * as esmProjectUtil from '../../../../lib/utils/is-esm-project.js';
@@ -71,6 +72,7 @@ vi.mock('../../../../lib/compiler/helpers/get-value-or-default.js', () => ({
 vi.mock('../../../../lib/utils/is-esm-project.js');
 
 describe('Rspack Compiler', () => {
+  const absoluteTsconfigPath = resolve(process.cwd(), 'tsconfig.json');
   let compiler: RspackCompiler;
 
   // Access mock functions from the hoisted rspack mock
@@ -154,7 +156,7 @@ describe('Rspack Compiler', () => {
       ).toThrow('Could not find TypeScript configuration file');
     });
 
-    it('should call rspackDefaultsFactory with correct arguments', () => {
+    it('should pass an absolute tsconfig path to Rspack', () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(getValueOrDefault)
         .mockReturnValueOnce('main') // entryFile
@@ -175,7 +177,7 @@ describe('Rspack Compiler', () => {
         '',
         'main',
         false,
-        'tsconfig.json',
+        absoluteTsconfigPath,
         expect.objectContaining({
           beforeHooks: [],
           afterHooks: [],
@@ -205,7 +207,7 @@ describe('Rspack Compiler', () => {
         '',
         'main',
         false,
-        'tsconfig.json',
+        absoluteTsconfigPath,
         expect.anything(),
         true,
         undefined,
@@ -230,7 +232,7 @@ describe('Rspack Compiler', () => {
         '',
         'main',
         true,
-        'tsconfig.json',
+        absoluteTsconfigPath,
         expect.anything(),
         false,
         undefined,
@@ -257,7 +259,7 @@ describe('Rspack Compiler', () => {
         '',
         'main',
         false,
-        'tsconfig.json',
+        absoluteTsconfigPath,
         expect.anything(),
         false,
         tsOptions,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using the Nest CLI Rspack builder in a project with an inherited TypeScript configuration, the tsconfig path is passed to Rspack as a relative path. Rspack may fail to resolve extended configurations outside the application directory, resulting in errors such as:

```
Tsconfig not found tsconfig.root.json
```

The same project builds successfully with the TypeScript builder.

## What is the new behavior?

The Nest CLI now resolves the TypeScript configuration path to an absolute path before passing it to Rspack and TsconfigPathsPlugin. This allows inherited tsconfig files to resolve correctly in monorepos and nested project layouts.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
