### PR TITLE
fix(cli): surface plugin load errors instead of "not compatible"

### DIFF
--- a/lib/compiler/plugins/plugins-loader.ts
+++ b/lib/compiler/plugins/plugins-loader.ts
@@ -99,24 +99,35 @@ export class PluginsLoader {
     ];
 
     return pluginNames.map((item) => {
+      const binaryPath = this.resolvePluginPath(item, nodeModulePaths);
       try {
-        try {
-          const binaryPath = require.resolve(
-            `${item}/${PLUGIN_ENTRY_FILENAME}`,
-            {
-              paths: nodeModulePaths,
-            },
-          );
-          return require(binaryPath);
-        } catch {
-          // entry-point resolution failed, try bare module resolve
-        }
-
-        const binaryPath = require.resolve(item, { paths: nodeModulePaths });
         return require(binaryPath);
       } catch (e) {
-        throw new Error(`"${item}" plugin is not installed.`, { cause: e });
+        // Resolution succeeded, so the plugin IS installed — it crashed while
+        // being evaluated (e.g. its own imports are incompatible with the
+        // TypeScript version it ended up resolving). Surface the real reason
+        // instead of falling through to a misleading "not compatible" error.
+        throw new Error(
+          `"${item}" plugin failed to load: ${(e as Error)?.message ?? e}`,
+          { cause: e },
+        );
       }
     });
+  }
+
+  private resolvePluginPath(item: string, nodeModulePaths: string[]): string {
+    try {
+      return require.resolve(`${item}/${PLUGIN_ENTRY_FILENAME}`, {
+        paths: nodeModulePaths,
+      });
+    } catch {
+      // entry-point resolution failed, try bare module resolve
+    }
+
+    try {
+      return require.resolve(item, { paths: nodeModulePaths });
+    } catch (e) {
+      throw new Error(`"${item}" plugin is not installed.`, { cause: e });
+    }
   }
 }

--- a/test/lib/compiler/plugins/plugins-loader.spec.ts
+++ b/test/lib/compiler/plugins/plugins-loader.spec.ts
@@ -95,6 +95,18 @@ vi.mock('module', async (importOriginal) => {
         if (id.includes('invalid-plugin')) {
           return {};
         }
+        // Simulates a plugin whose entry point resolves fine but blows up
+        // while being evaluated (e.g. a TypeScript version mismatch in the
+        // plugin's own imports). The bare package still loads, but exposes
+        // no compiler hooks.
+        if (id.includes('broken-plugin/plugin')) {
+          throw new SyntaxError(
+            "The requested module 'typescript' does not provide an export named 'ObjectFlags'",
+          );
+        }
+        if (id.includes('broken-plugin')) {
+          return {};
+        }
         return realReq(id);
       };
       mockedReq.resolve = (id: string, opts?: any) => {
@@ -103,7 +115,8 @@ vi.mock('module', async (importOriginal) => {
           id.includes('declarations-plugin') ||
           id.includes('readonly-plugin') ||
           id.includes('options-tracker') ||
-          id.includes('invalid-plugin')
+          id.includes('invalid-plugin') ||
+          id.includes('broken-plugin')
         ) {
           return id;
         }
@@ -147,6 +160,15 @@ describe('PluginsLoader', () => {
   it('should throw for a plugin that exports no hooks', () => {
     const loader = new PluginsLoader();
     expect(() => loader.load(['invalid-plugin'])).toThrow(/plugin/i);
+  });
+
+  it('should surface the original error when the plugin entry point resolves but fails to load', () => {
+    const loader = new PluginsLoader();
+    // Must not be reported as "not compatible" — the entry point exists, it
+    // just crashed while loading. The real cause has to reach the user.
+    expect(() => loader.load(['broken-plugin'])).toThrow(
+      /does not provide an export named 'ObjectFlags'/,
+    );
   });
 
   it('should throw for a plugin that is not installed', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #3549

`PluginsLoader.resolvePluginReferences()` wraps both `require.resolve()` **and** `require()` of the `<plugin>/plugin` entry point in a single bare `catch {}`. So any error thrown while *evaluating* the entry point (not only a resolution failure) is swallowed, and the loader falls back to requiring the bare package. That module loads fine but exposes no `before`/`after`/`afterDeclarations`, so the user gets:

```
Error  The "@nestjs/swagger" plugin is not compatible with Nest CLI. Neither "after()" nor "before()" nor "afterDeclarations()" function have been provided.
```

…while the real error is never shown. In #3549 that hidden error is:

```
SyntaxError: The requested module 'typescript' does not provide an export named 'ObjectFlags'
```

(pnpm monorepo where `@nestjs/swagger` ends up resolving a different TypeScript major than the CLI).

## What is the new behavior?

Resolution and loading are separated:

- Fall back to the bare module only when the `<plugin>/plugin` entry point **cannot be resolved**.
- If the entry point resolves but throws while loading, re-throw with the original message embedded (the build action only prints `err.message`) and the original error attached as `cause`:

```
Error  "@nestjs/swagger" plugin failed to load: The requested module 'typescript' does not provide an export named 'ObjectFlags'
```

The "plugin is not installed" error is unchanged.

Added a unit test with a plugin whose entry point resolves but throws on evaluation, asserting the original message reaches the caller. Verified end-to-end against a pnpm monorepo repro of #3549 (TS 7.0.2 in one workspace, TS 6.0.3 in the Nest app).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This only stops the CLI from hiding the underlying error. The root cause of the mismatch in #3549 is that `@nestjs/swagger` does not declare `typescript` as a (peer) dependency, so pnpm serves it the hoisted copy (`node_modules/.pnpm/node_modules/typescript`) — which may be a different major than the one the app/CLI use. That part belongs in `nestjs/swagger` (see also nestjs/nest#10694).
