### PR TITLE
chore(configuration): add *.tsbuildinfo to default .gitignore template

### DIFF
--- a/lib/configuration/defaults.ts
+++ b/lib/configuration/defaults.ts
@@ -33,6 +33,9 @@ export const defaultGitIgnore = `# compiled output
 /node_modules
 /build
 
+# TypeScript build cache
+*.tsbuildinfo
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
This adds TypeScript build cache files to the default .gitignore for new Nest projects.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe: Chore (configuration update)
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`*.tsbuildinfo` is not included in the default `.gitignore`.


Issue Number: N/A


## What is the new behavior?
`*.tsbuildinfo` is added to the default `.gitignore`.



## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
